### PR TITLE
PRC-465: Error message formatting for child elements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/ContactSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/ContactSearchRequest.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 data class ContactSearchRequest(
 
   @Schema(description = "Last name of the contact", example = "Jones", nullable = false, maxLength = 12)
-  @field:NotBlank(message = "Last Name cannot be blank.")
+  @field:NotBlank(message = "lastName cannot be blank.")
   val lastName: String,
 
   @Schema(description = "First name of the contact", example = "Elton", nullable = true, maxLength = 12)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/EmailAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/email/EmailAddress.kt
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.Size
 
 @Schema(description = "A single email address")
 data class EmailAddress(
-  @field:Size(max = 240, message = "emailAddress must be <= 240 characters")
+  @field:Size(max = 240, message = "must be <= 240 characters")
   val emailAddress: String,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
@@ -218,7 +218,7 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
       )
       return listOf(
         Arguments.of(
-          "comments must be <= 240 characters",
+          "relationship.comments must be <= 240 characters",
           relationship.copy(comments = "".padStart(241, 'X')),
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
@@ -258,7 +258,7 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
       )
       return listOf(
         Arguments.of(
-          "comments must be <= 240 characters",
+          "relationship.comments must be <= 240 characters",
           CreateContactRequest(
             lastName = RandomStringUtils.secure().nextAlphabetic(35),
             firstName = "a new guy",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleEmailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleEmailsIntegrationTest.kt
@@ -167,7 +167,7 @@ class CreateMultipleEmailsIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
-      Arguments.of("emailAddress must be <= 240 characters", aMinimalRequest().copy(emailAddresses = listOf(EmailAddress("".padStart(241, 'X'))))),
+      Arguments.of("emailAddresses[0].emailAddress must be <= 240 characters", aMinimalRequest().copy(emailAddresses = listOf(EmailAddress("".padStart(241, 'X'))))),
       Arguments.of("emailAddresses must have at least 1 item", aMinimalRequest().copy(emailAddresses = emptyList())),
       Arguments.of(
         "createdBy must be <= 100 characters",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
@@ -236,7 +236,7 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
 
     val errors = testAPIClient.getBadResponseErrors(uri)
 
-    assertThat(errors.userMessage).isEqualTo("Validation failure(s): Last Name cannot be blank.")
+    assertThat(errors.userMessage).isEqualTo("Validation failure(s): lastName cannot be blank.")
   }
 
   @Test
@@ -249,7 +249,7 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
 
     val errors = testAPIClient.getBadResponseErrors(uri)
 
-    assertThat(errors.userMessage).contains("Validation failure(s): Failed to convert value of type 'java.lang.String' to required type 'java.time.LocalDate';")
+    assertThat(errors.userMessage).contains("Validation failure(s): dateOfBirth Failed to convert value of type 'java.lang.String' to required type 'java.time.LocalDate';")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigratePrisonerDomesticStatusIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigratePrisonerDomesticStatusIntegrationTest.kt
@@ -95,7 +95,7 @@ class MigratePrisonerDomesticStatusIntegrationTest : PostgresIntegrationTestBase
       .isBadRequest
       .expectBody()
       .jsonPath("$.userMessage")
-      .isEqualTo("Validation failure(s): domesticStatusCode must be exactly 1 character")
+      .isEqualTo("Validation failure(s): current.domesticStatusCode must be exactly 1 character")
   }
 
   private fun basicMigrationRequest(): MigratePrisonerDomesticStatusRequest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigratePrisonerNumberOfChildrenIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigratePrisonerNumberOfChildrenIntegrationTest.kt
@@ -95,7 +95,7 @@ class MigratePrisonerNumberOfChildrenIntegrationTest : PostgresIntegrationTestBa
       .isBadRequest
       .expectBody()
       .jsonPath("$.userMessage")
-      .isEqualTo("Validation failure(s): numberOfChildren must be less than 50 characters")
+      .isEqualTo("Validation failure(s): current.numberOfChildren must be less than 50 characters")
   }
 
   private fun basicMigrationRequest() = MigratePrisonerNumberOfChildrenRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/ContactSearchRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/ContactSearchRequestTest.kt
@@ -39,7 +39,7 @@ class ContactSearchRequestTest {
     val violations = validator.validate(request)
 
     assertThat(violations).hasSize(1)
-    assertThat(violations.first().message).isEqualTo("Last Name cannot be blank.")
+    assertThat(violations.first().message).isEqualTo("lastName cannot be blank.")
   }
 
   @Test


### PR DESCRIPTION
Append the path to the element if it's a field error. Did some shenanigans to handle where the field name is added to the start of the message.