### PR TITLE
PRC-465: Check for duplicate email on contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/HmppsContactsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/HmppsContactsApiExceptionHandler.kt
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.exception.DuplicateEmailException
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.exception.InvalidReferenceCodeGroupException
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.DuplicatePersonException
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -131,8 +132,8 @@ class HmppsContactsApiExceptionHandler {
       ),
     )
 
-  @ExceptionHandler(DuplicatePersonException::class)
-  fun handleDuplicatePersonException(e: DuplicatePersonException): ResponseEntity<ErrorResponse> = ResponseEntity
+  @ExceptionHandler(DuplicatePersonException::class, DuplicateEmailException::class)
+  fun handleDuplicatePersonException(e: RuntimeException): ResponseEntity<ErrorResponse> = ResponseEntity
     .status(CONFLICT)
     .body(
       ErrorResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/exception/DuplicateEmailException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/exception/DuplicateEmailException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.exception
+
+class DuplicateEmailException(val email: String) : RuntimeException("Contact already has an email address matching \"$email\"")


### PR DESCRIPTION
Unfortunately this can't be enforced with a unique index as NOMIS currently contains duplicates on a contact.