### PR TITLE
PRC-535 - API - Allow setting identity documents when creating a new contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
@@ -48,6 +48,14 @@ class ContactFacade(
           noms = request.relationship?.prisonerNumber.let { request.relationship!!.prisonerNumber },
         )
       }
+
+      creationResult.createdContact.identities.forEach {
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.CONTACT_IDENTITY_CREATED,
+          identifier = it.contactIdentityId,
+          contactId = creationResult.createdContact.id,
+        )
+      }
     }
 
   fun addContactRelationship(request: AddContactRelationshipRequest): PrisonerContactRelationshipDetails {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 import org.springframework.format.annotation.DateTimeFormat
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.identity.IdentityDocument
 import java.time.LocalDate
 
 @Schema(description = "Request to create a new contact")
@@ -84,6 +85,10 @@ data class CreateContactRequest(
   @Schema(description = "A description of the relationship if the contact should be linked to a prisoner", nullable = true, exampleClasses = [ContactRelationship::class])
   @field:Valid
   val relationship: ContactRelationship? = null,
+
+  @Schema(description = "Identity documents")
+  @field:Valid
+  val identities: List<IdentityDocument> = emptyList(),
 
   @Schema(description = "The id of the user creating the contact", example = "JD000001", maxLength = 100)
   @field:Size(max = 100, message = "createdBy must be <= 100 characters")


### PR DESCRIPTION
PRC-535 - API - Allow setting identity documents when creating a new contact