### PR TITLE
PRC-506: Get contact name API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchContactR
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactCreationResult
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactNameDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PatchContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipDetails
@@ -71,6 +72,8 @@ class ContactFacade(
     }
 
   fun getContact(id: Long): ContactDetails? = contactService.getContact(id)
+
+  fun getContactName(id: Long): ContactNameDetails? = contactService.getContactName(id)
 
   fun searchContacts(pageable: Pageable, request: ContactSearchRequest): Page<ContactSearchResultItem> = contactService.searchContacts(pageable, request)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactNameDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactNameDetails.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ContactNameDetails(
+  @Schema(
+    description =
+    """
+      The title code for the contact.
+      This is a coded value (from the group code TITLE in reference data).
+      Known values are MR, MRS, MISS, DR, MS, REV, SIR, BR, SR.
+      """,
+    example = "MR",
+    nullable = true,
+  )
+  val titleCode: String? = null,
+
+  @Schema(
+    description = "The description of the title code, if present",
+    example = "Mr",
+    nullable = true,
+  )
+  val titleDescription: String? = null,
+
+  @Schema(description = "The last name of the contact", example = "Doe")
+  val lastName: String,
+
+  @Schema(description = "The first name of the contact", example = "John")
+  val firstName: String,
+
+  @Schema(description = "The middle name of the contact, if any", example = "William", nullable = true)
+  val middleNames: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactCreationResult
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactNameDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItemPage
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PatchContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
@@ -128,6 +129,47 @@ class ContactController(
       ResponseEntity.ok(contact)
     } else {
       logger.info("Couldn't find contact with id '{}'", contactId)
+      ResponseEntity.notFound().build()
+    }
+  }
+
+  @GetMapping("/{contactId}/name")
+  @Operation(
+    summary = "Get contact name",
+    description = "Gets a contacts name details by their id. Includes title code, description, first name, middle names and last name.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Found the contact",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ContactNameDetails::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No contact with that id could be found",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
+  fun getContactName(
+    @PathVariable("contactId") @Parameter(
+      name = "contactId",
+      description = "The id of the contact",
+      example = "123456",
+    ) contactId: Long,
+  ): ResponseEntity<Any> {
+    val name = contactFacade.getContactName(contactId)
+    return if (name != null) {
+      ResponseEntity.ok(name)
+    } else {
+      logger.info("Couldn't find contact with id '{}' to get their name", contactId)
       ResponseEntity.notFound().build()
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateRelatio
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressPhoneDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactCreationResult
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactNameDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipDetails
@@ -74,6 +75,19 @@ class ContactService(
 
   fun getContact(id: Long): ContactDetails? = contactRepository.findById(id).getOrNull()
     ?.let { enrichContact(it) }
+
+  fun getContactName(id: Long): ContactNameDetails? = contactRepository.findById(id).getOrNull()
+    ?.let { contactEntity ->
+      ContactNameDetails(
+        titleCode = contactEntity.title,
+        titleDescription = contactEntity.title?.let {
+          referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.TITLE, it)?.description
+        },
+        lastName = contactEntity.lastName,
+        firstName = contactEntity.firstName,
+        middleNames = contactEntity.middleNames,
+      )
+    }
 
   fun searchContacts(pageable: Pageable, request: ContactSearchRequest): Page<ContactSearchResultItem> = contactSearchRepository.searchContacts(request, pageable).toModel()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactCreat
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmailDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactIdentityDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactNameDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactRestrictionDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
@@ -90,6 +91,17 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
     .isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBody(ContactDetails::class.java)
+    .returnResult().responseBody!!
+
+  fun getContactName(id: Long, role: String = "ROLE_CONTACTS_ADMIN"): ContactNameDetails = webTestClient.get()
+    .uri("/contact/$id/name")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(roles = listOf(role)))
+    .exchange()
+    .expectStatus()
+    .isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody(ContactNameDetails::class.java)
     .returnResult().responseBody!!
 
   fun getPrisonerContacts(prisonerNumber: String): PrisonerContactSummaryResponse = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactNameIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactNameIntegrationTest.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+
+class GetContactNameIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
+
+  override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.get()
+    .uri("/contact/1/name")
+    .accept(MediaType.APPLICATION_JSON)
+
+  @Test
+  fun `should return 404 if the contact doesn't exist`() {
+    webTestClient.get()
+      .uri("/contact/123456")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @Test
+  fun `should get the contact name with all fields if they have a title`() {
+    val contact = testAPIClient.createAContact(
+      CreateContactRequest(
+        title = "MR",
+        lastName = "Last",
+        firstName = "First",
+        middleNames = "Middle Names",
+        createdBy = "USER1",
+      ),
+    )
+
+    val name = testAPIClient.getContactName(contact.id)
+
+    with(name) {
+      assertThat(titleCode).isEqualTo("MR")
+      assertThat(titleDescription).isEqualTo("Mr")
+      assertThat(lastName).isEqualTo("Last")
+      assertThat(firstName).isEqualTo("First")
+      assertThat(middleNames).isEqualTo("Middle Names")
+    }
+  }
+
+  @Test
+  fun `should get the contact name with only optional fields`() {
+    val contact = testAPIClient.createAContact(
+      CreateContactRequest(
+        title = null,
+        lastName = "Last",
+        firstName = "First",
+        middleNames = null,
+        createdBy = "USER1",
+      ),
+    )
+
+    val name = testAPIClient.getContactName(contact.id)
+
+    with(name) {
+      assertThat(titleCode).isNull()
+      assertThat(titleDescription).isNull()
+      assertThat(lastName).isEqualTo("Last")
+      assertThat(firstName).isEqualTo("First")
+      assertThat(middleNames).isNull()
+    }
+  }
+}


### PR DESCRIPTION
Small API to be used when only the name is required. This avoids loading all phone numbers, addresses, etc.