### PR TITLE
PRC-578: Expand filtering and sorting for prisoner contact list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortProperties.kt
@@ -2,12 +2,16 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping
 
 import jakarta.validation.ValidationException
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactWithAddressEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSummaryEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 
-/*
- * This ensures search works as expected for clients of the API when there might be a difference in property names
- * on API types to the database entity mappings. There is a matching test that ensures everything on the API is mappable.
+/**
+ * These methods ensure search works as expected for clients of the API when there might be a difference in property names
+ * on API types to the database entity mappings. There is a matching test that ensures everything on the relevant APIs
+ * are mappable.
  */
+
 fun mapSortPropertiesOfContactSearch(property: String): String = when (property) {
   ContactSearchResultItem::id.name -> ContactWithAddressEntity::contactId.name
   ContactSearchResultItem::lastName.name -> ContactWithAddressEntity::lastName.name
@@ -32,5 +36,43 @@ fun mapSortPropertiesOfContactSearch(property: String): String = when (property)
   ContactSearchResultItem::endDate.name -> ContactWithAddressEntity::endDate.name
   ContactSearchResultItem::noFixedAddress.name -> ContactWithAddressEntity::noFixedAddress.name
   ContactSearchResultItem::comments.name -> ContactWithAddressEntity::comments.name
+  else -> throw ValidationException("Unable to sort on $property")
+}
+
+fun mapSortPropertiesOfPrisonerContactSearch(property: String): String = when (property) {
+  PrisonerContactSummary::prisonerContactId.name -> PrisonerContactSummaryEntity::prisonerContactId.name
+  PrisonerContactSummary::contactId.name -> PrisonerContactSummaryEntity::contactId.name
+  PrisonerContactSummary::prisonerNumber.name -> PrisonerContactSummaryEntity::prisonerNumber.name
+  PrisonerContactSummary::lastName.name -> PrisonerContactSummaryEntity::lastName.name
+  PrisonerContactSummary::firstName.name -> PrisonerContactSummaryEntity::firstName.name
+  PrisonerContactSummary::middleNames.name -> PrisonerContactSummaryEntity::middleNames.name
+  PrisonerContactSummary::dateOfBirth.name -> PrisonerContactSummaryEntity::dateOfBirth.name
+  PrisonerContactSummary::relationshipTypeCode.name -> PrisonerContactSummaryEntity::relationshipType.name
+  PrisonerContactSummary::relationshipTypeDescription.name -> PrisonerContactSummaryEntity::relationshipTypeDescription.name
+  PrisonerContactSummary::relationshipToPrisonerCode.name -> PrisonerContactSummaryEntity::relationshipToPrisoner.name
+  PrisonerContactSummary::relationshipToPrisonerDescription.name -> PrisonerContactSummaryEntity::relationshipToPrisonerDescription.name
+  PrisonerContactSummary::flat.name -> PrisonerContactSummaryEntity::flat.name
+  PrisonerContactSummary::property.name -> PrisonerContactSummaryEntity::property.name
+  PrisonerContactSummary::street.name -> PrisonerContactSummaryEntity::street.name
+  PrisonerContactSummary::area.name -> PrisonerContactSummaryEntity::area.name
+  PrisonerContactSummary::cityCode.name -> PrisonerContactSummaryEntity::cityCode.name
+  PrisonerContactSummary::cityDescription.name -> PrisonerContactSummaryEntity::cityDescription.name
+  PrisonerContactSummary::countyCode.name -> PrisonerContactSummaryEntity::countyCode.name
+  PrisonerContactSummary::countyDescription.name -> PrisonerContactSummaryEntity::countyDescription.name
+  PrisonerContactSummary::postcode.name -> PrisonerContactSummaryEntity::postCode.name
+  PrisonerContactSummary::countryCode.name -> PrisonerContactSummaryEntity::countryCode.name
+  PrisonerContactSummary::countryDescription.name -> PrisonerContactSummaryEntity::countryDescription.name
+  PrisonerContactSummary::primaryAddress.name -> PrisonerContactSummaryEntity::primaryAddress.name
+  PrisonerContactSummary::mailAddress.name -> PrisonerContactSummaryEntity::mailFlag.name
+  PrisonerContactSummary::phoneType.name -> PrisonerContactSummaryEntity::phoneType.name
+  PrisonerContactSummary::phoneTypeDescription.name -> PrisonerContactSummaryEntity::phoneTypeDescription.name
+  PrisonerContactSummary::phoneNumber.name -> PrisonerContactSummaryEntity::phoneNumber.name
+  PrisonerContactSummary::extNumber.name -> PrisonerContactSummaryEntity::extNumber.name
+  PrisonerContactSummary::isApprovedVisitor.name -> PrisonerContactSummaryEntity::approvedVisitor.name
+  PrisonerContactSummary::isNextOfKin.name -> PrisonerContactSummaryEntity::nextOfKin.name
+  PrisonerContactSummary::isEmergencyContact.name -> PrisonerContactSummaryEntity::emergencyContact.name
+  PrisonerContactSummary::isRelationshipActive.name -> PrisonerContactSummaryEntity::active.name
+  PrisonerContactSummary::currentTerm.name -> PrisonerContactSummaryEntity::currentTerm.name
+  PrisonerContactSummary::comments.name -> PrisonerContactSummaryEntity::comments.name
   else -> throw ValidationException("Unable to sort on $property")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/internal/PrisonerContactSearchParams.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/internal/PrisonerContactSearchParams.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.internal
+
+import org.springframework.data.domain.Pageable
+
+data class PrisonerContactSearchParams(
+  val prisonerNumber: String,
+  val active: Boolean?,
+  val relationshipType: String?,
+  val emergencyContact: Boolean?,
+  val nextOfKin: Boolean?,
+  val emergencyContactOrNextOfKin: Boolean?,
+  val pageable: Pageable,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSearchRepository.kt
@@ -1,0 +1,127 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Order
+import jakarta.persistence.criteria.Predicate
+import jakarta.persistence.criteria.Root
+import org.hibernate.query.NullPrecedence
+import org.hibernate.query.criteria.JpaOrder
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSummaryEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.mapSortPropertiesOfPrisonerContactSearch
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.internal.PrisonerContactSearchParams
+
+@Repository
+class PrisonerContactSearchRepository(
+  @PersistenceContext
+  private var entityManager: EntityManager,
+) {
+
+  fun searchPrisonerContacts(params: PrisonerContactSearchParams): Page<PrisonerContactSummaryEntity> {
+    val cb = entityManager.criteriaBuilder
+    val cq = cb.createQuery(PrisonerContactSummaryEntity::class.java)
+    val contact = cq.from(PrisonerContactSummaryEntity::class.java)
+
+    val predicates: List<Predicate> = buildPredicates(params, cb, contact)
+    val pageable = params.pageable
+
+    cq.where(*predicates.toTypedArray())
+
+    applySorting(pageable, cq, cb, contact)
+
+    val resultList = entityManager.createQuery(cq)
+      .setFirstResult(pageable.offset.toInt())
+      .setMaxResults(pageable.pageSize)
+      .resultList
+
+    val total = getTotalCount(params)
+
+    return PageImpl(resultList, pageable, total)
+  }
+
+  private fun getTotalCount(
+    request: PrisonerContactSearchParams,
+  ): Long {
+    val cb = entityManager.criteriaBuilder
+    val countQuery = cb.createQuery(Long::class.java)
+    val contact = countQuery.from(PrisonerContactSummaryEntity::class.java)
+
+    val predicates: List<Predicate> = buildPredicates(request, cb, contact)
+
+    countQuery.select(cb.count(contact)).where(*predicates.toTypedArray<Predicate>())
+    return entityManager.createQuery(countQuery).singleResult
+  }
+
+  private fun applySorting(
+    pageable: Pageable,
+    cq: CriteriaQuery<PrisonerContactSummaryEntity>,
+    cb: CriteriaBuilder,
+    contact: Root<PrisonerContactSummaryEntity>,
+  ) {
+    if (pageable.sort.isSorted) {
+      val order = pageable.sort.map {
+        val property = mapSortPropertiesOfPrisonerContactSearch(it.property)
+        var order: Order = if (it.isAscending) {
+          cb.asc(contact.get<String>(property))
+        } else {
+          cb.desc(contact.get<String>(property))
+        }
+        // order date of birth with nulls as if they are the eldest.
+        if (property == PrisonerContactSummaryEntity::dateOfBirth.name && order is JpaOrder) {
+          order = if (it.isAscending) {
+            order.nullPrecedence(NullPrecedence.FIRST)
+          } else {
+            order.nullPrecedence(NullPrecedence.LAST)
+          }
+        }
+        order
+      }.toList()
+      cq.orderBy(order)
+    }
+  }
+
+  private fun buildPredicates(
+    params: PrisonerContactSearchParams,
+    cb: CriteriaBuilder,
+    contact: Root<PrisonerContactSummaryEntity>,
+  ): MutableList<Predicate> {
+    val predicates: MutableList<Predicate> = ArrayList()
+    predicates.add(cb.equal(contact.get<String>(PrisonerContactSummaryEntity::prisonerNumber.name), params.prisonerNumber))
+    if (params.active != null) {
+      predicates.add(cb.equal(contact.get<Boolean>(PrisonerContactSummaryEntity::active.name), params.active))
+    }
+    if (params.emergencyContact != null) {
+      predicates.add(cb.equal(contact.get<Boolean>(PrisonerContactSummaryEntity::emergencyContact.name), params.emergencyContact))
+    }
+    if (params.nextOfKin != null) {
+      predicates.add(cb.equal(contact.get<Boolean>(PrisonerContactSummaryEntity::nextOfKin.name), params.nextOfKin))
+    }
+    if (params.emergencyContactOrNextOfKin != null) {
+      if (params.emergencyContactOrNextOfKin) {
+        predicates.add(
+          cb.or(
+            cb.equal(contact.get<Boolean>(PrisonerContactSummaryEntity::emergencyContact.name), true),
+            cb.equal(contact.get<Boolean>(PrisonerContactSummaryEntity::nextOfKin.name), true),
+          ),
+        )
+      } else {
+        predicates.add(
+          cb.and(
+            cb.equal(contact.get<Boolean>(PrisonerContactSummaryEntity::emergencyContact.name), false),
+            cb.equal(contact.get<Boolean>(PrisonerContactSummaryEntity::nextOfKin.name), false),
+          ),
+        )
+      }
+    }
+    params.relationshipType?.let {
+      predicates.add(cb.equal(contact.get<String>(PrisonerContactSummaryEntity::relationshipType.name), params.relationshipType))
+    }
+    return predicates
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSummaryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSummaryRepository.kt
@@ -1,12 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSummaryEntity
 
 @Repository
 interface PrisonerContactSummaryRepository : ReadOnlyRepository<PrisonerContactSummaryEntity, Long> {
-  fun findByPrisonerNumberAndActive(prisonerNumber: String, active: Boolean, pageable: Pageable): Page<PrisonerContactSummaryEntity>
   fun findByContactId(contactId: Long): List<PrisonerContactSummaryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactService.kt
@@ -2,20 +2,20 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.internal.PrisonerContactSearchParams
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactSummaryRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactSearchRepository
 
 @Service
 class PrisonerContactService(
-  private val prisonerContactSummaryRepository: PrisonerContactSummaryRepository,
+  private val prisonerContactSearchRepository: PrisonerContactSearchRepository,
   private val prisonerService: PrisonerService,
 ) {
-  fun getAllContacts(prisonerNumber: String, active: Boolean, pageable: Pageable): Page<PrisonerContactSummary> {
-    prisonerService.getPrisoner(prisonerNumber)
-      ?: throw EntityNotFoundException("Prisoner number $prisonerNumber - not found")
-    return prisonerContactSummaryRepository.findByPrisonerNumberAndActive(prisonerNumber, active, pageable).map { it.toModel() }
+  fun getAllContacts(params: PrisonerContactSearchParams): Page<PrisonerContactSummary> {
+    prisonerService.getPrisoner(params.prisonerNumber)
+      ?: throw EntityNotFoundException("Prisoner number ${params.prisonerNumber} - not found")
+    return prisonerContactSearchRepository.searchPrisonerContacts(params).map { it.toModel() }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
@@ -1,14 +1,21 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
+import org.apache.commons.lang3.RandomStringUtils
+import org.apache.commons.lang3.RandomUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.openapitools.jackson.nullable.JsonNullable
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper.TestAPIClient.PrisonerContactSummaryResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchRelationshipRequest
+import java.time.LocalDate
 
 class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
@@ -54,15 +61,7 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   fun `should return OK`() {
     stubPrisonSearchWithResponse("A4385DZ")
 
-    val contacts = webTestClient.get()
-      .uri(GET_PRISONER_CONTACT)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(PrisonerContactSummaryResponse::class.java)
-      .returnResult().responseBody!!
+    val contacts = getForUrl(GET_PRISONER_CONTACT)
 
     assertThat(contacts.content).hasSize(3)
 
@@ -89,15 +88,7 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   fun `should return phone numbers with latest first`() {
     stubPrisonSearchWithResponse("A1234BB")
 
-    val contacts = webTestClient.get()
-      .uri("/prisoner/A1234BB/contact")
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(PrisonerContactSummaryResponse::class.java)
-      .returnResult().responseBody!!
+    val contacts = getForUrl("/prisoner/A1234BB/contact")
 
     assertThat(contacts.content).hasSize(1)
 
@@ -131,15 +122,7 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(firstPage.content[0].contactId).isEqualTo(1)
     assertThat(firstPage.content[1].contactId).isEqualTo(10)
 
-    val contacts = webTestClient.get()
-      .uri("$GET_PRISONER_CONTACT?size=2&page=1&sort=contactId")
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(PrisonerContactSummaryResponse::class.java)
-      .returnResult().responseBody!!
+    val contacts = getForUrl("$GET_PRISONER_CONTACT?size=2&page=1&sort=contactId")
 
     assertThat(contacts.content).hasSize(1)
     assertThat(contacts.totalPages).isEqualTo(2)
@@ -153,15 +136,7 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   fun `should return sorted correctly`() {
     stubPrisonSearchWithResponse("A4385DZ")
 
-    val firstPage = webTestClient.get()
-      .uri("$GET_PRISONER_CONTACT?sort=lastName")
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(PrisonerContactSummaryResponse::class.java)
-      .returnResult().responseBody!!
+    val firstPage = getForUrl("$GET_PRISONER_CONTACT?sort=lastName")
 
     assertThat(firstPage.content).hasSize(3)
     assertThat(firstPage.totalPages).isEqualTo(1)
@@ -171,5 +146,416 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(firstPage.content[0].lastName).isEqualTo("Address")
     assertThat(firstPage.content[1].lastName).isEqualTo("Last")
     assertThat(firstPage.content[2].lastName).isEqualTo("Ten")
+  }
+
+  @Test
+  fun `should return with active or inactive correctly`() {
+    val prisonerNumber = "Z1234ZZ"
+    stubPrisonSearchWithResponse(prisonerNumber)
+    testAPIClient.createAContactWithARelationship(
+      CreateContactRequest(
+        lastName = "Active",
+        firstName = "Contact",
+        relationship = ContactRelationship(
+          prisonerNumber = prisonerNumber,
+          relationshipTypeCode = "S",
+          relationshipToPrisonerCode = "MOT",
+          isNextOfKin = false,
+          isEmergencyContact = false,
+          isApprovedVisitor = false,
+        ),
+        createdBy = "USER1",
+      ),
+    )
+    val prisonerContactIdToDeactivate = testAPIClient.createAContactWithARelationship(
+      CreateContactRequest(
+        lastName = "Inactive",
+        firstName = "Contact",
+        relationship = ContactRelationship(
+          prisonerNumber = prisonerNumber,
+          relationshipTypeCode = "S",
+          relationshipToPrisonerCode = "MOT",
+          isNextOfKin = false,
+          isEmergencyContact = false,
+          isApprovedVisitor = false,
+        ),
+        createdBy = "USER1",
+      ),
+    ).createdRelationship!!.prisonerContactId
+    testAPIClient.updateRelationship(
+      prisonerContactIdToDeactivate,
+      PatchRelationshipRequest(isRelationshipActive = JsonNullable.of(false), updatedBy = "USER1"),
+    )
+
+    val withActiveOnly = getForUrl("/prisoner/$prisonerNumber/contact?active=true")
+    assertThat(withActiveOnly.content).hasSize(1)
+    assertThat(withActiveOnly.content.first().lastName).isEqualTo("Active")
+
+    val withInactiveOnly = getForUrl("/prisoner/$prisonerNumber/contact?active=false")
+    assertThat(withInactiveOnly.content).hasSize(1)
+    assertThat(withInactiveOnly.content.first().lastName).isEqualTo("Inactive")
+
+    val defaultToAllStates = getForUrl("/prisoner/$prisonerNumber/contact?sort=lastName")
+    assertThat(defaultToAllStates.content).hasSize(2)
+    assertThat(defaultToAllStates.content.first().lastName).isEqualTo("Active")
+    assertThat(defaultToAllStates.content.last().lastName).isEqualTo("Inactive")
+  }
+
+  @Test
+  fun `should return with relationship type filtered correctly`() {
+    val prisonerNumber = "Z4567ZZ"
+    stubPrisonSearchWithResponse(prisonerNumber)
+    testAPIClient.createAContactWithARelationship(
+      CreateContactRequest(
+        lastName = "Social",
+        firstName = "Contact",
+        relationship = ContactRelationship(
+          prisonerNumber = prisonerNumber,
+          relationshipTypeCode = "S",
+          relationshipToPrisonerCode = "MOT",
+          isNextOfKin = false,
+          isEmergencyContact = false,
+          isApprovedVisitor = false,
+        ),
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContactWithARelationship(
+      CreateContactRequest(
+        lastName = "Official",
+        firstName = "Contact",
+        relationship = ContactRelationship(
+          prisonerNumber = prisonerNumber,
+          relationshipTypeCode = "O",
+          relationshipToPrisonerCode = "DR",
+          isNextOfKin = false,
+          isEmergencyContact = false,
+          isApprovedVisitor = false,
+        ),
+        createdBy = "USER1",
+      ),
+    )
+
+    val withNoTypeSpecified = getForUrl("/prisoner/$prisonerNumber/contact?sort=lastName")
+    assertThat(withNoTypeSpecified.content).hasSize(2)
+    assertThat(withNoTypeSpecified.content.first().lastName).isEqualTo("Official")
+    assertThat(withNoTypeSpecified.content.last().lastName).isEqualTo("Social")
+
+    val onlySocial = getForUrl("/prisoner/$prisonerNumber/contact?relationshipType=S&sort=lastName")
+    assertThat(onlySocial.content).hasSize(1)
+    assertThat(onlySocial.content.first().lastName).isEqualTo("Social")
+
+    val onlyOfficial = getForUrl("/prisoner/$prisonerNumber/contact?relationshipType=O&sort=lastName")
+    assertThat(onlyOfficial.content).hasSize(1)
+    assertThat(onlyOfficial.content.first().lastName).isEqualTo("Official")
+  }
+
+  @Test
+  fun `should return with emergency contact and next of kin filtered correctly`() {
+    val prisonerNumber = "X4567XX"
+    stubPrisonSearchWithResponse(prisonerNumber)
+    testAPIClient.createAContactWithARelationship(
+      CreateContactRequest(
+        lastName = "NOK Only",
+        firstName = "Contact",
+        relationship = ContactRelationship(
+          prisonerNumber = prisonerNumber,
+          relationshipTypeCode = "S",
+          relationshipToPrisonerCode = "MOT",
+          isNextOfKin = true,
+          isEmergencyContact = false,
+          isApprovedVisitor = false,
+        ),
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContactWithARelationship(
+      CreateContactRequest(
+        lastName = "EC Only",
+        firstName = "Contact",
+        relationship = ContactRelationship(
+          prisonerNumber = prisonerNumber,
+          relationshipTypeCode = "S",
+          relationshipToPrisonerCode = "FRI",
+          isNextOfKin = false,
+          isEmergencyContact = true,
+          isApprovedVisitor = false,
+        ),
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContactWithARelationship(
+      CreateContactRequest(
+        lastName = "NOK And EC",
+        firstName = "Contact",
+        relationship = ContactRelationship(
+          prisonerNumber = prisonerNumber,
+          relationshipTypeCode = "S",
+          relationshipToPrisonerCode = "FRI",
+          isNextOfKin = true,
+          isEmergencyContact = true,
+          isApprovedVisitor = false,
+        ),
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContactWithARelationship(
+      CreateContactRequest(
+        lastName = "Neither",
+        firstName = "Contact",
+        relationship = ContactRelationship(
+          prisonerNumber = prisonerNumber,
+          relationshipTypeCode = "S",
+          relationshipToPrisonerCode = "FRI",
+          isNextOfKin = false,
+          isEmergencyContact = false,
+          isApprovedVisitor = false,
+        ),
+        createdBy = "USER1",
+      ),
+    )
+
+    val withNoTypeSpecified = getForUrl("/prisoner/$prisonerNumber/contact")
+    assertThat(withNoTypeSpecified.content).hasSize(4)
+    assertThat(withNoTypeSpecified.content).extracting("lastName").containsExactlyInAnyOrder("NOK Only", "EC Only", "NOK And EC", "Neither")
+
+    val nextOfKin = getForUrl("/prisoner/$prisonerNumber/contact?nextOfKin=true")
+    assertThat(nextOfKin.content).hasSize(2)
+
+    assertThat(nextOfKin.content).extracting("lastName").containsExactlyInAnyOrder("NOK Only", "NOK And EC")
+    val notNextOfKin = getForUrl("/prisoner/$prisonerNumber/contact?nextOfKin=false")
+    assertThat(notNextOfKin.content).hasSize(2)
+    assertThat(notNextOfKin.content).extracting("lastName").containsExactlyInAnyOrder("EC Only", "Neither")
+
+    val emergencyContacts = getForUrl("/prisoner/$prisonerNumber/contact?emergencyContact=true")
+    assertThat(emergencyContacts.content).hasSize(2)
+    assertThat(emergencyContacts.content).extracting("lastName").containsExactlyInAnyOrder("EC Only", "NOK And EC")
+
+    val notEmergencyContacts = getForUrl("/prisoner/$prisonerNumber/contact?emergencyContact=false")
+    assertThat(notEmergencyContacts.content).hasSize(2)
+    assertThat(notEmergencyContacts.content).extracting("lastName").containsExactlyInAnyOrder("NOK Only", "Neither")
+
+    val emergencyContactOrNextOfKin = getForUrl("/prisoner/$prisonerNumber/contact?emergencyContactOrNextOfKin=true")
+    assertThat(emergencyContactOrNextOfKin.content).hasSize(3)
+    assertThat(emergencyContactOrNextOfKin.content).extracting("lastName").containsExactlyInAnyOrder("EC Only", "NOK Only", "NOK And EC")
+
+    val neitherEmergencyContactOrNextOfKin = getForUrl("/prisoner/$prisonerNumber/contact?emergencyContactOrNextOfKin=false")
+    assertThat(neitherEmergencyContactOrNextOfKin.content).hasSize(1)
+    assertThat(neitherEmergencyContactOrNextOfKin.content).extracting("lastName").containsExactlyInAnyOrder("Neither")
+
+    val emergencyContactAndNextOfKin = getForUrl("/prisoner/$prisonerNumber/contact?emergencyContact=true&nextOfKin=true")
+    assertThat(emergencyContactAndNextOfKin.content).hasSize(1)
+    assertThat(emergencyContactAndNextOfKin.content).extracting("lastName").containsExactlyInAnyOrder("NOK And EC")
+
+    val notEmergencyContactAndNextOfKin = getForUrl("/prisoner/$prisonerNumber/contact?emergencyContact=false&nextOfKin=false")
+    assertThat(notEmergencyContactAndNextOfKin.content).hasSize(1)
+    assertThat(notEmergencyContactAndNextOfKin.content).extracting("lastName").containsExactlyInAnyOrder("Neither")
+
+    val emergencyContactAndNotNextOfKin = getForUrl("/prisoner/$prisonerNumber/contact?emergencyContact=true&nextOfKin=false")
+    assertThat(emergencyContactAndNotNextOfKin.content).hasSize(1)
+    assertThat(emergencyContactAndNotNextOfKin.content).extracting("lastName").containsExactlyInAnyOrder("EC Only")
+
+    val nextOfKinAndNotEmergencyContact = getForUrl("/prisoner/$prisonerNumber/contact?emergencyContact=false&nextOfKin=true")
+    assertThat(nextOfKinAndNotEmergencyContact.content).hasSize(1)
+    assertThat(nextOfKinAndNotEmergencyContact.content).extracting("lastName").containsExactlyInAnyOrder("NOK Only")
+  }
+
+  @Test
+  fun `should sort by date of birth with nulls as eldest`() {
+    val prisonerNumber = "Z5678ZZ"
+    stubPrisonSearchWithResponse(prisonerNumber)
+    val relationship = ContactRelationship(
+      prisonerNumber = prisonerNumber,
+      relationshipTypeCode = "S",
+      relationshipToPrisonerCode = "FRI",
+      isNextOfKin = false,
+      isEmergencyContact = false,
+      isApprovedVisitor = false,
+    )
+    val randomLastName = RandomStringUtils.secure().nextAlphabetic(35)
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = randomLastName,
+        firstName = "Youngest",
+        dateOfBirth = LocalDate.of(2025, 1, 1),
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = randomLastName,
+        firstName = "Eldest",
+        dateOfBirth = LocalDate.of(1990, 1, 1),
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = randomLastName,
+        firstName = "None",
+        dateOfBirth = null,
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    )
+
+    val resultsEldestFirst = getForUrl("/prisoner/$prisonerNumber/contact?sort=dateOfBirth,asc")
+    assertThat(resultsEldestFirst.content).extracting("firstName").isEqualTo(
+      listOf("None", "Eldest", "Youngest"),
+    )
+
+    val resultsYoungestFirst = getForUrl("/prisoner/$prisonerNumber/contact?sort=dateOfBirth,desc")
+    assertThat(resultsYoungestFirst.content).extracting("firstName").isEqualTo(
+      listOf("Youngest", "Eldest", "None"),
+    )
+  }
+
+  @Test
+  fun `should sort by names is specified order`() {
+    val prisonerNumber = "Z6789ZZ"
+    stubPrisonSearchWithResponse(prisonerNumber)
+    val relationship = ContactRelationship(
+      prisonerNumber = prisonerNumber,
+      relationshipTypeCode = "S",
+      relationshipToPrisonerCode = "FRI",
+      isNextOfKin = false,
+      isEmergencyContact = false,
+      isApprovedVisitor = false,
+    )
+
+    val randomDob = LocalDate.now().minusDays(RandomUtils.secure().randomLong(100, 2000))
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "AA",
+        firstName = "B",
+        middleNames = "C",
+        dateOfBirth = randomDob,
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "AA",
+        firstName = "B",
+        dateOfBirth = randomDob,
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "AB",
+        firstName = "A",
+        dateOfBirth = randomDob,
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "AB",
+        firstName = "B",
+        dateOfBirth = randomDob,
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "AC",
+        firstName = "C",
+        middleNames = "A",
+        dateOfBirth = randomDob,
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "AC",
+        firstName = "C",
+        middleNames = "B",
+        dateOfBirth = randomDob,
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    )
+
+    val expectedOrder = listOf(
+      "AA, B C",
+      "AA, B",
+      "AB, A",
+      "AB, B",
+      "AC, C A",
+      "AC, C B",
+    )
+
+    val ascendingName = getForUrl("/prisoner/$prisonerNumber/contact?sort=lastName,asc&sort=firstName,asc&sort=middleNames,asc")
+    assertThat(ascendingName.content.map { "${it.lastName}, ${it.firstName}${if (it.middleNames != null) " ${it.middleNames}" else ""}" })
+      .isEqualTo(expectedOrder)
+
+    val descendingName = getForUrl("/prisoner/$prisonerNumber/contact?sort=lastName,desc&sort=firstName,desc&sort=middleNames,desc")
+    assertThat(descendingName.content.map { "${it.lastName}, ${it.firstName}${if (it.middleNames != null) " ${it.middleNames}" else ""}" })
+      .isEqualTo(expectedOrder.reversed())
+  }
+
+  @Test
+  fun `secondary sort by id should work`() {
+    val prisonerNumber = "Z7890ZZ"
+    stubPrisonSearchWithResponse(prisonerNumber)
+    val relationship = ContactRelationship(
+      prisonerNumber = prisonerNumber,
+      relationshipTypeCode = "S",
+      relationshipToPrisonerCode = "FRI",
+      isNextOfKin = false,
+      isEmergencyContact = false,
+      isApprovedVisitor = false,
+    )
+    val randomDob = LocalDate.now().minusDays(RandomUtils.secure().randomLong(100, 2000))
+    val lowestId = testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "AA",
+        firstName = "B",
+        dateOfBirth = randomDob,
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    ).id
+    val highestId = testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "AA",
+        firstName = "B",
+        dateOfBirth = randomDob,
+        relationship = relationship,
+        createdBy = "USER1",
+      ),
+    ).id
+
+    val expectedOrder = listOf(
+      lowestId,
+      highestId,
+    )
+
+    val ascendingName = getForUrl("/prisoner/$prisonerNumber/contact?sort=lastName,asc&sort=firstName,asc&sort=middleNames,asc&sort=contactId,asc")
+    assertThat(ascendingName.content).extracting("contactId").isEqualTo(expectedOrder)
+
+    val descendingName = getForUrl("/prisoner/$prisonerNumber/contact?sort=lastName,desc&sort=firstName,desc&sort=middleNames,desc&sort=contactId,desc")
+    assertThat(descendingName.content).extracting("contactId").isEqualTo(expectedOrder.reversed())
+  }
+
+  private fun getForUrl(url: String): PrisonerContactSummaryResponse {
+    val withActiveOnly = webTestClient.get()
+      .uri(url)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(PrisonerContactSummaryResponse::class.java)
+      .returnResult().responseBody!!
+    return withActiveOnly
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortPropertiesKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortPropertiesKtTest.kt
@@ -5,10 +5,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactWithAddressEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSummaryEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import kotlin.reflect.full.memberProperties
 
-class MapSortPropertiesTest {
+class MapSortPropertiesKtTest {
 
   @Test
   fun `can map contact search result item fields to contact with address entity fields`() {
@@ -20,9 +22,26 @@ class MapSortPropertiesTest {
   }
 
   @Test
-  fun `attempting to sort on an invalid field gives an error`() {
+  fun `attempting to sort on an invalid field for contact search gives an error`() {
     val expected = assertThrows<ValidationException> {
       mapSortPropertiesOfContactSearch("foo")
+    }
+    assertThat(expected.message).isEqualTo("Unable to sort on foo")
+  }
+
+  @Test
+  fun `can map prisoner contact search result item fields to entity fields`() {
+    PrisonerContactSummary::class.memberProperties.forEach { property ->
+      val mapped = mapSortPropertiesOfPrisonerContactSearch(property.name)
+      assertThat(mapped).isNotNull()
+      assertThat(PrisonerContactSummaryEntity::class.memberProperties.find { it.name == mapped }).isNotNull()
+    }
+  }
+
+  @Test
+  fun `attempting to sort on an invalid field for prisoner contact search gives an error`() {
+    val expected = assertThrows<ValidationException> {
+      mapSortPropertiesOfPrisonerContactSearch("foo")
     }
     assertThat(expected.message).isEqualTo("Unable to sort on foo")
   }


### PR DESCRIPTION
Fix the sorting so that it works the same as contact search. DOB with nulls meaning eldest first and mapping API to entity field names.

Add ability to filter
* active, inactive or both (default)
* social, official or both (default)
* emergency contact or not or either (default)
* next of kin or not or either (default)
* emergency contact or next of kin, not EC and not NOK, ignore EC & NOK (default)