### PR TITLE
PRC-531: Set db timeouts

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,11 @@ spring:
     url: 'jdbc:postgresql://${DB_SERVER}/${DB_NAME}?sslmode=${DB_SSL_MODE}'
     username: ${DB_USER}
     password: ${DB_PASS}
+    hikari:
+      pool-name: PERSONAL-RELATIONSHIPS-DB-CP
+      connection-timeout: 1000
+      validation-timeout: 500
+      maximum-pool-size: 25
 
   jpa:
     open-in-view: false
@@ -28,7 +33,14 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
+        session:
+          events:
+            log:
+              LOG_QUERIES_SLOWER_THAN_MS: 10000
+        javax:
+          persistence:
+            query:
+              timeout: 30000
   flyway:
     locations: classpath:/migrations/common,classpath:/migrations/prod
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -36,6 +36,10 @@
     <appender-ref ref="consoleAppender"/>
   </logger>
 
+  <logger name="org.hibernate.SQL_SLOW" additivity="false" level="INFO">
+    <appender-ref ref="consoleAppender"/>
+  </logger>
+
   <root level="INFO">
     <appender-ref ref="consoleAppender"/>
   </root>


### PR DESCRIPTION
Set connection pool properties to avoid hanging when connection pool is busy (max wait for connection 1 second, max time to validate session 0.5 seconds).

Increase connection pool size to 25 (in line with CSIP).

Attempt to set query timeout to 30 seconds.

Configure slow SQL log, anything slower than 10 seconds will log an info log.