### PR TITLE
PRC-539: Use batch API for linked prisoner lookup

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/prisonersearch/PrisonerNumbers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/prisonersearch/PrisonerNumbers.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch
+
+data class PrisonerNumbers(val prisonerNumbers: Set<String>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/prisonersearch/PrisonerSearchClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/prisonersearch/PrisonerSearchClient.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch
 
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
@@ -15,4 +16,12 @@ class PrisonerSearchClient(private val prisonerSearchApiWebClient: WebClient) {
     .bodyToMono(Prisoner::class.java)
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
     .block()
+
+  fun getPrisoners(prisonerNumbers: Set<String>): List<Prisoner> = prisonerSearchApiWebClient
+    .post()
+    .uri("/prisoner-search/prisoner-numbers")
+    .bodyValue(PrisonerNumbers(prisonerNumbers))
+    .retrieve()
+    .bodyToMono(object : ParameterizedTypeReference<List<Prisoner>>() {})
+    .block()!!
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersService.kt
@@ -11,29 +11,34 @@ class LinkedPrisonersService(
   private val prisonerService: PrisonerService,
 ) {
 
-  fun getLinkedPrisoners(contactId: Long): List<LinkedPrisonerDetails> = prisonerContactSummaryRepository.findByContactId(contactId)
-    .groupBy { it.prisonerNumber }
-    .mapNotNull { (prisonerNumber, summaries) ->
-      prisonerService.getPrisoner(prisonerNumber)
-        ?.let { prisoner ->
-          LinkedPrisonerDetails(
-            prisonerNumber = prisonerNumber,
-            lastName = prisoner.lastName,
-            firstName = prisoner.firstName,
-            middleNames = prisoner.middleNames,
-            prisonId = prisoner.prisonId,
-            prisonName = prisoner.prisonName,
-            relationships = summaries.map { summary ->
-              LinkedPrisonerRelationshipDetails(
-                prisonerContactId = summary.prisonerContactId,
-                relationshipTypeCode = summary.relationshipType,
-                relationshipTypeDescription = summary.relationshipTypeDescription,
-                relationshipToPrisonerCode = summary.relationshipToPrisoner,
-                relationshipToPrisonerDescription = summary.relationshipToPrisonerDescription,
-                isRelationshipActive = summary.active,
-              )
-            },
-          )
-        }
-    }
+  fun getLinkedPrisoners(contactId: Long): List<LinkedPrisonerDetails> {
+    val relationshipsByPrisonerNumber =
+      prisonerContactSummaryRepository.findByContactId(contactId).groupBy { it.prisonerNumber }
+    val prisoners = if (relationshipsByPrisonerNumber.isNotEmpty()) prisonerService.getPrisoners(relationshipsByPrisonerNumber.keys) else emptyList()
+
+    return relationshipsByPrisonerNumber
+      .mapNotNull { (prisonerNumber, summaries) ->
+        prisoners.find { it.prisonerNumber == prisonerNumber }
+          ?.let { prisoner ->
+            LinkedPrisonerDetails(
+              prisonerNumber = prisonerNumber,
+              lastName = prisoner.lastName,
+              firstName = prisoner.firstName,
+              middleNames = prisoner.middleNames,
+              prisonId = prisoner.prisonId,
+              prisonName = prisoner.prisonName,
+              relationships = summaries.map { summary ->
+                LinkedPrisonerRelationshipDetails(
+                  prisonerContactId = summary.prisonerContactId,
+                  relationshipTypeCode = summary.relationshipType,
+                  relationshipTypeDescription = summary.relationshipTypeDescription,
+                  relationshipToPrisonerCode = summary.relationshipToPrisoner,
+                  relationshipToPrisonerDescription = summary.relationshipToPrisonerDescription,
+                  isRelationshipActive = summary.active,
+                )
+              },
+            )
+          }
+      }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerService.kt
@@ -7,4 +7,5 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.Priso
 @Service
 class PrisonerService(private val prisonerSearchClient: PrisonerSearchClient) {
   fun getPrisoner(prisonerNumber: String): Prisoner? = prisonerSearchClient.getPrisoner(prisonerNumber)
+  fun getPrisoners(prisonerNumbers: Set<String>): List<Prisoner> = prisonerSearchClient.getPrisoners(prisonerNumbers)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
@@ -66,6 +66,10 @@ abstract class IntegrationTestBase {
     prisonerSearchApiServer.stubGetPrisoner(prisoner)
   }
 
+  protected fun stubSearchPrisonersByPrisonerNumbers(idsBeingSearchFor: Set<String>, prisonersToReturn: List<Prisoner>) {
+    prisonerSearchApiServer.stubSearchPrisonersByPrisonerNumber(idsBeingSearchFor, prisonersToReturn)
+  }
+
   protected fun stubPrisonSearchWithNotFoundResponse(prisonerNumber: String) {
     prisonerSearchApiServer.stubGetPrisonerReturnNoResults(prisonerNumber)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
@@ -60,6 +60,7 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
     val prisoner1OtherRelationship = addRelationship(prisoner1, "OTHER")
     val prisoner2FatherRelationship = addRelationship(prisoner2, "FA")
 
+    stubSearchPrisonersByPrisonerNumbers(setOf(prisoner1.prisonerNumber, prisoner2.prisonerNumber), listOf(prisoner1, prisoner2))
     val linkedPrisoners = testAPIClient.getLinkedPrisoners(savedContactId)
     assertThat(linkedPrisoners).isEqualTo(
       listOf(
@@ -119,7 +120,7 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
     val prisoner1OtherRelationship = addRelationship(prisoner1, "OTHER")
     addRelationship(prisoner2, "FA")
 
-    stubPrisonSearchWithNotFoundResponse(prisoner2.prisonerNumber)
+    stubSearchPrisonersByPrisonerNumbers(setOf(prisoner1.prisonerNumber, prisoner2.prisonerNumber), listOf(prisoner1))
 
     val linkedPrisoners = testAPIClient.getLinkedPrisoners(savedContactId)
     assertThat(linkedPrisoners).isEqualTo(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.wiremock
 
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.post
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.Prisoner
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.PrisonerNumbers
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.prisoner
 
 class PrisonerSearchApiMockServer : MockServer(8092) {
@@ -23,6 +26,21 @@ class PrisonerSearchApiMockServer : MockServer(8092) {
             .withHeader("Content-Type", "application/json")
             .withBody(
               mapper.writeValueAsString(prisoner),
+            )
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubSearchPrisonersByPrisonerNumber(idsBeingSearchFor: Set<String>, prisonersToReturn: List<Prisoner>) {
+    stubFor(
+      post("/prisoner-search/prisoner-numbers")
+        .withRequestBody(equalToJson(mapper.writeValueAsString(PrisonerNumbers(idsBeingSearchFor)), true, true))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              mapper.writeValueAsString(prisonersToReturn),
             )
             .withStatus(200),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersServiceTest.kt
@@ -20,7 +20,7 @@ class LinkedPrisonersServiceTest {
   private val contactId: Long = 123
 
   @Test
-  fun `should call search service only once per prisoner even if multiple relationships`() {
+  fun `Should search for unique prisoner ids and join with multiple relationships even if to the same prisoner`() {
     whenever(repo.findByContactId(contactId)).thenReturn(
       listOf(
         // two relationships for A1234BC and one for X6789YZ
@@ -29,8 +29,7 @@ class LinkedPrisonersServiceTest {
         prisonerContactEntity(777, "X6789YZ", "S", "Social", "FA", "Father", true),
       ),
     )
-    whenever(prisonerService.getPrisoner("A1234BC")).thenReturn(prisoner(prisonerNumber = "A1234BC", firstName = "A", middleNames = "1234", lastName = "BC", prisonId = "BXI", prisonName = "Brixton (HMP)"))
-    whenever(prisonerService.getPrisoner("X6789YZ")).thenReturn(prisoner(prisonerNumber = "X6789YZ", firstName = "X", middleNames = null, lastName = "YZ"))
+    whenever(prisonerService.getPrisoners(setOf("A1234BC", "X6789YZ"))).thenReturn(listOf(prisoner(prisonerNumber = "A1234BC", firstName = "A", middleNames = "1234", lastName = "BC", prisonId = "BXI", prisonName = "Brixton (HMP)"), prisoner(prisonerNumber = "X6789YZ", firstName = "X", middleNames = null, lastName = "YZ")))
 
     val linkedPrisoners = service.getLinkedPrisoners(contactId)
 
@@ -82,8 +81,7 @@ class LinkedPrisonersServiceTest {
       ),
     )
 
-    verify(prisonerService, times(1)).getPrisoner("A1234BC")
-    verify(prisonerService, times(1)).getPrisoner("X6789YZ")
+    verify(prisonerService, times(1)).getPrisoners(setOf("A1234BC", "X6789YZ"))
   }
 
   @Test
@@ -94,8 +92,7 @@ class LinkedPrisonersServiceTest {
         prisonerContactEntity(777, "X6789YZ", "S", "Social", "FA", "Father", true),
       ),
     )
-    whenever(prisonerService.getPrisoner("A1234BC")).thenReturn(prisoner(prisonerNumber = "A1234BC", firstName = "A", middleNames = "1234", lastName = "BC"))
-    whenever(prisonerService.getPrisoner("X6789YZ")).thenReturn(null)
+    whenever(prisonerService.getPrisoners(setOf("A1234BC", "X6789YZ"))).thenReturn(listOf(prisoner(prisonerNumber = "A1234BC", firstName = "A", middleNames = "1234", lastName = "BC")))
 
     val linkedPrisoners = service.getLinkedPrisoners(contactId)
 
@@ -120,8 +117,7 @@ class LinkedPrisonersServiceTest {
       ),
     )
 
-    verify(prisonerService, times(1)).getPrisoner("A1234BC")
-    verify(prisonerService, times(1)).getPrisoner("X6789YZ")
+    verify(prisonerService, times(1)).getPrisoners(setOf("A1234BC", "X6789YZ"))
   }
 
   private fun prisonerContactEntity(


### PR DESCRIPTION
Lookup linked prisoners using the batch API rather than one prisoner at a time. This API just omits any prisoners that can't be found from the results.