### PR TITLE
PRC-577: Contact search sort fixes & improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortProperties.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping
+
+import jakarta.validation.ValidationException
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactWithAddressEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+
+/*
+ * This ensures search works as expected for clients of the API when there might be a difference in property names
+ * on API types to the database entity mappings. There is a matching test that ensures everything on the API is mappable.
+ */
+fun mapSortPropertiesOfContactSearch(property: String): String = when (property) {
+  ContactSearchResultItem::id.name -> ContactWithAddressEntity::contactId.name
+  ContactSearchResultItem::lastName.name -> ContactWithAddressEntity::lastName.name
+  ContactSearchResultItem::firstName.name -> ContactWithAddressEntity::firstName.name
+  ContactSearchResultItem::middleNames.name -> ContactWithAddressEntity::middleNames.name
+  ContactSearchResultItem::dateOfBirth.name -> ContactWithAddressEntity::dateOfBirth.name
+  ContactSearchResultItem::createdBy.name -> ContactWithAddressEntity::createdBy.name
+  ContactSearchResultItem::createdTime.name -> ContactWithAddressEntity::createdTime.name
+  ContactSearchResultItem::flat.name -> ContactWithAddressEntity::flat.name
+  ContactSearchResultItem::property.name -> ContactWithAddressEntity::property.name
+  ContactSearchResultItem::street.name -> ContactWithAddressEntity::street.name
+  ContactSearchResultItem::area.name -> ContactWithAddressEntity::area.name
+  ContactSearchResultItem::cityCode.name -> ContactWithAddressEntity::cityCode.name
+  ContactSearchResultItem::cityDescription.name -> ContactWithAddressEntity::cityDescription.name
+  ContactSearchResultItem::countyCode.name -> ContactWithAddressEntity::countyCode.name
+  ContactSearchResultItem::countyDescription.name -> ContactWithAddressEntity::countyDescription.name
+  ContactSearchResultItem::postcode.name -> ContactWithAddressEntity::postCode.name
+  ContactSearchResultItem::countryCode.name -> ContactWithAddressEntity::countryCode.name
+  ContactSearchResultItem::countryDescription.name -> ContactWithAddressEntity::countryDescription.name
+  ContactSearchResultItem::mailAddress.name -> ContactWithAddressEntity::mailFlag.name
+  ContactSearchResultItem::startDate.name -> ContactWithAddressEntity::startDate.name
+  ContactSearchResultItem::endDate.name -> ContactWithAddressEntity::endDate.name
+  ContactSearchResultItem::noFixedAddress.name -> ContactWithAddressEntity::noFixedAddress.name
+  ContactSearchResultItem::comments.name -> ContactWithAddressEntity::comments.name
+  else -> throw ValidationException("Unable to sort on $property")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -11,8 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort.Direction
-import org.springframework.data.web.PageableDefault
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -201,7 +199,6 @@ class ContactController(
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
   fun searchContacts(
     @Parameter(description = "Pageable configurations", required = false)
-    @PageableDefault(sort = ["lastName", "firstName", "middleNames", "createdTime"], direction = Direction.ASC)
     pageable: Pageable,
     @ModelAttribute @Valid @Parameter(description = "Contact search criteria", required = true) request: ContactSearchRequest,
   ) = contactFacade.searchContacts(pageable, request)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortPropertiesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortPropertiesTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping
+
+import jakarta.validation.ValidationException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactWithAddressEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+import kotlin.reflect.full.memberProperties
+
+class MapSortPropertiesTest {
+
+  @Test
+  fun `can map contact search result item fields to contact with address entity fields`() {
+    ContactSearchResultItem::class.memberProperties.forEach { property ->
+      val mapped = mapSortPropertiesOfContactSearch(property.name)
+      assertThat(mapped).isNotNull()
+      assertThat(ContactWithAddressEntity::class.memberProperties.find { it.name == mapped }).isNotNull()
+    }
+  }
+
+  @Test
+  fun `attempting to sort on an invalid field gives an error`() {
+    val expected = assertThrows<ValidationException> {
+      mapSortPropertiesOfContactSearch("foo")
+    }
+    assertThat(expected.message).isEqualTo("Unable to sort on foo")
+  }
+}


### PR DESCRIPTION
Made date of birth sort with nulls as if they are the eldest so nulls first/last depending on asc/desc.

Fixed issue where if there are multiple fields being sorted on it was only the last applied.

Removed default sort which was undocumented and might provide unexpected results.

Properly map all fields from API to db type. This is to make things like sorting on id work where the field in the API is called `id` but in the database entity it's called `contactId` so a user would sort on `id` as that's what's in the API but it wouldn't work and failed silently.