### PR TITLE
PRC-395: Nomis admin event processing for MERGE and RESET + refactoring for re-use and tidying swagger tags and labels.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/OpenApiConfiguration.kt
@@ -60,7 +60,14 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
         },
         Tag().apply {
           name("Restrictions")
-          description("Endpoints for creating and managing restrictions including global and relationship-specific varieties.")
+          description(
+            """
+            Endpoints for creating and managing restrictions. Two kinds of restrictions are supported:
+             - Estate wide restrictions (known as global or contact restrictions), which apply to all the contact's relationships.
+             - Prisoner-contact restrictions, which apply to a specific relationship between a prisoner and a contact.
+            There are also restrictions that can apply to a prisoner (and all of their relationships) but these are not supported here.
+            """.trimIndent(),
+          )
         },
         Tag().apply {
           name("Reference data")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/OpenApiConfiguration.kt
@@ -41,7 +41,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
       Info()
         .title("Personal Relationships API")
         .version(version)
-        .description("API for management of contacts and their relationships to prisoners including restrictions that apply to the contact or relationship specifically.")
+        .description("API for the management of contacts, their relationships to prisoners and restrictions.")
         .contact(
           Contact()
             .name("HMPPS Digital Studio")
@@ -52,32 +52,27 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
       listOf(
         Tag().apply {
           name("Contacts")
-          description("APIs relating to creating and managing a contact")
+          description("Endpoints for creating and managing contacts.")
         },
         Tag().apply {
-          name("Prisoner Contact Relationship")
-          description("APIs relating to creating and managing relationships between contacts and prisoners")
+          name("Prisoner relationships")
+          description("Endpoints for creating and managing the relationships between contacts and prisoners.")
         },
         Tag().apply {
           name("Restrictions")
-          description(
-            """
-            APIs relating to creating and managing restrictions. Two kinds of restrictions are supported in this API
-            
-             - Estate wide restrictions, a.k.a global and contact restrictions. These apply to all of a contacts relationships.
-             - Prisoner-contact restrictions. These apply to a relationship between a specific prisoner and contact. 
-             
-            There are also restrictions that can apply to a prisoner and all of their relationships but those are not supported by this API.
-            """.trimIndent(),
-          )
+          description("Endpoints for creating and managing restrictions including global and relationship-specific varieties.")
         },
         Tag().apply {
-          name("Reference Data")
-          description("APIs relating to reference data used in the service")
+          name("Reference data")
+          description("Endpoints for accessing the reference data used in this service")
         },
         Tag().apply {
-          name("Sync & Migrate")
-          description("APIs relating to data sync and migration with NOMIS")
+          name("Migrate and sync")
+          description("Endpoints for migrating and synchronising data to and from NOMIS")
+        },
+        Tag().apply {
+          name("Sync admin")
+          description("Endpoints use by synchronisation for administrative purposes")
         },
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/EmploymentFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/EmploymentFacade.kt
@@ -5,10 +5,10 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.Cr
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.PatchEmploymentsRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.UpdateEmploymentRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.EmploymentDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.EmploymentService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.EmploymentService
 
 @Service
 class EmploymentFacade(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -29,7 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.Prisone
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.MergePrisonerContactService
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncAdminService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactAddressPhoneService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactAddressService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactEmailService
@@ -70,7 +70,7 @@ class SyncFacade(
   private val syncPrisonerContactService: SyncPrisonerContactService,
   private val syncPrisonerContactRestrictionService: SyncPrisonerContactRestrictionService,
   private val syncEmploymentService: SyncEmploymentService,
-  private val mergePrisonerContactService: MergePrisonerContactService,
+  private val syncAdminService: SyncAdminService,
   private val outboundEventsService: OutboundEventsService,
 ) {
   // ================================================================
@@ -449,7 +449,7 @@ class SyncFacade(
   //  restrictions as they are in NOMIS after the merge for the retained prisoner.
   // =====================================================================================
 
-  fun mergePrisonerContacts(request: MergePrisonerContactRequest) = mergePrisonerContactService.mergePrisonerContacts(request)
+  fun mergePrisonerContacts(request: MergePrisonerContactRequest) = syncAdminService.mergePrisonerContacts(request)
     .also {
       sendEventsForRelationshipsRemoved(it.relationshipsRemoved)
       sendEventsForRelationshipsCreated(request.retainedPrisonerNumber, it.relationshipsCreated)
@@ -463,7 +463,7 @@ class SyncFacade(
   //    - An old booking (for the same prisoner) is reinstated
   // ===========================================================================================================
 
-  fun resetPrisonerContacts(request: ResetPrisonerContactRequest) = mergePrisonerContactService.resetPrisonerContacts(request)
+  fun resetPrisonerContacts(request: ResetPrisonerContactRequest) = syncAdminService.resetPrisonerContacts(request)
     .also {
       sendEventsForRelationshipsRemoved(it.relationshipsRemoved)
       sendEventsForRelationshipsCreated(request.prisonerNumber, it.relationshipsCreated)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.MergePrisonerContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.ResetPrisonerContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreateContactEmailRequest
@@ -23,6 +24,8 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdateEmploymentRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdatePrisonerContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdatePrisonerContactRestrictionRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.PrisonerContactAndRestrictionIds
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.PrisonerRelationshipIds
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
@@ -439,54 +442,75 @@ class SyncFacade(
       )
     }
 
-  // ================================================================
-  //  Replace the full set of relationships for a prisoner
-  // ================================================================
+  // =====================================================================================
+  //  MERGE - Replace the full set of relationships and restrictions for two prisoners
+  //  after an offender merge in NOMIS. This request contains a removed prisoner number
+  //  and a retained prisoner number along with the full set of relationships and
+  //  restrictions as they are in NOMIS after the merge for the retained prisoner.
+  // =====================================================================================
 
   fun mergePrisonerContacts(request: MergePrisonerContactRequest) = mergePrisonerContactService.mergePrisonerContacts(request)
     .also {
-      it.relationshipsRemoved.map { relationshipRemoved ->
-        relationshipRemoved.prisonerContactRestrictionIds.map { prisonerContactRestrictionId ->
-          // Send an event for each prisoner contact restriction removed
-          outboundEventsService.send(
-            outboundEvent = OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED,
-            identifier = prisonerContactRestrictionId,
-            contactId = relationshipRemoved.contactId,
-            noms = relationshipRemoved.prisonerNumber,
-            source = Source.NOMIS,
-          )
-        }
-
-        // Send an event for each prisoner contact removed
-        outboundEventsService.send(
-          outboundEvent = OutboundEvent.PRISONER_CONTACT_DELETED,
-          identifier = relationshipRemoved.prisonerContactId,
-          contactId = relationshipRemoved.contactId,
-          noms = relationshipRemoved.prisonerNumber,
-          source = Source.NOMIS,
-        )
-      }
-
-      it.relationshipsCreated.map { relationshipCreated ->
-        // Send an event for each prisoner contact restriction created for each relationship
-        relationshipCreated.restrictions.map { restriction ->
-          outboundEventsService.send(
-            outboundEvent = OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED,
-            identifier = restriction.dpsId,
-            contactId = relationshipCreated.contactId,
-            noms = request.retainedPrisonerNumber,
-            source = Source.NOMIS,
-          )
-        }
-
-        // Send an event for each prisoner contact created
-        outboundEventsService.send(
-          outboundEvent = OutboundEvent.PRISONER_CONTACT_CREATED,
-          identifier = relationshipCreated.relationship.dpsId,
-          contactId = relationshipCreated.contactId,
-          noms = request.retainedPrisonerNumber,
-          source = Source.NOMIS,
-        )
-      }
+      sendEventsForRelationshipsRemoved(it.relationshipsRemoved)
+      sendEventsForRelationshipsCreated(request.retainedPrisonerNumber, it.relationshipsCreated)
     }
+
+  // ======================================================================================
+  //  RESET - Replaces the full set of relationships and restrictions for a single prisoner.
+  //  This is called by the Syscon sync service when one of the following events occur:
+  //    - A new booking is recorded for the prisoner in NOMIS
+  //    - A booking move (from one prisoner to another) is completed in NOMIS
+  //    - An old booking (for the same prisoner) is reinstated
+  // ===========================================================================================================
+
+  fun resetPrisonerContacts(request: ResetPrisonerContactRequest) = mergePrisonerContactService.resetPrisonerContacts(request)
+    .also {
+      sendEventsForRelationshipsRemoved(it.relationshipsRemoved)
+      sendEventsForRelationshipsCreated(request.prisonerNumber, it.relationshipsCreated)
+    }
+
+  private fun sendEventsForRelationshipsRemoved(
+    relationshipsRemoved: List<PrisonerRelationshipIds>,
+  ) = relationshipsRemoved.map { removed ->
+    removed.prisonerContactRestrictionIds.map { prisonerContactRestrictionId ->
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED,
+        identifier = prisonerContactRestrictionId,
+        contactId = removed.contactId,
+        noms = removed.prisonerNumber,
+        source = Source.NOMIS,
+      )
+    }
+
+    outboundEventsService.send(
+      outboundEvent = OutboundEvent.PRISONER_CONTACT_DELETED,
+      identifier = removed.prisonerContactId,
+      contactId = removed.contactId,
+      noms = removed.prisonerNumber,
+      source = Source.NOMIS,
+    )
+  }
+
+  private fun sendEventsForRelationshipsCreated(
+    prisonerNumber: String,
+    relationshipsCreated: List<PrisonerContactAndRestrictionIds>,
+  ) = relationshipsCreated.map { created ->
+    created.restrictions.map { restriction ->
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED,
+        identifier = restriction.dpsId,
+        contactId = created.contactId,
+        noms = prisonerNumber,
+        source = Source.NOMIS,
+      )
+    }
+
+    outboundEventsService.send(
+      outboundEvent = OutboundEvent.PRISONER_CONTACT_CREATED,
+      identifier = created.relationship.dpsId,
+      contactId = created.contactId,
+      noms = prisonerNumber,
+      source = Source.NOMIS,
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/ResetPrisonerContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/ResetPrisonerContactRequest.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "The request to remove and replace relationships and relationship restrictions for a prisoner")
+data class ResetPrisonerContactRequest(
+
+  @Schema(description = "The prisoner number to reset relationships for")
+  val prisonerNumber: String,
+
+  @Schema(description = "The list of relationships to create in place of the existing")
+  val prisonerContacts: List<SyncPrisonerRelationship>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/ResetPrisonerContactResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/ResetPrisonerContactResponse.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "The response object for a reset of relationships for a prisoner")
+data class ResetPrisonerContactResponse(
+  val relationshipsCreated: List<PrisonerContactAndRestrictionIds>,
+  val relationshipsRemoved: List<PrisonerRelationshipIds>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CityController.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.City
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.CityService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
-@Tag(name = "Reference Data")
+@Tag(name = "Reference data")
 @Deprecated(
   level = DeprecationLevel.WARNING,
   message = "No longer used. Please use the generic endpoint /reference-codes/group/{groupCode} for all reference values",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountryController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountryController.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Country
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.CountryService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
-@Tag(name = "Reference Data")
+@Tag(name = "Reference data")
 @Deprecated(
   level = DeprecationLevel.WARNING,
   message = "No longer used. Please use the generic endpoint /reference-codes/group/{groupCode} for all reference values",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountyController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountyController.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.County
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.CountyService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
-@Tag(name = "Reference Data")
+@Tag(name = "Reference data")
 @Deprecated(
   level = DeprecationLevel.WARNING,
   message = "No longer used. Please use the generic endpoint /reference-codes/group/{groupCode} for all reference values",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/LanguageController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/LanguageController.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Language
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.LanguageService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
-@Tag(name = "Reference Data")
+@Tag(name = "Reference data")
 @Deprecated(
   level = DeprecationLevel.WARNING,
   message = "No longer used. Please use the generic endpoint /reference-codes/group/{groupCode} for all reference values",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
@@ -44,7 +44,7 @@ class PrisonerContactController(
 ) {
 
   @Operation(summary = "Endpoint to get a prisoner contact relationship by relationship id")
-  @Tag(name = "Prisoner Contact Relationship")
+  @Tag(name = "Prisoner relationships")
   @ApiResponses(
     value = [
       ApiResponse(
@@ -84,7 +84,7 @@ class PrisonerContactController(
     summary = "Update prisoner contact relationship",
     description = "Update the relationship between the contact and a prisoner.",
   )
-  @Tag(name = "Prisoner Contact Relationship")
+  @Tag(name = "Prisoner relationships")
   @ApiResponses(
     value = [
       ApiResponse(
@@ -122,7 +122,7 @@ class PrisonerContactController(
     summary = "Add a new prisoner contact relationship",
     description = "Creates a new relationship between the contact and a prisoner.",
   )
-  @Tag(name = "Prisoner Contact Relationship")
+  @Tag(name = "Prisoner relationships")
   @ApiResponses(
     value = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.PrisonNumberDoc
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Prisoner Contact Relationship")
+@Tag(name = "Prisoner relationships")
 @RestController
 @RequestMapping(value = ["prisoner"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ReferenceCodeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ReferenceCodeController.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ReferenceCod
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ReferenceCodeService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Reference Data")
+@Tag(name = "Reference data")
 @RestController
 @RequestMapping(value = ["reference-codes"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ReferenceCodeController(private val referenceCodeService: ReferenceCodeService) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigrateContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigrateContactController.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.ContactMigr
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["migrate/contact"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigratePrisonerDomesticStatusController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigratePrisonerDomesticStatusController.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.PrisonerDom
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["migrate/domestic-status"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigratePrisonerNumberOfChildrenController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigratePrisonerNumberOfChildrenController.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.Pris
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.PrisonerNumberOfChildrenMigrationService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["migrate/number-of-children"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactAddressPhoneSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactAddressPhoneSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactAddressPhone
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactAddressPhoneSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactAddressSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactAddressSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactAddress
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactAddressSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactEmailSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactEmailSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactEmail
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactEmailSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactIdentitySyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactIdentitySyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactIdentity
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactIdentitySyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactPhoneSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactPhoneSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactPhone
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactPhoneSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactRestrictionSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactRestrictionSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactRestriction
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactRestrictionSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncCon
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/EmploymentSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/EmploymentSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncEmp
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class EmploymentSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactRestrictionSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactRestrictionSyncController.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPri
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactSyncController.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPri
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerDomesticStatusSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerDomesticStatusSyncController.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPri
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class PrisonerDomesticStatusSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerNumberOfChildrenSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerNumberOfChildrenSyncController.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPri
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Migrate and sync")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class PrisonerNumberOfChildrenSyncController(val prisonerNumberOfChildrenSyncFacade: PrisonerNumberOfChildrenSyncFacade) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/SyncAdminController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/SyncAdminController.kt
@@ -15,20 +15,22 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.SyncFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.MergePrisonerContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.ResetPrisonerContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.MergePrisonerContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ResetPrisonerContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync & Migrate")
+@Tag(name = "Sync admin")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses
-data class MergePrisonerContactController(val syncFacade: SyncFacade) {
+data class SyncAdminController(val syncFacade: SyncFacade) {
 
-  @PostMapping(path = ["/prisoner-contact/merge"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @PostMapping(path = ["/admin/merge"], consumes = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(
-    summary = "Removes and recreates relationships and restrictions after an offender merge.",
-    description = "Removes and recreates relationships and restrictions after an offender merge.",
+    summary = "Removes and recreates relationships and restrictions after a prisoner merge in NOMIS",
+    description = "Relationships are removed for the old and new numbers, and then recreated for new number only",
   )
   @ApiResponses(
     value = [
@@ -53,4 +55,33 @@ data class MergePrisonerContactController(val syncFacade: SyncFacade) {
   fun mergePrisonerContacts(
     @Valid @RequestBody mergePrisonerContactRequest: MergePrisonerContactRequest,
   ) = syncFacade.mergePrisonerContacts(mergePrisonerContactRequest)
+
+  @PostMapping(path = ["/admin/reset"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @Operation(
+    summary = "Removes and recreates relationships and restrictions for one prisoner to reset them to match what exists in NOMIS.",
+    description = "Similar to a merge but for one prisoner, catering for events like booking moves, new bookings, and reinstated bookings",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The relationships and restrictions were successfully replaced",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ResetPrisonerContactResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The request failed validation with invalid or missing data supplied",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('PERSONAL_RELATIONSHIPS_MIGRATION')")
+  fun resetPrisonerContacts(
+    @Valid @RequestBody request: ResetPrisonerContactRequest,
+  ) = syncFacade.resetPrisonerContacts(request)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -37,7 +37,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactPhoneDeta
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactSearchRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.EmploymentService
 import java.time.LocalDateTime
 import kotlin.jvm.optionals.getOrNull
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/EmploymentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/EmploymentService.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.Up
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.EmploymentDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.EmploymentRepository
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.OrganisationService
 import java.time.LocalDateTime
 
 @Service

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/MergePrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/MergePrisonerContactService.kt
@@ -5,11 +5,14 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactRestrictionEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.MergePrisonerContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.ResetPrisonerContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncPrisonerRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.ElementType
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.IdPair
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.MergePrisonerContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.PrisonerContactAndRestrictionIds
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.PrisonerRelationshipIds
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ResetPrisonerContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRestrictionRepository
 import java.time.LocalDateTime
@@ -20,7 +23,12 @@ class MergePrisonerContactService(
   val prisonerContactRepository: PrisonerContactRepository,
   val prisonerContactRestrictionRepository: PrisonerContactRestrictionRepository,
 ) {
-
+  /**
+   * MERGE - Called by the Syscon Sync Service when an offender merge happens in NOMIS.
+   * This removes the relationships and relationship restrictions for both old and new prisoner numbers,
+   * and then recreates the relationships and restrictions provided in the request for the
+   * retained prisoner number only.
+   */
   fun mergePrisonerContacts(request: MergePrisonerContactRequest): MergePrisonerContactResponse {
     // Get the list of relationships for both prisoner numbers
     val relationshipsForRemovedPrisoner = prisonerContactRepository.findAllByPrisonerNumber(request.removedPrisonerNumber)
@@ -35,7 +43,7 @@ class MergePrisonerContactService(
       prisonerContactRestrictionRepository.findAllByPrisonerContactId(relationship.prisonerContactId)
     }.flatten()
 
-    // Delete the restrictions
+    // Delete the relationship restrictions for both prisoners
     relationshipsForRemovedPrisoner.map { relationship ->
       prisonerContactRestrictionRepository.deleteAllByPrisonerContactId(relationship.prisonerContactId)
     }
@@ -43,13 +51,13 @@ class MergePrisonerContactService(
       prisonerContactRestrictionRepository.deleteAllByPrisonerContactId(relationship.prisonerContactId)
     }
 
-    // Delete the relationships for both prisoner numbers
+    // Delete the relationships for both prisoners
     prisonerContactRepository.deleteAllByPrisonerNumber(request.removedPrisonerNumber)
     prisonerContactRepository.deleteAllByPrisonerNumber(request.retainedPrisonerNumber)
 
     // Recreate the relationships and restrictions provided for the retained prisoner number only
-    val relationshipPairs = extractAndSavePrisonerContacts(request)
-    val restrictionPairs = extractAndSavePrisonerContactRestrictions(request, relationshipPairs)
+    val relationshipPairs = extractAndSavePrisonerContacts(request.prisonerContacts)
+    val restrictionPairs = extractAndSavePrisonerContactRestrictions(request.prisonerContacts, relationshipPairs)
 
     // Build the response objects for relationships and restrictions that were removed
     val relationshipsRemovedPrisoner = buildRelationshipsRemoved(relationshipsForRemovedPrisoner, restrictionsForRemovedPrisoner)
@@ -61,7 +69,47 @@ class MergePrisonerContactService(
     )
   }
 
-  fun buildRelationshipsRemoved(
+  /**
+   * RESET - Called by the Syscon Sync Service for 3 admin scenarios which can happen in NOMIS.
+   * 1. New booking - someone comes back into prison on a new booking.
+   * 2. Reactivate an old booking - bookings are re-instated over an existing booking.
+   * 3. Booking move - to correct misidentified people (i.e. the booking was created against the wrong name)
+   *
+   * For each of these scenarios the action is the same:
+   *  - Remove the relationships and restrictions for a prisoner
+   *  - Recreate the relationships and restrictions for this prisoner to match what is present in NOMIS
+   */
+  fun resetPrisonerContacts(request: ResetPrisonerContactRequest): ResetPrisonerContactResponse {
+    // Get the list of relationship entities for the prisoner
+    val relationshipsForPrisoner = prisonerContactRepository.findAllByPrisonerNumber(request.prisonerNumber)
+
+    // Get the list of prisoner contact restrictions for the prisoner
+    val restrictionsForPrisoner = relationshipsForPrisoner.map { relationship ->
+      prisonerContactRestrictionRepository.findAllByPrisonerContactId(relationship.prisonerContactId)
+    }.flatten()
+
+    // Delete the prisoner contact restrictions
+    relationshipsForPrisoner.map { relationship ->
+      prisonerContactRestrictionRepository.deleteAllByPrisonerContactId(relationship.prisonerContactId)
+    }
+
+    // Delete the prisoner contacts
+    prisonerContactRepository.deleteAllByPrisonerNumber(request.prisonerNumber)
+
+    // Recreate the relationships and restrictions provided for this prisoner
+    val relationshipPairs = extractAndSavePrisonerContacts(request.prisonerContacts)
+    val restrictionPairs = extractAndSavePrisonerContactRestrictions(request.prisonerContacts, relationshipPairs)
+
+    // Build a list of the IDs for relationships that were removed
+    val relationshipsRemoved = buildRelationshipsRemoved(relationshipsForPrisoner, restrictionsForPrisoner)
+
+    return ResetPrisonerContactResponse(
+      relationshipsCreated = buildContactsAndRestrictionsResponse(relationshipPairs, restrictionPairs),
+      relationshipsRemoved = relationshipsRemoved,
+    )
+  }
+
+  private fun buildRelationshipsRemoved(
     relationships: List<PrisonerContactEntity>,
     restrictions: List<PrisonerContactRestrictionEntity>,
   ): List<PrisonerRelationshipIds> = relationships.map { relationship ->
@@ -77,7 +125,7 @@ class MergePrisonerContactService(
     )
   }
 
-  fun buildContactsAndRestrictionsResponse(
+  private fun buildContactsAndRestrictionsResponse(
     relationships: List<Pair<Long, PrisonerContactEntity>>,
     restrictions: List<Pair<Long, List<Pair<Long, PrisonerContactRestrictionEntity>>>>,
   ) = relationships.map { relationship ->
@@ -93,7 +141,7 @@ class MergePrisonerContactService(
     }
   }.flatten()
 
-  fun extractAndSavePrisonerContacts(req: MergePrisonerContactRequest) = req.prisonerContacts.map { relationship ->
+  private fun extractAndSavePrisonerContacts(prisonerContacts: List<SyncPrisonerRelationship>) = prisonerContacts.map { relationship ->
     Pair(
       relationship.id,
       prisonerContactRepository.save(
@@ -109,7 +157,7 @@ class MergePrisonerContactService(
           active = relationship.active,
           approvedVisitor = relationship.approvedVisitor,
           currentTerm = relationship.currentTerm,
-          createdBy = relationship.createUsername ?: "MERGE",
+          createdBy = relationship.createUsername ?: "SYSTEM",
           createdTime = relationship.createDateTime ?: LocalDateTime.now(),
         ).also {
           it.updatedBy = relationship.modifyUsername
@@ -120,10 +168,10 @@ class MergePrisonerContactService(
     )
   }
 
-  fun extractAndSavePrisonerContactRestrictions(
-    req: MergePrisonerContactRequest,
+  private fun extractAndSavePrisonerContactRestrictions(
+    prisonerContacts: List<SyncPrisonerRelationship>,
     prisonerContactPairs: List<Pair<Long, PrisonerContactEntity>>,
-  ) = req.prisonerContacts.map { relationship ->
+  ) = prisonerContacts.map { relationship ->
     // We need to know the saved prisonerContactId for each of the relationship
     val thisRelationship = prisonerContactPairs.find { it.first == relationship.id }
 
@@ -140,7 +188,7 @@ class MergePrisonerContactService(
               startDate = restriction.startDate,
               expiryDate = restriction.expiryDate,
               comments = restriction.comment,
-              createdBy = restriction.createUsername ?: "MERGE",
+              createdBy = restriction.createUsername ?: "SYSTEM",
               createdTime = restriction.createDateTime ?: LocalDateTime.now(),
               updatedBy = restriction.modifyUsername,
               updatedTime = restriction.modifyDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncAdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncAdminService.kt
@@ -19,7 +19,7 @@ import java.time.LocalDateTime
 
 @Service
 @Transactional
-class MergePrisonerContactService(
+class SyncAdminService(
   val prisonerContactRepository: PrisonerContactRepository,
   val prisonerContactRestrictionRepository: PrisonerContactRestrictionRepository,
 ) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/EmploymentFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/EmploymentFacadeTest.kt
@@ -11,10 +11,10 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.internal.PatchEmploym
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.CreateEmploymentRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.PatchEmploymentsRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.UpdateEmploymentRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.EmploymentService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.EmploymentService
 
 class EmploymentFacadeTest {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
@@ -42,7 +42,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPri
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.MergePrisonerContactService
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncAdminService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactAddressPhoneService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactAddressService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactEmailService
@@ -67,7 +67,7 @@ class SyncFacadeTest {
   private val syncPrisonerContactService: SyncPrisonerContactService = mock()
   private val syncPrisonerContactRestrictionService: SyncPrisonerContactRestrictionService = mock()
   private val syncEmploymentService: SyncEmploymentService = mock()
-  private val mergePrisonerContactService: MergePrisonerContactService = mock()
+  private val syncAdminService: SyncAdminService = mock()
   private val outboundEventsService: OutboundEventsService = mock()
 
   private val facade = SyncFacade(
@@ -81,7 +81,7 @@ class SyncFacadeTest {
     syncPrisonerContactService,
     syncPrisonerContactRestrictionService,
     syncEmploymentService,
-    mergePrisonerContactService,
+    syncAdminService,
     outboundEventsService,
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncAdminIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncAdminIntegrationTest.kt
@@ -23,10 +23,10 @@ import java.time.LocalDate
 
 @Sql("classpath:merge.tests/data-for-merge-test.sql")
 @Sql(scripts = ["classpath:merge.tests/cleanup-merge-test.sql"], executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-class MergePrisonerContactsIntegrationTest : PostgresIntegrationTestBase() {
+class SyncAdminIntegrationTest : PostgresIntegrationTestBase() {
 
   @Nested
-  inner class MergePrisonerContactTests {
+  inner class SyncAdminTests {
 
     @BeforeEach
     fun resetEvents() {
@@ -36,7 +36,7 @@ class MergePrisonerContactsIntegrationTest : PostgresIntegrationTestBase() {
     @Test
     fun `Merge endpoint should return unauthorized if no token provided`() {
       webTestClient.post()
-        .uri("/sync/prisoner-contact/merge")
+        .uri("/sync/admin/merge")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(createMergeRequest(retained = "A3333AA", removed = "A4444AA"))
@@ -48,7 +48,7 @@ class MergePrisonerContactsIntegrationTest : PostgresIntegrationTestBase() {
     @Test
     fun `Merge endpoint should return forbidden without an authorised role on the token`() {
       webTestClient.post()
-        .uri("/sync/prisoner-contact/merge")
+        .uri("/sync/admin/merge")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(createMergeRequest(retained = "A3333AA", removed = "A4444AA"))
@@ -61,7 +61,7 @@ class MergePrisonerContactsIntegrationTest : PostgresIntegrationTestBase() {
     @Test
     fun `should remove the prisoner contacts and restrictions with nothing to recreate - empty list provided`() {
       val mergeResponse = webTestClient.post()
-        .uri("/sync/prisoner-contact/merge")
+        .uri("/sync/admin/merge")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
@@ -85,7 +85,7 @@ class MergePrisonerContactsIntegrationTest : PostgresIntegrationTestBase() {
     @Test
     fun `should remove the prisoner contacts and restrictions then recreate for the retained prisoner`() {
       val mergeResponse = webTestClient.post()
-        .uri("/sync/prisoner-contact/merge")
+        .uri("/sync/admin/merge")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -62,7 +62,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactPhoneDeta
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactSearchRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.EmploymentService
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/EmploymentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/EmploymentServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
@@ -21,7 +21,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.Pa
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.UpdateEmploymentRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.EmploymentRepository
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.OrganisationService
 import java.time.LocalDateTime.now
 import java.util.*
 


### PR DESCRIPTION
This PR:
* Implements the 2 sync admin endpoints for MERGE and RESET
* Refactors merge so that it shares many features with the RESET operation.
* Renames the sync admin controller, service and tests to group them as SyncAdminService/Controller/Test
* Refactors the swagger tags to tidy and clarify descriptions.
* Moves the EmploymentService into the services package (it was in the services/sync package)

No tests for RESET as yet - early version so Syscon can generate their API types and see the request/response formats.
I will follow this with an integration test for reset. 