### PR TITLE
PRC-464: Add multiple address phone numbers API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacade.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateContactAddressPhoneRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressPhoneDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactAddressPhoneService
@@ -21,6 +22,17 @@ class ContactAddressPhoneFacade(
       secondIdentifier = it.contactAddressId,
       contactId = contactId,
     )
+  }
+
+  fun createMultiple(contactId: Long, contactAddressId: Long, request: CreateMultiplePhoneNumbersRequest): List<ContactAddressPhoneDetails> = contactAddressPhoneService.createMultiple(contactId, contactAddressId, request).also { created ->
+    created.map {
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
+        identifier = it.contactAddressPhoneId,
+        secondIdentifier = it.contactAddressId,
+        contactId = contactId,
+      )
+    }
   }
 
   fun update(contactId: Long, contactAddressPhoneId: Long, request: UpdateContactAddressPhoneRequest): ContactAddressPhoneDetails = contactAddressPhoneService.update(contactId, contactAddressPhoneId, request).also {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacade.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultipleContactPhoneNumbersRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
@@ -23,7 +23,7 @@ class ContactPhoneFacade(
     )
   }
 
-  fun createMultiple(contactId: Long, request: CreateMultipleContactPhoneNumbersRequest): List<ContactPhoneDetails> = contactPhoneService.createMultiple(contactId, request).also { created ->
+  fun createMultiple(contactId: Long, request: CreateMultiplePhoneNumbersRequest): List<ContactPhoneDetails> = contactPhoneService.createMultiple(contactId, request).also { created ->
     created.forEach {
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_PHONE_CREATED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/CreateMultiplePhoneNumbersRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/CreateMultiplePhoneNumbersRequest.kt
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 
-@Schema(description = "Request to create multiple phone numbers for a contact")
-data class CreateMultipleContactPhoneNumbersRequest(
+@Schema(description = "Request to create multiple phone numbers for a contact or an address")
+data class CreateMultiplePhoneNumbersRequest(
   @Schema(description = "Phone numbers")
   @field:Valid
   @field:Size(min = 1, message = "phoneNumbers must have at least 1 item")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -91,7 +92,7 @@ class ContactEmailController(private val contactEmailFacade: ContactEmailFacade)
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = ContactEmailDetails::class),
+            array = ArraySchema(schema = Schema(implementation = ContactEmailDetails::class)),
           ),
         ],
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -22,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactPhoneFacade
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultipleContactPhoneNumbersRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
@@ -92,7 +93,7 @@ class ContactPhoneController(private val contactPhoneFacade: ContactPhoneFacade)
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = ContactPhoneDetails::class),
+            array = ArraySchema(schema = Schema(implementation = ContactPhoneDetails::class)),
           ),
         ],
       ),
@@ -115,7 +116,7 @@ class ContactPhoneController(private val contactPhoneFacade: ContactPhoneFacade)
       description = "The id of the contact",
       example = "123456",
     ) contactId: Long,
-    @Valid @RequestBody request: CreateMultipleContactPhoneNumbersRequest,
+    @Valid @RequestBody request: CreateMultiplePhoneNumbersRequest,
   ): ResponseEntity<Any> {
     val createdPhone = contactPhoneFacade.createMultiple(contactId, request)
     return ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneService.kt
@@ -2,12 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
-import jakarta.validation.ValidationException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactPhoneEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.ReferenceCodeGroup
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultipleContactPhoneNumbersRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
@@ -16,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactAddressPh
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactPhoneDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactPhoneRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.validatePhoneNumber
 import java.time.LocalDateTime
 
 @Service
@@ -40,7 +40,7 @@ class ContactPhoneService(
   }
 
   @Transactional
-  fun createMultiple(contactId: Long, request: CreateMultipleContactPhoneNumbersRequest): List<ContactPhoneDetails> {
+  fun createMultiple(contactId: Long, request: CreateMultiplePhoneNumbersRequest): List<ContactPhoneDetails> {
     validateContactExists(contactId)
     return request.phoneNumbers.map {
       createANewPhoneNumber(
@@ -115,12 +115,6 @@ class ContactPhoneService(
     val existing = contactPhoneRepository.findById(contactPhoneId)
       .orElseThrow { EntityNotFoundException("Contact phone ($contactPhoneId) not found") }
     return existing
-  }
-
-  private fun validatePhoneNumber(phoneNumber: String) {
-    if (!phoneNumber.matches(Regex("\\+?[\\d\\s()]+"))) {
-      throw ValidationException("Phone number invalid, it can only contain numbers, () and whitespace with an optional + at the start")
-    }
   }
 
   private fun validateContactExists(contactId: Long) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/PhoneNumberUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/PhoneNumberUtils.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.util
+
+import jakarta.validation.ValidationException
+
+fun validatePhoneNumber(phoneNumber: String) {
+  if (!phoneNumber.matches(Regex("\\+?[\\d\\s()]+"))) {
+    throw ValidationException("Phone number invalid, it can only contain numbers, () and whitespace with an optional + at the start")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
@@ -9,7 +9,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactPhoneNumberDetails
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultipleContactPhoneNumbersRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.PhoneNumber
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdatePhoneRequest
@@ -78,7 +78,7 @@ class ContactPhoneFacadeTest {
     )
     whenever(phoneService.createMultiple(any(), any())).thenReturn(expectedCreated)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
-    val request = CreateMultipleContactPhoneNumbersRequest(
+    val request = CreateMultiplePhoneNumbersRequest(
       listOf(
         PhoneNumber(
           phoneType = "MOB",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.CreateM
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.email.UpdateEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateContactAddressPhoneRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultipleContactPhoneNumbersRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdatePhoneRequest
@@ -176,7 +176,7 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
     .expectBody(ContactPhoneDetails::class.java)
     .returnResult().responseBody!!
 
-  fun createMultipleContactPhones(contactId: Long, request: CreateMultipleContactPhoneNumbersRequest, role: String = "ROLE_CONTACTS_ADMIN"): List<ContactPhoneDetails> = webTestClient.post()
+  fun createMultipleContactPhones(contactId: Long, request: CreateMultiplePhoneNumbersRequest, role: String = "ROLE_CONTACTS_ADMIN"): List<ContactPhoneDetails> = webTestClient.post()
     .uri("/contact/$contactId/phones")
     .accept(MediaType.APPLICATION_JSON)
     .contentType(MediaType.APPLICATION_JSON)
@@ -229,6 +229,19 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
     .isCreated
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBody(ContactAddressPhoneDetails::class.java)
+    .returnResult().responseBody!!
+
+  fun createMultipleContactAddressPhones(contactId: Long, contactAddressId: Long, request: CreateMultiplePhoneNumbersRequest, role: String = "ROLE_CONTACTS_ADMIN"): List<ContactAddressPhoneDetails> = webTestClient.post()
+    .uri("/contact/$contactId/address/$contactAddressId/phones")
+    .accept(MediaType.APPLICATION_JSON)
+    .contentType(MediaType.APPLICATION_JSON)
+    .headers(authorised(role))
+    .bodyValue(request)
+    .exchange()
+    .expectStatus()
+    .isCreated
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBodyList(ContactAddressPhoneDetails::class.java)
     .returnResult().responseBody!!
 
   fun updateAContactAddressPhone(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneServiceTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
@@ -17,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactPhoneDetailsEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactPhoneEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.ReferenceCodeGroup
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultipleContactPhoneNumbersRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.PhoneNumber
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdatePhoneRequest
@@ -59,40 +58,9 @@ class ContactPhoneServiceTest {
     createdTime = now(),
   )
 
-  companion object {
-    @JvmStatic
-    fun invalidPhoneNumbers(): List<Arguments> = listOf(
-      "!",
-      "\"",
-      "£",
-      "$",
-      "%",
-      "^",
-      "&",
-      "*",
-      "_",
-      "-",
-      "=",
-      // + not allowed unless at start
-      "0+",
-      ":",
-      ";",
-      "[",
-      "]",
-      "{",
-      "}",
-      "@",
-      "#",
-      "~",
-      "/",
-      "\\",
-      "'",
-    ).map { Arguments.of(it) }
-  }
-
   @Nested
   inner class CreateMultiplePhones {
-    private val request = CreateMultipleContactPhoneNumbersRequest(
+    private val request = CreateMultiplePhoneNumbersRequest(
       listOf(
         PhoneNumber(
           "MOB",
@@ -137,7 +105,7 @@ class ContactPhoneServiceTest {
     }
 
     @ParameterizedTest
-    @MethodSource("uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactPhoneServiceTest#invalidPhoneNumbers")
+    @MethodSource("uk.gov.justice.digital.hmpps.hmppscontactsapi.util.PhoneNumberTestUtils#invalidPhoneNumbers")
     fun `should throw ValidationException creating phone if phone contains invalid chars`(phoneNumber: String) {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.PHONE_TYPE, "MOB")).thenReturn(
@@ -280,7 +248,7 @@ class ContactPhoneServiceTest {
     }
 
     @ParameterizedTest
-    @MethodSource("uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactPhoneServiceTest#invalidPhoneNumbers")
+    @MethodSource("uk.gov.justice.digital.hmpps.hmppscontactsapi.util.PhoneNumberTestUtils#invalidPhoneNumbers")
     fun `should throw ValidationException creating phone if phone contains invalid chars`(phoneNumber: String) {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.PHONE_TYPE, "MOB")).thenReturn(
@@ -453,7 +421,7 @@ class ContactPhoneServiceTest {
     }
 
     @ParameterizedTest
-    @MethodSource("uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactPhoneServiceTest#invalidPhoneNumbers")
+    @MethodSource("uk.gov.justice.digital.hmpps.hmppscontactsapi.util.PhoneNumberTestUtils#invalidPhoneNumbers")
     fun `should throw ValidationException updating phone if phone contains invalid chars`(phoneNumber: String) {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(contactPhoneRepository.findById(contactPhoneId)).thenReturn(Optional.of(existingPhone))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/PhoneNumberTestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/PhoneNumberTestUtils.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.util
+
+import org.junit.jupiter.params.provider.Arguments
+
+class PhoneNumberTestUtils {
+
+  companion object {
+    @JvmStatic
+    fun invalidPhoneNumbers(): List<Arguments> = listOf(
+      "!",
+      "\"",
+      "£",
+      "$",
+      "%",
+      "^",
+      "&",
+      "*",
+      "_",
+      "-",
+      "=",
+      // + not allowed unless at start
+      "0+",
+      ":",
+      ";",
+      "[",
+      "]",
+      "{",
+      "}",
+      "@",
+      "#",
+      "~",
+      "/",
+      "\\",
+      "'",
+    ).map { Arguments.of(it) }
+  }
+}


### PR DESCRIPTION
Re-uses the request from contact address phone as it's the same and the parent ids are part of the URL.

Also minor swagger fix on other recently added multi add APIs