### PR TITLE
PRC-489: Fix some field length validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/AddContactRelationshipRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/AddContactRelationshipRequest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 
 data class AddContactRelationshipRequest(
@@ -8,6 +9,7 @@ data class AddContactRelationshipRequest(
   val contactId: Long,
 
   @Schema(description = "A description of the contacts relationship to a prisoner", exampleClasses = [ContactRelationship::class])
+  @field:Valid
   val relationship: ContactRelationship,
 
   @Schema(description = "The id of the user creating the contact", example = "JD000001", maxLength = 100)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/ContactRelationship.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/ContactRelationship.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 
 data class ContactRelationship(
 
@@ -23,6 +24,7 @@ data class ContactRelationship(
   val isEmergencyContact: Boolean,
 
   @Schema(description = "Comments about the contacts relationship with the prisoner", example = "Some additional information", nullable = true)
+  @field:Size(max = 240, message = "comments must be <= 240 characters")
   val comments: String? = null,
 
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactAddressPhoneRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactAddressPhoneRequest.kt
@@ -13,7 +13,7 @@ data class CreateContactAddressPhoneRequest(
   val phoneType: String,
 
   @Schema(description = "Phone number", example = "+1234567890")
-  @field:Size(max = 240, message = "phoneNumber must be <= 240 characters")
+  @field:Size(max = 40, message = "phoneNumber must be <= 40 characters")
   val phoneNumber: String,
 
   @Schema(description = "Extension number", example = "123")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactAddressRequest.kt
@@ -23,15 +23,19 @@ data class CreateContactAddressRequest(
   val primaryAddress: Boolean = false,
 
   @Schema(description = "Flat number or name", example = "Flat 2B", nullable = true)
+  @field:Size(max = 30, message = "flat must be <= 30 characters")
   val flat: String? = null,
 
   @Schema(description = "Building or house number or name", example = "Mansion House", nullable = true)
+  @field:Size(max = 50, message = "property must be <= 50 characters")
   val property: String? = null,
 
   @Schema(description = "Street or road name", example = "Acacia Avenue", nullable = true)
+  @field:Size(max = 160, message = "street must be <= 160 characters")
   val street: String? = null,
 
   @Schema(description = "Area", example = "Morton Heights", nullable = true)
+  @field:Size(max = 70, message = "area must be <= 70 characters")
   val area: String? = null,
 
   @Schema(description = "City code - from NOMIS", example = "13232", nullable = true)
@@ -43,6 +47,7 @@ data class CreateContactAddressRequest(
   val countyCode: String? = null,
 
   @Schema(description = "Postcode", example = "S13 4FH", nullable = true)
+  @field:Size(max = 12, message = "postcode must be <= 12 characters")
   val postcode: String? = null,
 
   @Schema(description = "Country code - from NOMIS", example = "UK", nullable = true)
@@ -65,6 +70,7 @@ data class CreateContactAddressRequest(
   val noFixedAddress: Boolean? = false,
 
   @Schema(description = "Any additional information or comments about the address", example = "Some additional information", nullable = true)
+  @field:Size(max = 240, message = "comments must be <= 240 characters")
   val comments: String? = null,
 
   @Schema(description = "The id of the user who created the contact", example = "JD000001")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
@@ -39,6 +40,7 @@ data class CreateContactRequest(
   val dateOfBirth: LocalDate? = null,
 
   @Schema(description = "A description of the relationship if the contact should be linked to a prisoner", nullable = true, exampleClasses = [ContactRelationship::class])
+  @field:Valid
   val relationship: ContactRelationship? = null,
 
   @Schema(description = "The id of the user creating the contact", example = "JD000001", maxLength = 100)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateIdentityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateIdentityRequest.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size
 @Schema(description = "Request to create a new contact identity")
 data class CreateIdentityRequest(
   @Schema(description = "Type of identity", example = "DL")
-  @field:Size(max = 20, message = "identityType must be <= 20 characters")
+  @field:Size(max = 12, message = "identityType must be <= 12 characters")
   val identityType: String,
 
   @Schema(description = "The identity value such as driving licence number", example = "DL123456789")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreatePhoneRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreatePhoneRequest.kt
@@ -10,7 +10,7 @@ data class CreatePhoneRequest(
   val phoneType: String,
 
   @Schema(description = "Phone number", example = "+1234567890")
-  @field:Size(max = 240, message = "phoneNumber must be <= 240 characters")
+  @field:Size(max = 40, message = "phoneNumber must be <= 40 characters")
   val phoneNumber: String,
 
   @Schema(description = "Extension number", example = "123", nullable = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/PatchContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/PatchContactAddressRequest.kt
@@ -25,15 +25,19 @@ data class PatchContactAddressRequest(
   val primaryAddress: JsonNullable<Boolean> = JsonNullable.undefined(),
 
   @Schema(description = "Flat number or name", example = "Flat 2B", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 30, message = "flat must be <= 30 characters")
   val flat: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "Building or house number or name", example = "Mansion House", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 50, message = "property must be <= 50 characters")
   val property: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "Street or road name", example = "Acacia Avenue", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 160, message = "street must be <= 160 characters")
   val street: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "Area", example = "Morton Heights", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 70, message = "area must be <= 70 characters")
   val area: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "City code - from NOMIS reference data", example = "BIRM", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
@@ -45,6 +49,7 @@ data class PatchContactAddressRequest(
   val countyCode: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "Postcode", example = "S13 4FH", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 12, message = "postcode must be <= 12 characters")
   val postcode: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "Country code - from NOMIS reference data", example = "UK", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
@@ -67,6 +72,7 @@ data class PatchContactAddressRequest(
   val noFixedAddress: JsonNullable<Boolean> = JsonNullable.undefined(),
 
   @Schema(description = "Any additional information or comments about the address", example = "Some additional information", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 240, message = "comments must be <= 240 characters")
   val comments: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "The id of the user who updated the address", example = "JD000001", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateContactAddressPhoneRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateContactAddressPhoneRequest.kt
@@ -10,7 +10,7 @@ data class UpdateContactAddressPhoneRequest(
   val phoneType: String,
 
   @Schema(description = "Phone number", example = "+1234567890")
-  @field:Size(max = 240, message = "phoneNumber must be <= 240 characters")
+  @field:Size(max = 40, message = "phoneNumber must be <= 40 characters")
   val phoneNumber: String,
 
   @Schema(description = "Extension number", example = "123")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateContactAddressRequest.kt
@@ -22,15 +22,19 @@ data class UpdateContactAddressRequest(
   val primaryAddress: Boolean,
 
   @Schema(description = "Flat number or name", example = "Flat 2B", nullable = true)
+  @field:Size(max = 30, message = "flat must be <= 30 characters")
   val flat: String? = null,
 
   @Schema(description = "Building or house number or name", example = "Mansion House", nullable = true)
+  @field:Size(max = 50, message = "property must be <= 50 characters")
   val property: String? = null,
 
   @Schema(description = "Street or road name", example = "Acacia Avenue", nullable = true)
+  @field:Size(max = 160, message = "street must be <= 160 characters")
   val street: String? = null,
 
   @Schema(description = "Area", example = "Morton Heights", nullable = true)
+  @field:Size(max = 70, message = "area must be <= 70 characters")
   val area: String? = null,
 
   @Schema(description = "City code - from NOMIS reference data", example = "BIRM", nullable = true)
@@ -42,6 +46,7 @@ data class UpdateContactAddressRequest(
   val countyCode: String? = null,
 
   @Schema(description = "Postcode", example = "S13 4FH", nullable = true)
+  @field:Size(max = 12, message = "postcode must be <= 12 characters")
   val postcode: String? = null,
 
   @Schema(description = "Country code - from NOMIS reference data", example = "UK", nullable = true)
@@ -64,6 +69,7 @@ data class UpdateContactAddressRequest(
   val noFixedAddress: Boolean? = false,
 
   @Schema(description = "Any additional information or comments about the address", example = "Some additional information", nullable = true)
+  @field:Size(max = 240, message = "comments must be <= 240 characters")
   val comments: String? = null,
 
   @Schema(description = "The id of the user who updated the address", example = "JD000001")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateIdentityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateIdentityRequest.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size
 @Schema(description = "Request to update an existing contact identity")
 data class UpdateIdentityRequest(
   @Schema(description = "Type of identity", example = "DL")
-  @field:Size(max = 20, message = "identityType must be <= 20 characters")
+  @field:Size(max = 12, message = "identityType must be <= 12 characters")
   val identityType: String,
 
   @Schema(description = "The identity value such as driving licence number", example = "DL123456789")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdatePhoneRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdatePhoneRequest.kt
@@ -10,7 +10,7 @@ data class UpdatePhoneRequest(
   val phoneType: String,
 
   @Schema(description = "Phone number", example = "+1234567890")
-  @field:Size(max = 240, message = "phoneNumber must be <= 240 characters")
+  @field:Size(max = 40, message = "phoneNumber must be <= 40 characters")
   val phoneNumber: String,
 
   @Schema(description = "Extension number", example = "123", nullable = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateRelationshipRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateRelationshipRequest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 import org.openapitools.jackson.nullable.JsonNullable
 
 @Schema(description = "Request to update an existing relationship details")
@@ -30,9 +31,11 @@ data class UpdateRelationshipRequest(
   val isRelationshipActive: JsonNullable<Boolean> = JsonNullable.undefined(),
 
   @Schema(description = "Comments about the contacts relationship with the prisoner", example = "Some additional information", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 240, message = "comments must be <= 240 characters")
   val comments: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "The id of the user who updated the contact", example = "JD000001", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
+  @field:Size(max = 100, message = "updatedBy must be <= 100 characters")
   val updatedBy: String,
 
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactAddressService.kt
@@ -46,6 +46,7 @@ class ContactAddressService(
 
   fun create(contactId: Long, request: CreateContactAddressRequest): CreateAddressResponse {
     validateContactExists(contactId)
+    validateAddressType(request.addressType)
     validateCityCode(request.cityCode)
     validateCountyCode(request.countyCode)
     validateCountryCode(request.countryCode)
@@ -63,6 +64,7 @@ class ContactAddressService(
   fun update(contactId: Long, contactAddressId: Long, request: UpdateContactAddressRequest): UpdateAddressResponse {
     val contact = validateContactExists(contactId)
     val existing = validateExistingAddress(contactAddressId)
+    validateAddressType(request.addressType)
     validateCityCode(request.cityCode)
     validateCountyCode(request.countyCode)
     validateCountryCode(request.countryCode)
@@ -114,6 +116,7 @@ class ContactAddressService(
       logger.error("Contact address update specified for a contact not linked to this address")
       throw ValidationException("Contact ID ${contact.contactId} is not linked to the address ${existing.contactAddressId}")
     }
+    request.addressType.ifPresent { validateAddressType(it) }
     request.cityCode.ifPresent { validateCityCode(it) }
     request.countyCode.ifPresent { validateCountyCode(it) }
     request.countryCode.ifPresent { validateCountryCode(it) }
@@ -197,6 +200,10 @@ class ContactAddressService(
 
   private fun validateCityCode(cityCode: String?) {
     cityCode?.let { validateReferenceDataExists(it, ReferenceCodeGroup.CITY) }
+  }
+
+  private fun validateAddressType(addressType: String?) {
+    addressType?.let { validateReferenceDataExists(it, ReferenceCodeGroup.ADDRESS_TYPE) }
   }
 
   private fun validateReferenceDataExists(code: String, groupCode: ReferenceCodeGroup) = referenceCodeRepository

--- a/src/main/resources/migrations/common/V2025.02.20.18__column_lengths.sql
+++ b/src/main/resources/migrations/common/V2025.02.20.18__column_lengths.sql
@@ -1,0 +1,13 @@
+--
+-- Contact identity value and issuing authority were longer than in NOMIS or than validation allowed. Reducing the size
+-- to ensure we don't accidentally start accepting longer values that cannot be synced to NOMIS.
+-- Also reducing length of reference_codes.code to 12 as all columns backed by reference data are also set to 12
+-- as per NOMIS. This prevents us adding a code that is not usable in practice.
+--
+
+ALTER TABLE contact_identity ALTER COLUMN identity_value TYPE VARCHAR(20);
+ALTER TABLE contact_identity ALTER COLUMN issuing_authority TYPE VARCHAR(40);
+
+ALTER TABLE reference_codes ALTER COLUMN code TYPE VARCHAR(12);
+
+-- End

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
@@ -194,15 +194,15 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("phoneType must be <= 12 characters", aMinimalRequest().copy(phoneType = "".padStart(13))),
-      Arguments.of("phoneNumber must be <= 240 characters", aMinimalRequest().copy(phoneNumber = "".padStart(241))),
+      Arguments.of("phoneType must be <= 12 characters", aMinimalRequest().copy(phoneType = "".padStart(13, 'X'))),
+      Arguments.of("phoneNumber must be <= 40 characters", aMinimalRequest().copy(phoneNumber = "".padStart(41, '9'))),
       Arguments.of(
         "extNumber must be <= 7 characters",
-        aMinimalRequest().copy(extNumber = "".padStart(8)),
+        aMinimalRequest().copy(extNumber = "".padStart(8, 'X')),
       ),
       Arguments.of(
         "createdBy must be <= 100 characters",
-        aMinimalRequest().copy(createdBy = "".padStart(101)),
+        aMinimalRequest().copy(createdBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactEmailIntegrationTest.kt
@@ -167,10 +167,10 @@ class CreateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("emailAddress must be <= 240 characters", aMinimalRequest().copy(emailAddress = "".padStart(241))),
+      Arguments.of("emailAddress must be <= 240 characters", aMinimalRequest().copy(emailAddress = "".padStart(241, 'X'))),
       Arguments.of(
         "createdBy must be <= 100 characters",
-        aMinimalRequest().copy(createdBy = "".padStart(101)),
+        aMinimalRequest().copy(createdBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
@@ -245,15 +245,15 @@ class CreateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("identityType must be <= 20 characters", aMinimalRequest().copy(identityType = "".padStart(21))),
-      Arguments.of("identityValue must be <= 20 characters", aMinimalRequest().copy(identityValue = "".padStart(21))),
+      Arguments.of("identityType must be <= 12 characters", aMinimalRequest().copy(identityType = "".padStart(13, 'X'))),
+      Arguments.of("identityValue must be <= 20 characters", aMinimalRequest().copy(identityValue = "".padStart(21, 'X'))),
       Arguments.of(
         "issuingAuthority must be <= 40 characters",
-        aMinimalRequest().copy(issuingAuthority = "".padStart(41)),
+        aMinimalRequest().copy(issuingAuthority = "".padStart(41, 'X')),
       ),
       Arguments.of(
         "createdBy must be <= 100 characters",
-        aMinimalRequest().copy(createdBy = "".padStart(101)),
+        aMinimalRequest().copy(createdBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -173,22 +173,22 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("title must be <= 12 characters", aMinimalCreateContactRequest().copy(title = "".padStart(13))),
+      Arguments.of("title must be <= 12 characters", aMinimalCreateContactRequest().copy(title = "".padStart(13, 'X'))),
       Arguments.of(
         "lastName must be <= 35 characters",
-        aMinimalCreateContactRequest().copy(lastName = "".padStart(36)),
+        aMinimalCreateContactRequest().copy(lastName = "".padStart(36, 'X')),
       ),
       Arguments.of(
         "firstName must be <= 35 characters",
-        aMinimalCreateContactRequest().copy(firstName = "".padStart(36)),
+        aMinimalCreateContactRequest().copy(firstName = "".padStart(36, 'X')),
       ),
       Arguments.of(
         "middleNames must be <= 35 characters",
-        aMinimalCreateContactRequest().copy(middleNames = "".padStart(36)),
+        aMinimalCreateContactRequest().copy(middleNames = "".padStart(36, 'X')),
       ),
       Arguments.of(
         "createdBy must be <= 100 characters",
-        aMinimalCreateContactRequest().copy(createdBy = "".padStart(101)),
+        aMinimalCreateContactRequest().copy(createdBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
@@ -226,15 +226,15 @@ class CreateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("phoneType must be <= 12 characters", aMinimalRequest().copy(phoneType = "".padStart(13))),
-      Arguments.of("phoneNumber must be <= 240 characters", aMinimalRequest().copy(phoneNumber = "".padStart(241))),
+      Arguments.of("phoneType must be <= 12 characters", aMinimalRequest().copy(phoneType = "".padStart(13, 'X'))),
+      Arguments.of("phoneNumber must be <= 40 characters", aMinimalRequest().copy(phoneNumber = "".padStart(241, 'X'))),
       Arguments.of(
         "extNumber must be <= 7 characters",
-        aMinimalRequest().copy(extNumber = "".padStart(8)),
+        aMinimalRequest().copy(extNumber = "".padStart(8, 'X')),
       ),
       Arguments.of(
         "createdBy must be <= 100 characters",
-        aMinimalRequest().copy(createdBy = "".padStart(101)),
+        aMinimalRequest().copy(createdBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactRestrictionIntegrationTest.kt
@@ -206,10 +206,10 @@ class CreateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("comments must be <= 240 characters", aMinimalRequest().copy(comments = "".padStart(241))),
+      Arguments.of("comments must be <= 240 characters", aMinimalRequest().copy(comments = "".padStart(241, 'X'))),
       Arguments.of(
         "createdBy must be <= 100 characters",
-        aMinimalRequest().copy(createdBy = "".padStart(101)),
+        aMinimalRequest().copy(createdBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreatePrisonerContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreatePrisonerContactRestrictionIntegrationTest.kt
@@ -223,10 +223,10 @@ class CreatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("comments must be <= 240 characters", aMinimalRequest().copy(comments = "".padStart(241))),
+      Arguments.of("comments must be <= 240 characters", aMinimalRequest().copy(comments = "".padStart(241, 'X'))),
       Arguments.of(
         "createdBy must be <= 100 characters",
-        aMinimalRequest().copy(createdBy = "".padStart(101)),
+        aMinimalRequest().copy(createdBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
@@ -461,29 +461,41 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
       Arguments.of(
-        "addressType must be <= 12 characters",
-        aMinimalPatchAddressRequest().copy(addressType = JsonNullable.of("".padStart(13))),
+        "flat must be <= 30 characters",
+        aMinimalPatchAddressRequest().copy(flat = JsonNullable.of("".padStart(31, 'X'))),
       ),
       Arguments.of(
-        "cityCode must be <= 12 characters",
-        aMinimalPatchAddressRequest().copy(cityCode = JsonNullable.of("".padStart(13))),
+        "property must be <= 50 characters",
+        aMinimalPatchAddressRequest().copy(property = JsonNullable.of("".padStart(51, 'X'))),
       ),
       Arguments.of(
-        "countyCode must be <= 12 characters",
-        aMinimalPatchAddressRequest().copy(countyCode = JsonNullable.of("".padStart(13))),
+        "street must be <= 160 characters",
+        aMinimalPatchAddressRequest().copy(street = JsonNullable.of("".padStart(161, 'X'))),
       ),
       Arguments.of(
-        "countryCode must be <= 12 characters",
-        aMinimalPatchAddressRequest().copy(countryCode = JsonNullable.of("".padStart(13))),
+        "area must be <= 70 characters",
+        aMinimalPatchAddressRequest().copy(area = JsonNullable.of("".padStart(71, 'X'))),
+      ),
+      Arguments.of(
+        "postcode must be <= 12 characters",
+        aMinimalPatchAddressRequest().copy(postcode = JsonNullable.of("".padStart(13, 'X'))),
+      ),
+      Arguments.of(
+        "comments must be <= 240 characters",
+        aMinimalPatchAddressRequest().copy(comments = JsonNullable.of("".padStart(241, 'X'))),
       ),
       Arguments.of(
         "updatedBy must be <= 100 characters",
-        aMinimalPatchAddressRequest().copy(updatedBy = "".padStart(101)),
+        aMinimalPatchAddressRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 
     @JvmStatic
     fun referenceTypeNotFound(): List<Arguments> = listOf(
+      Arguments.of(
+        "No reference data found for groupCode: ADDRESS_TYPE and code: INVALID",
+        aMinimalPatchAddressRequest().copy(addressType = JsonNullable.of("INVALID")),
+      ),
       Arguments.of(
         "No reference data found for groupCode: CITY and code: INVALID",
         aMinimalPatchAddressRequest().copy(cityCode = JsonNullable.of("INVALID")),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
@@ -440,30 +440,37 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
+      Arguments.of("flat must be <= 30 characters", aMinimalUpdateAddressRequest().copy(flat = "".padStart(31, 'X'))),
       Arguments.of(
-        "addressType must be <= 12 characters",
-        aMinimalUpdateAddressRequest().copy(addressType = "".padStart(13)),
+        "property must be <= 50 characters",
+        aMinimalUpdateAddressRequest().copy(property = "".padStart(51, 'X')),
       ),
       Arguments.of(
-        "cityCode must be <= 12 characters",
-        aMinimalUpdateAddressRequest().copy(cityCode = "".padStart(13)),
+        "street must be <= 160 characters",
+        aMinimalUpdateAddressRequest().copy(street = "".padStart(161, 'X')),
+      ),
+      Arguments.of("area must be <= 70 characters", aMinimalUpdateAddressRequest().copy(area = "".padStart(71, 'X'))),
+      Arguments.of(
+        "postcode must be <= 12 characters",
+        aMinimalUpdateAddressRequest().copy(postcode = "".padStart(13, 'X')),
       ),
       Arguments.of(
-        "countyCode must be <= 12 characters",
-        aMinimalUpdateAddressRequest().copy(countyCode = "".padStart(13)),
+        "comments must be <= 240 characters",
+        aMinimalUpdateAddressRequest().copy(comments = "".padStart(241, 'X')),
       ),
-      Arguments.of(
-        "countryCode must be <= 12 characters",
-        aMinimalUpdateAddressRequest().copy(countryCode = "".padStart(13)),
-      ),
+
       Arguments.of(
         "updatedBy must be <= 100 characters",
-        aMinimalUpdateAddressRequest().copy(updatedBy = "".padStart(101)),
+        aMinimalUpdateAddressRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 
     @JvmStatic
     fun referenceTypeNotFound(): List<Arguments> = listOf(
+      Arguments.of(
+        "No reference data found for groupCode: ADDRESS_TYPE and code: INVALID",
+        aMinimalUpdateAddressRequest().copy(addressType = "INVALID"),
+      ),
       Arguments.of(
         "No reference data found for groupCode: CITY and code: INVALID",
         aMinimalUpdateAddressRequest().copy(cityCode = "INVALID"),
@@ -486,6 +493,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       street = "Hello Road",
       updatedBy = "updated",
     )
+
     private fun aMinimalCreateAddressRequest() = CreateContactAddressRequest(
       addressType = "HOME",
       primaryAddress = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
@@ -259,15 +259,15 @@ class UpdateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("phoneType must be <= 12 characters", aMinimalRequest().copy(phoneType = "".padStart(13))),
-      Arguments.of("phoneNumber must be <= 240 characters", aMinimalRequest().copy(phoneNumber = "".padStart(241))),
+      Arguments.of("phoneType must be <= 12 characters", aMinimalRequest().copy(phoneType = "".padStart(13, 'X'))),
+      Arguments.of("phoneNumber must be <= 40 characters", aMinimalRequest().copy(phoneNumber = "".padStart(41, '9'))),
       Arguments.of(
         "extNumber must be <= 7 characters",
-        aMinimalRequest().copy(extNumber = "".padStart(8)),
+        aMinimalRequest().copy(extNumber = "".padStart(8, 'X')),
       ),
       Arguments.of(
         "updatedBy must be <= 100 characters",
-        aMinimalRequest().copy(updatedBy = "".padStart(101)),
+        aMinimalRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
@@ -213,10 +213,10 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("emailAddress must be <= 240 characters", aMinimalRequest().copy(emailAddress = "".padStart(241))),
+      Arguments.of("emailAddress must be <= 240 characters", aMinimalRequest().copy(emailAddress = "".padStart(241, 'X'))),
       Arguments.of(
         "updatedBy must be <= 100 characters",
-        aMinimalRequest().copy(updatedBy = "".padStart(101)),
+        aMinimalRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
@@ -259,15 +259,15 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("identityType must be <= 20 characters", aMinimalRequest().copy(identityType = "".padStart(21))),
-      Arguments.of("identityValue must be <= 20 characters", aMinimalRequest().copy(identityValue = "".padStart(21))),
+      Arguments.of("identityType must be <= 12 characters", aMinimalRequest().copy(identityType = "".padStart(13, 'X'))),
+      Arguments.of("identityValue must be <= 20 characters", aMinimalRequest().copy(identityValue = "".padStart(21, 'X'))),
       Arguments.of(
         "issuingAuthority must be <= 40 characters",
-        aMinimalRequest().copy(issuingAuthority = "".padStart(41)),
+        aMinimalRequest().copy(issuingAuthority = "".padStart(41, 'X')),
       ),
       Arguments.of(
         "updatedBy must be <= 100 characters",
-        aMinimalRequest().copy(updatedBy = "".padStart(101)),
+        aMinimalRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
@@ -259,15 +259,15 @@ class UpdateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("phoneType must be <= 12 characters", aMinimalRequest().copy(phoneType = "".padStart(13))),
-      Arguments.of("phoneNumber must be <= 240 characters", aMinimalRequest().copy(phoneNumber = "".padStart(241))),
+      Arguments.of("phoneType must be <= 12 characters", aMinimalRequest().copy(phoneType = "".padStart(13, 'X'))),
+      Arguments.of("phoneNumber must be <= 40 characters", aMinimalRequest().copy(phoneNumber = "".padStart(41, '9'))),
       Arguments.of(
         "extNumber must be <= 7 characters",
-        aMinimalRequest().copy(extNumber = "".padStart(8)),
+        aMinimalRequest().copy(extNumber = "".padStart(8, 'X')),
       ),
       Arguments.of(
         "updatedBy must be <= 100 characters",
-        aMinimalRequest().copy(updatedBy = "".padStart(101)),
+        aMinimalRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactRestrictionIntegrationTest.kt
@@ -252,10 +252,10 @@ class UpdateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("comments must be <= 240 characters", aMinimalRequest().copy(comments = "".padStart(241))),
+      Arguments.of("comments must be <= 240 characters", aMinimalRequest().copy(comments = "".padStart(241, 'X'))),
       Arguments.of(
         "updatedBy must be <= 100 characters",
-        aMinimalRequest().copy(updatedBy = "".padStart(101)),
+        aMinimalRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdatePrisonerContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdatePrisonerContactRestrictionIntegrationTest.kt
@@ -282,10 +282,10 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("comments must be <= 240 characters", aMinimalRequest().copy(comments = "".padStart(241))),
+      Arguments.of("comments must be <= 240 characters", aMinimalRequest().copy(comments = "".padStart(241, 'X'))),
       Arguments.of(
         "updatedBy must be <= 100 characters",
-        aMinimalRequest().copy(updatedBy = "".padStart(101)),
+        aMinimalRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 


### PR DESCRIPTION
Some field length validation was missing or incorrect. Added missing tests and added/corrected validation.

Also reduced length of identity document columns to match NOMIS & validation.

Also reduced size of "code" in reference_codes to 12 to match NOMIS to prevent us adding any values that would not fit into their respective columns or NOMIS.