### PR TITLE
PRC-136: Page and sort linked prisoners

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import org.slf4j.LoggerFactory
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactSearchRequest
@@ -121,7 +121,7 @@ class ContactFacade(
 
   fun getContactName(id: Long): ContactNameDetails? = contactService.getContactName(id)
 
-  fun searchContacts(pageable: Pageable, request: ContactSearchRequest): Page<ContactSearchResultItem> = contactService.searchContacts(pageable, request)
+  fun searchContacts(pageable: Pageable, request: ContactSearchRequest): PagedModel<ContactSearchResultItem> = PagedModel(contactService.searchContacts(pageable, request))
 
   fun patchRelationship(prisonerContactId: Long, request: PatchRelationshipRequest) {
     contactService.updateContactRelationship(prisonerContactId, request)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.MergePrisonerContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.ResetPrisonerContactRequest
@@ -109,7 +110,7 @@ class SyncFacade(
       )
     }
 
-  fun getContactIds(pageable: Pageable) = syncContactService.getContactIds(pageable)
+  fun getContactIds(pageable: Pageable) = PagedModel(syncContactService.getContactIds(pageable))
 
   // ================================================================
   //  Contact Phone

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactSearchResultItemPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactSearchResultItemPage.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
-
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-
-// This is not directly used but are required to make Swagger produce a spec with page and content fields typed correctly
-class ContactSearchResultItemPage(content: List<ContactSearchResultItem>, pageable: Pageable, total: Long) : PageImpl<ContactSearchResultItem>(content, pageable, total)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/LinkedPrisonerPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/LinkedPrisonerPage.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
-
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-
-// This is not directly used but are required to make Swagger produce a spec with page and content fields typed correctly
-class LinkedPrisonerPage(content: List<LinkedPrisonerDetails>, pageable: Pageable, total: Long) : PageImpl<LinkedPrisonerDetails>(content, pageable, total)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactSummaryPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactSummaryPage.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
-
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-
-// This is not directly used but are required to make Swagger produce a spec with page and content fields typed correctly
-class PrisonerContactSummaryPage(content: List<PrisonerContactSummary>, pageable: Pageable, total: Long) : PageImpl<PrisonerContactSummary>(content, pageable, total)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSummaryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSummaryRepository.kt
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSummaryEntity
 
 @Repository
 interface PrisonerContactSummaryRepository : ReadOnlyRepository<PrisonerContactSummaryEntity, Long> {
-  fun findByContactId(contactId: Long, pageable: Pageable): Page<PrisonerContactSummaryEntity>
+  fun findByContactId(contactId: Long): List<PrisonerContactSummaryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -10,7 +10,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
+import org.springdoc.core.annotations.ParameterObject
+import org.springdoc.core.converters.models.PageableAsQueryParam
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -29,7 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchContactR
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactCreationResult
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactNameDetails
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItemPage
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PatchContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -182,12 +185,6 @@ class ContactController(
       ApiResponse(
         responseCode = "200",
         description = "Found contacts",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ContactSearchResultItemPage::class),
-          ),
-        ],
       ),
       ApiResponse(
         responseCode = "400",
@@ -197,11 +194,12 @@ class ContactController(
     ],
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
+  @PageableAsQueryParam
   fun searchContacts(
-    @Parameter(description = "Pageable configurations", required = false)
+    @Parameter(hidden = true)
     pageable: Pageable,
-    @ModelAttribute @Valid @Parameter(description = "Contact search criteria", required = true) request: ContactSearchRequest,
-  ) = contactFacade.searchContacts(pageable, request)
+    @ModelAttribute @Valid @ParameterObject request: ContactSearchRequest,
+  ): PagedModel<ContactSearchResultItem> = contactFacade.searchContacts(pageable, request)
 
   @PatchMapping("/{contactId}")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactLinkedPrisonersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactLinkedPrisonersController.kt
@@ -2,20 +2,20 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springdoc.core.converters.models.PageableAsQueryParam
-import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.LinkedPrisonerPage
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.LinkedPrisonerDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.LinkedPrisonersService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -29,19 +29,13 @@ class ContactLinkedPrisonersController(private val linkedPrisonersService: Linke
   @GetMapping
   @Operation(
     summary = "Get linked prisoners",
-    description = "Gets a list of prisoners that have an active relationship with the contact",
+    description = "Gets a list of prisoners that have an active relationship with the contact. Sorted by prisoner lastName, firstName, middleNames and the prisoner number.",
   )
   @ApiResponses(
     value = [
       ApiResponse(
         responseCode = "200",
         description = "Found the the linked prisoners successfully. Can be an empty list.",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = LinkedPrisonerPage::class),
-          ),
-        ],
       ),
       ApiResponse(
         responseCode = "404",
@@ -51,14 +45,26 @@ class ContactLinkedPrisonersController(private val linkedPrisonersService: Linke
     ],
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
-  @PageableAsQueryParam
   fun getContactLinkedPrisoners(
     @PathVariable("contactId") @Parameter(
+      `in` = ParameterIn.PATH,
       name = "contactId",
       description = "The id of the contact",
       example = "123456",
     ) contactId: Long,
-    @Parameter(description = "Pageable configurations", required = false)
-    pageable: Pageable,
-  ) = linkedPrisonersService.getLinkedPrisoners(contactId, pageable)
+    @Parameter(
+      `in` = ParameterIn.QUERY,
+      description = "Zero-based page index (0..N)",
+      name = "page",
+      schema = Schema(type = "integer", defaultValue = "0"),
+    )
+    page: Int = 0,
+    @Parameter(
+      `in` = ParameterIn.QUERY,
+      description = "The size of the page to be returned",
+      name = "size",
+      schema = Schema(type = "integer", defaultValue = "20"),
+    )
+    size: Int = 20,
+  ): PagedModel<LinkedPrisonerDetails> = linkedPrisonersService.getLinkedPrisoners(contactId, page, size)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
@@ -9,10 +9,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springdoc.core.annotations.ParameterObject
 import org.springdoc.core.converters.models.PageableAsQueryParam
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.internal.PrisonerContactSearchParams
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummaryPage
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.PrisonerContactService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.PrisonNumberDoc
@@ -39,12 +37,6 @@ class PrisonerController(private val prisonerContactService: PrisonerContactServ
       ApiResponse(
         responseCode = "200",
         description = "List of all contacts for the prisoner",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = PrisonerContactSummaryPage::class),
-          ),
-        ],
       ),
       ApiResponse(
         responseCode = "404",
@@ -95,8 +87,8 @@ class PrisonerController(private val prisonerContactService: PrisonerContactServ
       required = false,
     )
     emergencyContactOrNextOfKin: Boolean? = null,
-    @ParameterObject pageable: Pageable,
-  ): Page<PrisonerContactSummary> {
+    @Parameter(hidden = true) pageable: Pageable,
+  ): PagedModel<PrisonerContactSummary> {
     val params = PrisonerContactSearchParams(
       prisonerNumber = prisonerNumber,
       active = active,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
@@ -8,11 +8,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.springdoc.core.annotations.ParameterObject
-import org.springframework.data.domain.Page
+import org.springdoc.core.converters.models.PageableAsQueryParam
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort.Direction
 import org.springframework.data.web.PageableDefault
+import org.springframework.data.web.PagedModel
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -187,9 +187,10 @@ class ContactSyncController(
     ],
   )
   @PreAuthorize("hasAnyRole('PERSONAL_RELATIONSHIPS_MIGRATION')")
+  @PageableAsQueryParam
   fun reconcileContacts(
-    @ParameterObject
+    @Parameter(hidden = true)
     @PageableDefault(sort = ["contactId"], size = 100, direction = Direction.ASC)
     pageable: Pageable,
-  ): Page<SyncContactId> = syncFacade.getContactIds(pageable)
+  ): PagedModel<SyncContactId> = syncFacade.getContactIds(pageable)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper
 
+import org.springframework.data.web.PagedModel
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -568,8 +569,8 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
     .expectBody(ContactAddressResponse::class.java)
     .returnResult().responseBody!!
 
-  fun getLinkedPrisoners(contactId: Long): LinkedPrisonerResponse = webTestClient.get()
-    .uri("/contact/$contactId/linked-prisoners")
+  fun getLinkedPrisoners(contactId: Long, page: Int? = null, size: Int? = null): LinkedPrisonerResponse = webTestClient.get()
+    .uri("/contact/$contactId/linked-prisoners?${page?.let { "page=$page&"} }${size?.let { "size=$size"} }")
     .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
     .exchange()
     .expectStatus()
@@ -643,72 +644,21 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
 
   data class ContactSearchResponse(
     val content: List<ContactSearchResultItem>,
-    val pageable: ReturnedPageable,
-    val last: Boolean,
-    val totalPages: Int,
-    val totalElements: Int,
-    val first: Boolean,
-    val size: Int,
-    val number: Int,
-    val sort: ReturnedSort,
-    val numberOfElements: Int,
-    val empty: Boolean,
+    val page: PagedModel.PageMetadata,
   )
 
   data class PrisonerContactSummaryResponse(
     val content: List<PrisonerContactSummary>,
-    val pageable: ReturnedPageable,
-    val last: Boolean,
-    val totalPages: Int,
-    val totalElements: Int,
-    val first: Boolean,
-    val size: Int,
-    val number: Int,
-    val sort: ReturnedSort,
-    val numberOfElements: Int,
-    val empty: Boolean,
+    val page: PagedModel.PageMetadata,
   )
 
   data class LinkedPrisonerResponse(
     val content: List<LinkedPrisonerDetails>,
-    val pageable: ReturnedPageable,
-    val last: Boolean,
-    val totalPages: Int,
-    val totalElements: Int,
-    val first: Boolean,
-    val size: Int,
-    val number: Int,
-    val sort: ReturnedSort,
-    val numberOfElements: Int,
-    val empty: Boolean,
-  )
-
-  data class ReturnedPageable(
-    val pageNumber: Int,
-    val pageSize: Int,
-    val sort: ReturnedSort,
-    val offset: Int,
-    val unpaged: Boolean,
-    val paged: Boolean,
-  )
-
-  data class ReturnedSort(
-    val empty: Boolean,
-    val unsorted: Boolean,
-    val sorted: Boolean,
+    val page: PagedModel.PageMetadata,
   )
 
   data class ContactIdsResponse(
     val content: List<SyncContactId>,
-    val pageable: ReturnedPageable,
-    val last: Boolean,
-    val totalPages: Int,
-    val totalElements: Int,
-    val first: Boolean,
-    val size: Int,
-    val number: Int,
-    val sort: ReturnedSort,
-    val numberOfElements: Int,
-    val empty: Boolean,
+    val page: PagedModel.PageMetadata,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
@@ -63,27 +63,13 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
       setOf(prisoner1.prisonerNumber, prisoner2.prisonerNumber),
       listOf(prisoner1, prisoner2),
     )
-    val linkedPrisoners = testAPIClient.getLinkedPrisoners(savedContactId)
-    assertThat(linkedPrisoners.size).isEqualTo(10) // page size
-    assertThat(linkedPrisoners.totalElements).isEqualTo(3)
-    assertThat(linkedPrisoners.totalPages).isEqualTo(1)
-    assertThat(linkedPrisoners.pageable.pageNumber).isEqualTo(0)
+    val linkedPrisoners = testAPIClient.getLinkedPrisoners(savedContactId, 0, 10)
+    assertThat(linkedPrisoners.page.size).isEqualTo(10)
+    assertThat(linkedPrisoners.page.totalElements).isEqualTo(3)
+    assertThat(linkedPrisoners.page.totalPages).isEqualTo(1)
+    assertThat(linkedPrisoners.page.number).isEqualTo(0)
     assertThat(linkedPrisoners.content).isEqualTo(
       listOf(
-        LinkedPrisonerDetails(
-          prisonerNumber = prisoner2.prisonerNumber,
-          firstName = prisoner2.firstName,
-          middleNames = prisoner2.middleNames,
-          lastName = prisoner2.lastName,
-          prisonId = prisoner2.prisonId,
-          prisonName = prisoner2.prisonName,
-          prisonerContactId = prisoner2FatherRelationship.prisonerContactId,
-          relationshipTypeCode = "S",
-          relationshipTypeDescription = "Social",
-          relationshipToPrisonerCode = "FA",
-          relationshipToPrisonerDescription = "Father",
-          isRelationshipActive = true,
-        ),
         LinkedPrisonerDetails(
           prisonerNumber = prisoner1.prisonerNumber,
           firstName = prisoner1.firstName,
@@ -112,6 +98,20 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
           relationshipToPrisonerDescription = "Friend",
           isRelationshipActive = true,
         ),
+        LinkedPrisonerDetails(
+          prisonerNumber = prisoner2.prisonerNumber,
+          firstName = prisoner2.firstName,
+          middleNames = prisoner2.middleNames,
+          lastName = prisoner2.lastName,
+          prisonId = prisoner2.prisonId,
+          prisonName = prisoner2.prisonName,
+          prisonerContactId = prisoner2FatherRelationship.prisonerContactId,
+          relationshipTypeCode = "S",
+          relationshipTypeDescription = "Social",
+          relationshipToPrisonerCode = "FA",
+          relationshipToPrisonerDescription = "Father",
+          isRelationshipActive = true,
+        ),
       ),
     )
   }
@@ -127,7 +127,7 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
     stubSearchPrisonersByPrisonerNumbers(setOf(prisoner1.prisonerNumber, prisoner2.prisonerNumber), listOf(prisoner1))
 
     val linkedPrisoners = testAPIClient.getLinkedPrisoners(savedContactId)
-    assertThat(linkedPrisoners.totalElements).isEqualTo(2)
+    assertThat(linkedPrisoners.page.totalElements).isEqualTo(2)
     assertThat(linkedPrisoners.content).isEqualTo(
       listOf(
         LinkedPrisonerDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
@@ -120,9 +120,9 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(firstPage.content).hasSize(2)
-    assertThat(firstPage.totalPages).isEqualTo(2)
-    assertThat(firstPage.totalElements).isEqualTo(3)
-    assertThat(firstPage.number).isEqualTo(0)
+    assertThat(firstPage.page.totalPages).isEqualTo(2)
+    assertThat(firstPage.page.totalElements).isEqualTo(3)
+    assertThat(firstPage.page.number).isEqualTo(0)
 
     assertThat(firstPage.content[0].contactId).isEqualTo(1)
     assertThat(firstPage.content[1].contactId).isEqualTo(10)
@@ -130,9 +130,9 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     val contacts = getForUrl("$GET_PRISONER_CONTACT?size=2&page=1&sort=contactId")
 
     assertThat(contacts.content).hasSize(1)
-    assertThat(contacts.totalPages).isEqualTo(2)
-    assertThat(contacts.totalElements).isEqualTo(3)
-    assertThat(contacts.number).isEqualTo(1)
+    assertThat(contacts.page.totalPages).isEqualTo(2)
+    assertThat(contacts.page.totalElements).isEqualTo(3)
+    assertThat(contacts.page.number).isEqualTo(1)
 
     assertThat(contacts.content[0].contactId).isEqualTo(18)
   }
@@ -144,9 +144,9 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     val firstPage = getForUrl("$GET_PRISONER_CONTACT?sort=lastName")
 
     assertThat(firstPage.content).hasSize(3)
-    assertThat(firstPage.totalPages).isEqualTo(1)
-    assertThat(firstPage.totalElements).isEqualTo(3)
-    assertThat(firstPage.number).isEqualTo(0)
+    assertThat(firstPage.page.totalPages).isEqualTo(1)
+    assertThat(firstPage.page.totalElements).isEqualTo(3)
+    assertThat(firstPage.page.number).isEqualTo(0)
 
     assertThat(firstPage.content[0].lastName).isEqualTo("Address")
     assertThat(firstPage.content[1].lastName).isEqualTo("Last")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
@@ -37,8 +37,8 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
 
     with(body!!) {
       assertThat(content).isEmpty()
-      assertThat(totalElements).isEqualTo(0)
-      assertThat(totalPages).isEqualTo(0)
+      assertThat(page.totalElements).isEqualTo(0)
+      assertThat(page.totalPages).isEqualTo(0)
     }
   }
 
@@ -55,9 +55,9 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     with(body!!) {
       assertThat(content).isNotEmpty()
       assertThat(content.size).isEqualTo(1)
-      assertThat(totalElements).isEqualTo(1)
+      assertThat(page.totalElements).isEqualTo(1)
 
-      assertThat(totalPages).isEqualTo(1)
+      assertThat(page.totalPages).isEqualTo(1)
 
       val contact = content.first()
       assertThat(contact.id).isEqualTo(12)
@@ -92,15 +92,10 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     with(body!!) {
       assertThat(content).isNotEmpty()
       assertThat(content.size).isEqualTo(1)
-      assertThat(totalElements).isEqualTo(1)
-      assertThat(pageable.pageNumber).isEqualTo(0)
-      assertThat(pageable.pageSize).isEqualTo(10)
-      assertThat(pageable.sort.sorted).isEqualTo(false)
-      assertThat(sort.sorted).isEqualTo(false)
-      assertThat(first).isEqualTo(true)
-      assertThat(size).isEqualTo(10)
-      assertThat(number).isEqualTo(0)
-      assertThat(totalPages).isEqualTo(1)
+      assertThat(page.totalElements).isEqualTo(1)
+      assertThat(page.number).isEqualTo(0)
+      assertThat(page.size).isEqualTo(10)
+      assertThat(page.totalPages).isEqualTo(1)
 
       val contact = content.first()
       assertThat(contact.id).isEqualTo(1)
@@ -141,9 +136,8 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     with(body!!) {
       assertThat(content).isNotEmpty()
       assertThat(content.size).isEqualTo(1)
-      assertThat(totalElements).isEqualTo(1)
-
-      assertThat(totalPages).isEqualTo(1)
+      assertThat(page.totalElements).isEqualTo(1)
+      assertThat(page.totalPages).isEqualTo(1)
 
       val contact = content.first()
       assertThat(contact.id).isEqualTo(1)
@@ -182,9 +176,8 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     with(body!!) {
       assertThat(content).isNotEmpty()
       assertThat(content.size).isEqualTo(2)
-      assertThat(totalElements).isEqualTo(2)
-
-      assertThat(totalPages).isEqualTo(1)
+      assertThat(page.totalElements).isEqualTo(2)
+      assertThat(page.totalPages).isEqualTo(1)
 
       val contact = content.first()
       assertThat(contact.id).isEqualTo(16)
@@ -209,9 +202,8 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     with(body!!) {
       assertThat(content).isNotEmpty()
       assertThat(content.size).isEqualTo(1)
-      assertThat(totalElements).isEqualTo(1)
-
-      assertThat(totalPages).isEqualTo(1)
+      assertThat(page.totalElements).isEqualTo(1)
+      assertThat(page.totalPages).isEqualTo(1)
 
       val contact = content.first()
       assertThat(contact.id).isEqualTo(18)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIntegrationTest.kt
@@ -267,20 +267,20 @@ class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
       val firstPage = testAPIClient.syncReconcileContacts(0, 2)
       with(firstPage) {
-        assertThat(totalElements).isGreaterThanOrEqualTo(3)
+        assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
         assertThat(content).hasSize(2)
         assertThat(content).extracting("contactId").hasSize(2)
       }
 
       val secondPage = testAPIClient.syncReconcileContacts(1, 2)
       with(secondPage) {
-        assertThat(totalElements).isGreaterThanOrEqualTo(3)
+        assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
         assertThat(content.size).isGreaterThanOrEqualTo(1)
       }
 
       val bigPage = testAPIClient.syncReconcileContacts(0, 100)
       with(bigPage) {
-        assertThat(totalElements).isGreaterThanOrEqualTo(3)
+        assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
         assertThat(content.size).isGreaterThanOrEqualTo(3)
         assertThat(content).extracting("contactId").containsAll(listOf(5005L, 5006L, 5007L))
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
@@ -9,9 +9,9 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.whenever
 import org.openapitools.jackson.nullable.JsonNullable
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.web.PagedModel
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactAddressDetails
@@ -164,14 +164,14 @@ class ContactControllerTest {
           pageable,
           ContactSearchRequest("last", "first", "middle", LocalDate.of(1980, 1, 1)),
         ),
-      ).thenReturn(pageContacts)
+      ).thenReturn(PagedModel(pageContacts))
 
       // Act
-      val result: Page<ContactSearchResultItem> = controller.searchContacts(pageable, ContactSearchRequest("last", "first", "middle", LocalDate.of(1980, 1, 1)))
+      val result: PagedModel<ContactSearchResultItem> = controller.searchContacts(pageable, ContactSearchRequest("last", "first", "middle", LocalDate.of(1980, 1, 1)))
 
       // Then
       assertNotNull(result)
-      assertThat(result.totalElements).isEqualTo(1)
+      assertThat(result.metadata!!.totalElements).isEqualTo(1)
       assertThat(result.content[0].lastName).isEqualTo("last")
       assertThat(result.content[0].firstName).isEqualTo("first")
       assertThat(result.content[0].mailAddress).isEqualTo(true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactLinkedPrisonersControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactLinkedPrisonersControllerTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.LinkedPrisonerDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.LinkedPrisonersService
 
@@ -30,9 +30,8 @@ class ContactLinkedPrisonersControllerTest {
         isRelationshipActive = true,
       ),
     )
-    val pageable = Pageable.unpaged()
-    whenever(service.getLinkedPrisoners(123, pageable)).thenReturn(PageImpl(expected))
-    val response = controller.getContactLinkedPrisoners(123, pageable)
+    whenever(service.getLinkedPrisoners(123, 0, 10)).thenReturn(PagedModel(PageImpl(expected)))
+    val response = controller.getContactLinkedPrisoners(123, 0, 10)
     assertThat(response.content).isEqualTo(expected)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersServiceTest.kt
@@ -2,11 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSummaryEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.prisoner
@@ -23,14 +23,12 @@ class LinkedPrisonersServiceTest {
 
   @Test
   fun `Should search for unique prisoner ids and join with multiple relationships even if to the same prisoner`() {
-    whenever(repo.findByContactId(contactId, pageable)).thenReturn(
-      PageImpl(
-        listOf(
-          // two relationships for A1234BC and one for X6789YZ
-          prisonerContactEntity(999, "A1234BC", "S", "Social", "FRI", "Friend", true),
-          prisonerContactEntity(888, "A1234BC", "O", "Official", "LAW", "Lawyer", false),
-          prisonerContactEntity(777, "X6789YZ", "S", "Social", "FA", "Father", true),
-        ),
+    whenever(repo.findByContactId(contactId)).thenReturn(
+      listOf(
+        // two relationships for A1234BC and one for X6789YZ
+        prisonerContactEntity(999, "A1234BC", "S", "Social", "FRI", "Friend", true),
+        prisonerContactEntity(888, "A1234BC", "O", "Official", "LAW", "Lawyer", false),
+        prisonerContactEntity(777, "X6789YZ", "S", "Social", "FA", "Father", true),
       ),
     )
     whenever(
@@ -54,7 +52,7 @@ class LinkedPrisonersServiceTest {
       ),
     )
 
-    val linkedPrisoners = service.getLinkedPrisoners(contactId, pageable)
+    val linkedPrisoners = service.getLinkedPrisoners(contactId, 0, 10)
 
     assertThat(linkedPrisoners.content).isEqualTo(
       listOf(
@@ -106,12 +104,10 @@ class LinkedPrisonersServiceTest {
 
   @Test
   fun `should include results even if they don't have a matching prisoner`() {
-    whenever(repo.findByContactId(contactId, pageable)).thenReturn(
-      PageImpl(
-        listOf(
-          prisonerContactEntity(999, "A1234BC", "S", "Social", "FRI", "Friend", true),
-          prisonerContactEntity(777, "X6789YZ", "S", "Social", "FA", "Father", true),
-        ),
+    whenever(repo.findByContactId(contactId)).thenReturn(
+      listOf(
+        prisonerContactEntity(999, "A1234BC", "S", "Social", "FRI", "Friend", true),
+        prisonerContactEntity(777, "X6789YZ", "S", "Social", "FA", "Father", true),
       ),
     )
     whenever(
@@ -123,22 +119,10 @@ class LinkedPrisonersServiceTest {
       ),
     ).thenReturn(listOf(prisoner(prisonerNumber = "A1234BC", firstName = "A", middleNames = "1234", lastName = "BC")))
 
-    val linkedPrisoners = service.getLinkedPrisoners(contactId, pageable)
+    val linkedPrisoners = service.getLinkedPrisoners(contactId, 0, 10)
 
     assertThat(linkedPrisoners.content).isEqualTo(
       listOf(
-        LinkedPrisonerDetails(
-          prisonerNumber = "A1234BC",
-          firstName = "A",
-          middleNames = "1234",
-          lastName = "BC",
-          prisonerContactId = 999,
-          relationshipTypeCode = "S",
-          relationshipTypeDescription = "Social",
-          relationshipToPrisonerCode = "FRI",
-          relationshipToPrisonerDescription = "Friend",
-          isRelationshipActive = true,
-        ),
         LinkedPrisonerDetails(
           prisonerNumber = "X6789YZ",
           firstName = null,
@@ -151,10 +135,140 @@ class LinkedPrisonersServiceTest {
           relationshipToPrisonerDescription = "Father",
           isRelationshipActive = true,
         ),
+        LinkedPrisonerDetails(
+          prisonerNumber = "A1234BC",
+          firstName = "A",
+          middleNames = "1234",
+          lastName = "BC",
+          prisonerContactId = 999,
+          relationshipTypeCode = "S",
+          relationshipTypeDescription = "Social",
+          relationshipToPrisonerCode = "FRI",
+          relationshipToPrisonerDescription = "Friend",
+          isRelationshipActive = true,
+        ),
       ),
     )
 
     verify(prisonerService, times(1)).getPrisoners(setOf("A1234BC", "X6789YZ"))
+  }
+
+  @Test
+  fun `should work with more than 1000 linked prisoners by batching calls to prisoner search`() {
+    val entities =
+      (1..2000).map { id -> prisonerContactEntity(id.toLong(), "A${id}BC", "S", "Social", "FRI", "Friend", true) }
+    val prisonersBatchOne = (1..1000).map { id ->
+      prisoner(
+        prisonerNumber = "A${id}BC",
+        firstName = "A",
+        middleNames = "1234",
+        lastName = "BC",
+      )
+    }
+    val prisonersBatchTwo = (1001..2000).map { id ->
+      prisoner(
+        prisonerNumber = "A${id}BC",
+        firstName = "A",
+        middleNames = "1234",
+        lastName = "BC",
+      )
+    }
+    whenever(repo.findByContactId(contactId)).thenReturn(entities)
+    whenever(prisonerService.getPrisoners(any())).thenReturn(prisonersBatchOne).thenReturn(prisonersBatchTwo)
+
+    val linkedPrisoners = service.getLinkedPrisoners(contactId, 0, 10000)
+    assertThat(linkedPrisoners.content).hasSize(2000)
+    // Check they all found a matching prisoner
+    assertThat(linkedPrisoners.content).allMatch { it.firstName == "A" }
+    verify(prisonerService, times(2)).getPrisoners(any())
+  }
+
+  @Test
+  fun `should apply paging`() {
+    val entities =
+      (1..29).map { id -> prisonerContactEntity(id.toLong(), "A${id}BC", "S", "Social", "FRI", "Friend", true) }
+    val prisonersBatchOne = (1..29).map { id ->
+      prisoner(
+        prisonerNumber = "A${id}BC",
+        firstName = "A",
+        middleNames = "1234",
+        lastName = "BC",
+      )
+    }
+    whenever(repo.findByContactId(contactId)).thenReturn(entities)
+    whenever(prisonerService.getPrisoners(any())).thenReturn(prisonersBatchOne)
+
+    val pageOne = service.getLinkedPrisoners(contactId, 0, 10)
+    assertThat(pageOne.content).hasSize(10)
+    assertThat(pageOne.metadata!!.totalElements).isEqualTo(29)
+    assertThat(pageOne.metadata!!.totalPages).isEqualTo(3)
+    assertThat(pageOne.metadata!!.number).isEqualTo(0)
+    assertThat(pageOne.metadata!!.size).isEqualTo(10)
+
+    val pageTwo = service.getLinkedPrisoners(contactId, 1, 10)
+    assertThat(pageTwo.content).hasSize(10)
+    assertThat(pageTwo.metadata!!.totalElements).isEqualTo(29)
+    assertThat(pageTwo.metadata!!.totalPages).isEqualTo(3)
+    assertThat(pageTwo.metadata!!.number).isEqualTo(1)
+    assertThat(pageTwo.metadata!!.size).isEqualTo(10)
+
+    val pageThree = service.getLinkedPrisoners(contactId, 2, 10)
+    assertThat(pageThree.content).hasSize(9)
+    assertThat(pageThree.metadata!!.totalElements).isEqualTo(29)
+    assertThat(pageThree.metadata!!.totalPages).isEqualTo(3)
+    assertThat(pageThree.metadata!!.number).isEqualTo(2)
+    assertThat(pageThree.metadata!!.size).isEqualTo(10)
+
+    val megaPage = service.getLinkedPrisoners(contactId, 0, 1000)
+    assertThat(megaPage.content).hasSize(29)
+    assertThat(megaPage.metadata!!.totalElements).isEqualTo(29)
+    assertThat(megaPage.metadata!!.totalPages).isEqualTo(1)
+    assertThat(megaPage.metadata!!.number).isEqualTo(0)
+    assertThat(megaPage.metadata!!.size).isEqualTo(1000)
+  }
+
+  @Test
+  fun `Should sort by prisoner name and then prisoner number`() {
+    whenever(repo.findByContactId(contactId)).thenReturn(
+      listOf(
+        prisonerContactEntity(888, "D1234EF", "O", "Official", "LAW", "Lawyer", false),
+        prisonerContactEntity(999, "A1234BC", "S", "Social", "FRI", "Friend", true),
+        prisonerContactEntity(777, "X6789YZ", "S", "Social", "FA", "Father", true),
+        prisonerContactEntity(1000, "A1235BC", "S", "Social", "FA", "Father", true),
+      ),
+    )
+    val prisonerWithSameName = prisoner(
+      prisonerNumber = "A1234BC",
+      firstName = "A",
+      middleNames = "1234",
+      lastName = "BC",
+      prisonId = "BXI",
+      prisonName = "Brixton (HMP)",
+    )
+    whenever(
+      prisonerService.getPrisoners(
+        setOf(
+          "A1234BC",
+          "D1234EF",
+          "X6789YZ",
+          "A1235BC",
+        ),
+      ),
+    ).thenReturn(
+      listOf(
+        prisonerWithSameName,
+        prisonerWithSameName.copy(prisonerNumber = "X6789YZ"),
+        prisonerWithSameName.copy(prisonerNumber = "A1235BC", middleNames = "1235"),
+        prisoner(prisonerNumber = "D1234EF", firstName = "D", middleNames = null, lastName = "EF"),
+        prisoner(prisonerNumber = "A1235BC", firstName = "D", middleNames = null, lastName = "EF"),
+      ),
+    )
+
+    val linkedPrisoners = service.getLinkedPrisoners(contactId, 0, 10)
+
+    assertThat(linkedPrisoners.content).extracting("prisonerNumber").isEqualTo(
+      listOf("A1234BC", "X6789YZ", "A1235BC", "D1234EF"),
+    )
   }
 
   private fun prisonerContactEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactServiceTest.kt
@@ -90,7 +90,7 @@ class PrisonerContactServiceTest {
     val result = prisonerContactService.getAllContacts(request)
 
     result.content hasSize 2
-    assertThat(result).containsAll(
+    assertThat(result.content).containsAll(
       listOf(
         c1.toModel(
           RestrictionsSummary(
@@ -149,7 +149,7 @@ class PrisonerContactServiceTest {
     val result = prisonerContactService.getAllContacts(request)
 
     result.content hasSize 2
-    assertThat(result).containsAll(
+    assertThat(result.content).containsAll(
       listOf(
         c1.toModel(
           RestrictionsSummary(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactFacadeTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactAddressDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactAddressPhoneDetails
@@ -318,7 +319,7 @@ class ContactFacadeTest {
 
     whenever(contactService.searchContacts(any(), any())).thenReturn(result)
 
-    assertThat(contactFacade.searchContacts(pageable, request)).isEqualTo(result)
+    assertThat(contactFacade.searchContacts(pageable, request)).isEqualTo(PagedModel(result))
 
     verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
   }


### PR DESCRIPTION
Changed linked prisoners to page in memory to allow sorting based on name then prisoner number. I've manually tested this with 10000 linked prisoners and it took less than 15 seconds.

Also move to PagedModel instead of PageImpl to fix a spring warning about using an unsafe type. This is a breaking change and needs some fixes to the client code.

Also fixed a number of swagger issues with the paged endpoints.