### PR TITLE
PRC-465: Add multiple email address API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacade.kt
@@ -2,8 +2,9 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateMultipleEmailsRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmailDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactEmailService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
@@ -21,6 +22,16 @@ class ContactEmailFacade(
       identifier = it.contactEmailId,
       contactId = contactId,
     )
+  }
+
+  fun createMultiple(contactId: Long, request: CreateMultipleEmailsRequest): List<ContactEmailDetails> = contactEmailService.createMultiple(contactId, request).also { created ->
+    created.forEach {
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_EMAIL_CREATED,
+        identifier = it.contactEmailId,
+        contactId = contactId,
+      )
+    }
   }
 
   fun update(contactId: Long, contactEmailId: Long, request: UpdateEmailRequest): ContactEmailDetails = contactEmailService.update(contactId, contactEmailId, request).also {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/CreateEmailRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/CreateEmailRequest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/CreateMultipleEmailsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/CreateMultipleEmailsRequest.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
+
+@Schema(description = "Request to create a new email address")
+data class CreateMultipleEmailsRequest(
+
+  @Schema(description = "Email addresses")
+  @field:Valid
+  @field:Size(min = 1, message = "emailAddresses must have at least 1 item")
+  val emailAddresses: List<EmailAddress>,
+
+  @Schema(description = "User who created the entry", example = "admin")
+  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
+  val createdBy: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/EmailAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/EmailAddress.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+
+@Schema(description = "A single email address")
+data class EmailAddress(
+  @field:Size(max = 240, message = "emailAddress must be <= 240 characters")
+  val emailAddress: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/UpdateEmailRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/UpdateEmailRequest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailController.kt
@@ -21,19 +21,20 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactEmailFacade
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateMultipleEmailsRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmailDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @Tag(name = "Contacts")
 @RestController
-@RequestMapping(value = ["contact/{contactId}/email"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(value = ["contact/{contactId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses
 class ContactEmailController(private val contactEmailFacade: ContactEmailFacade) {
 
-  @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @PostMapping("/email", consumes = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(
     summary = "Create new contact email",
     description = "Creates a new email for the specified contact",
@@ -77,7 +78,51 @@ class ContactEmailController(private val contactEmailFacade: ContactEmailFacade)
       .body(created)
   }
 
-  @PutMapping("/{contactEmailId}", consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @PostMapping("/emails", consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @Operation(
+    summary = "Create multiple contact email addresses",
+    description = "Creates one or more new email addresses for the specified contact",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "201",
+        description = "Created all the contact email addresses successfully",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ContactEmailDetails::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The request has invalid or missing fields",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Could not find the the contact this email is for",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN','ROLE_CONTACTS__RW')")
+  fun createMultipleEmailAddresses(
+    @PathVariable("contactId") @Parameter(
+      name = "contactId",
+      description = "The id of the contact",
+      example = "123456",
+    ) contactId: Long,
+    @Valid @RequestBody request: CreateMultipleEmailsRequest,
+  ): ResponseEntity<Any> {
+    val created = contactEmailFacade.createMultiple(contactId, request)
+    return ResponseEntity
+      .status(HttpStatus.CREATED)
+      .body(created)
+  }
+
+  @PutMapping("/email/{contactEmailId}", consumes = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(
     summary = "Update contact email",
     description = "Updates an existing contact email by id",
@@ -121,7 +166,7 @@ class ContactEmailController(private val contactEmailFacade: ContactEmailFacade)
     @Valid @RequestBody request: UpdateEmailRequest,
   ): ResponseEntity<Any> = ResponseEntity.ok(contactEmailFacade.update(contactId, contactEmailId, request))
 
-  @GetMapping("/{contactEmailId}")
+  @GetMapping("/email/{contactEmailId}")
   @Operation(
     summary = "Get an email",
     description = "Gets a contacts email by id",
@@ -159,7 +204,7 @@ class ContactEmailController(private val contactEmailFacade: ContactEmailFacade)
     ) contactEmailId: Long,
   ): ResponseEntity<Any> = ResponseEntity.ok(contactEmailFacade.get(contactId, contactEmailId))
 
-  @DeleteMapping("/{contactEmailId}")
+  @DeleteMapping("/email/{contactEmailId}")
   @Operation(
     summary = "Delete contact email",
     description = "Deletes an existing contact email by id",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactEmailService.kt
@@ -6,8 +6,9 @@ import jakarta.validation.ValidationException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEmailEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateMultipleEmailsRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmailDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactEmailRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
@@ -27,13 +28,27 @@ class ContactEmailService(
   @Transactional
   fun create(contactId: Long, request: CreateEmailRequest): ContactEmailDetails {
     validateContactExists(contactId)
-    validateEmailAddress(request.emailAddress)
+    return createAnEmail(request.emailAddress, request.createdBy, contactId)
+  }
+
+  @Transactional
+  fun createMultiple(contactId: Long, request: CreateMultipleEmailsRequest): List<ContactEmailDetails> {
+    validateContactExists(contactId)
+    return request.emailAddresses.map { createAnEmail(it.emailAddress, request.createdBy, contactId) }
+  }
+
+  private fun createAnEmail(
+    emailAddress: String,
+    createdBy: String,
+    contactId: Long,
+  ): ContactEmailDetails {
+    validateEmailAddress(emailAddress)
     val created = contactEmailRepository.saveAndFlush(
       ContactEmailEntity(
         contactEmailId = 0,
         contactId = contactId,
-        emailAddress = request.emailAddress,
-        createdBy = request.createdBy,
+        emailAddress = emailAddress,
+        createdBy = createdBy,
       ),
     )
     return created.toDomainWithType()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacadeTest.kt
@@ -10,8 +10,8 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactEmailDetails
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactEmailService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRestrictionRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmploymentRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateIdentityRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePhoneRequest
@@ -19,12 +18,14 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchEmployme
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactRestrictionRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateEmploymentRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateIdentityRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePrisonerContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateRelationshipRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateMultipleEmailsRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressPhoneDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressResponse
@@ -288,6 +289,19 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
     .isCreated
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBody(ContactEmailDetails::class.java)
+    .returnResult().responseBody!!
+
+  fun createContactEmails(contactId: Long, request: CreateMultipleEmailsRequest, role: String = "ROLE_CONTACTS_ADMIN"): List<ContactEmailDetails> = webTestClient.post()
+    .uri("/contact/$contactId/emails")
+    .accept(MediaType.APPLICATION_JSON)
+    .contentType(MediaType.APPLICATION_JSON)
+    .headers(authorised(role))
+    .bodyValue(request)
+    .exchange()
+    .expectStatus()
+    .isCreated
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBodyList(ContactEmailDetails::class.java)
     .returnResult().responseBody!!
 
   fun updateAContactEmail(contactId: Long, contactEmailId: Long, request: UpdateEmailRequest, role: String = "ROLE_CONTACTS_ADMIN"): ContactEmailDetails = webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactEmailIntegrationTest.kt
@@ -9,7 +9,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactEmailInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
@@ -12,8 +12,8 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactEmailInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailControllerTest.kt
@@ -11,8 +11,8 @@ import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactEmailFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactEmailDetails
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmailDetails
 import java.time.LocalDateTime
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactEmailServiceTest.kt
@@ -16,8 +16,8 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEmailEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmailDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactEmailRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository


### PR DESCRIPTION
Support for the "add another" pattern in the UI when adding email addresses. Moved email request entities into common package. Will follow suit for other APIs as I come to them.