### PR TITLE
PRC-549: Add deceased date to search results

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactWithAddressEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactWithAddressEntity.kt
@@ -24,6 +24,8 @@ data class ContactWithAddressEntity(
 
   val dateOfBirth: LocalDate?,
 
+  val deceasedDate: LocalDate?,
+
   val createdBy: String,
 
   val createdTime: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactSummaryEntity.kt
@@ -25,6 +25,8 @@ data class PrisonerContactSummaryEntity(
 
   val dateOfBirth: LocalDate?,
 
+  val deceasedDate: LocalDate?,
+
   val contactAddressId: Long?,
 
   val flat: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactsServiceMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactsServiceMappers.kt
@@ -15,6 +15,7 @@ fun ContactWithAddressEntity.toModel() = ContactSearchResultItem(
   firstName = this.firstName,
   middleNames = this.middleNames,
   dateOfBirth = this.dateOfBirth,
+  deceasedDate = this.deceasedDate,
   createdBy = this.createdBy,
   createdTime = this.createdTime,
   flat = this.flat,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/MapSortProperties.kt
@@ -18,6 +18,7 @@ fun mapSortPropertiesOfContactSearch(property: String): String = when (property)
   ContactSearchResultItem::firstName.name -> ContactWithAddressEntity::firstName.name
   ContactSearchResultItem::middleNames.name -> ContactWithAddressEntity::middleNames.name
   ContactSearchResultItem::dateOfBirth.name -> ContactWithAddressEntity::dateOfBirth.name
+  ContactSearchResultItem::deceasedDate.name -> ContactWithAddressEntity::deceasedDate.name
   ContactSearchResultItem::createdBy.name -> ContactWithAddressEntity::createdBy.name
   ContactSearchResultItem::createdTime.name -> ContactWithAddressEntity::createdTime.name
   ContactSearchResultItem::flat.name -> ContactWithAddressEntity::flat.name
@@ -47,6 +48,7 @@ fun mapSortPropertiesOfPrisonerContactSearch(property: String): String = when (p
   PrisonerContactSummary::firstName.name -> PrisonerContactSummaryEntity::firstName.name
   PrisonerContactSummary::middleNames.name -> PrisonerContactSummaryEntity::middleNames.name
   PrisonerContactSummary::dateOfBirth.name -> PrisonerContactSummaryEntity::dateOfBirth.name
+  PrisonerContactSummary::deceasedDate.name -> PrisonerContactSummaryEntity::deceasedDate.name
   PrisonerContactSummary::relationshipTypeCode.name -> PrisonerContactSummaryEntity::relationshipType.name
   PrisonerContactSummary::relationshipTypeDescription.name -> PrisonerContactSummaryEntity::relationshipTypeDescription.name
   PrisonerContactSummary::relationshipToPrisonerCode.name -> PrisonerContactSummaryEntity::relationshipToPrisoner.name

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/PrisonerContactMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/PrisonerContactMappers.kt
@@ -12,6 +12,7 @@ fun PrisonerContactSummaryEntity.toModel(restrictionSummary: RestrictionsSummary
   firstName = this.firstName,
   middleNames = this.middleNames,
   dateOfBirth = this.dateOfBirth,
+  deceasedDate = this.deceasedDate,
   relationshipTypeCode = this.relationshipType,
   relationshipTypeDescription = this.relationshipTypeDescription,
   relationshipToPrisonerCode = this.relationshipToPrisoner,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactSearchResultItem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactSearchResultItem.kt
@@ -23,6 +23,9 @@ data class ContactSearchResultItem(
   @Schema(description = "The date of birth of the contact, if known", example = "1980-01-01", nullable = true)
   val dateOfBirth: LocalDate? = null,
 
+  @Schema(description = "The date the contact deceased, if known", example = "1980-01-01", nullable = true)
+  val deceasedDate: LocalDate? = null,
+
   @Schema(description = "The id of the user who created the contact", example = "JD000001")
   val createdBy: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactSummary.kt
@@ -28,6 +28,9 @@ data class PrisonerContactSummary(
   @Schema(description = "The date of birth of the contact", example = "1980-01-01")
   val dateOfBirth: LocalDate?,
 
+  @Schema(description = "The date the contact deceased, if known", example = "1980-01-01", nullable = true)
+  val deceasedDate: LocalDate?,
+
   @Schema(
     description =
     """

--- a/src/main/resources/migrations/common/R__v_contacts_with_primary_address.sql
+++ b/src/main/resources/migrations/common/R__v_contacts_with_primary_address.sql
@@ -13,6 +13,7 @@ select
     c.created_by,
     c.created_time,
     c.date_of_birth,
+    c.deceased_date,
     c.first_name,
     c.last_name,
     c.middle_names,

--- a/src/main/resources/migrations/common/R__v_prisoner_contacts.sql
+++ b/src/main/resources/migrations/common/R__v_prisoner_contacts.sql
@@ -16,6 +16,7 @@ AS
       c.middle_names,
       c.last_name,
       c.date_of_birth,
+      c.deceased_date,
       ca.contact_address_id,
       ca.flat,
       ca.property,

--- a/src/main/resources/migrations/test/V2024.08.02.4__example_data.sql
+++ b/src/main/resources/migrations/test/V2024.08.02.4__example_data.sql
@@ -115,7 +115,9 @@ values (1, 1, 'A1234BB', 'S', true, 'FA', 'Comment', 'MDI', 'TIM', current_times
        -- Mike Toby
        (27, 1, 'A4385DZ', 'S', true, 'FA', 'Comment', 'MDI', 'TIM', current_timestamp),
        (28, 10, 'A4385DZ', 'S', true, 'MOT', 'Comment', 'MDI', 'TIM', current_timestamp),
-       (29, 18, 'A4385DZ', 'S', true, 'FRI', null, 'MDI', 'TIM', current_timestamp);
+       (29, 18, 'A4385DZ', 'S', true, 'FRI', null, 'MDI', 'TIM', current_timestamp),
+       -- Stubbed Prisoner With Dead Contact
+       (30, 19, 'E4567FG', 'S', true, 'FRI', 'Dead Contact', 'MDI', 'TIM', current_timestamp);
 
 insert into prisoner_contact_restriction (prisoner_contact_id, restriction_type, start_date, expiry_date, comments, created_by, created_time, updated_by, updated_time )
 values

--- a/src/main/resources/migrations/test/V2024.08.02.5__reset_example_sequences.sql
+++ b/src/main/resources/migrations/test/V2024.08.02.5__reset_example_sequences.sql
@@ -5,7 +5,7 @@ alter sequence if exists contact_address_contact_address_id_seq restart with 18;
 alter sequence if exists contact_email_contact_email_id_seq restart with 5;
 alter sequence if exists contact_identity_contact_identity_id_seq restart with 5;
 alter sequence if exists contact_phone_contact_phone_id_seq restart with 13;
-alter sequence if exists prisoner_contact_prisoner_contact_id_seq restart with 30;
+alter sequence if exists prisoner_contact_prisoner_contact_id_seq restart with 31;
 alter sequence if exists contact_restriction_contact_restriction_id_seq restart with 5;
 alter sequence if exists contact_address_phone_contact_address_phone_id_seq restart with 2;
 alter sequence if exists prisoner_contact_restriction_prisoner_contact_restriction_id_seq restart with 6;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
@@ -735,6 +735,14 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     )
   }
 
+  @Test
+  fun `should return dead contact with deceased date`() {
+    stubPrisonSearchWithResponse("E4567FG")
+    val deadContacts = getForUrl("/prisoner/E4567FG/contact")
+    assertThat(deadContacts.content).hasSize(1)
+    assertThat(deadContacts.content[0].deceasedDate).isEqualTo(LocalDate.of(2000, 1, 1))
+  }
+
   private fun getForUrl(url: String): PrisonerContactSummaryResponse {
     val withActiveOnly = webTestClient.get()
       .uri(url)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
@@ -190,6 +190,18 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   }
 
   @Test
+  fun `should get contacts with a deceased date`() {
+    val uri = UriComponentsBuilder.fromPath("contact/search")
+      .queryParam("lastName", "Dead")
+      .build()
+      .toUri()
+
+    val body = testAPIClient.getSearchContactResults(uri)!!
+    assertThat(body.page.totalElements).isEqualTo(1)
+    assertThat(body.content[0].deceasedDate).isEqualTo(LocalDate.of(2000, 1, 1))
+  }
+
+  @Test
   fun `should get the contacts with minimal addresses associated with them when searched by last name`() {
     val uri = UriComponentsBuilder.fromPath("contact/search")
       .queryParam("lastName", "Address")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -990,6 +990,7 @@ class ContactServiceTest {
       middleNames = "middle",
       firstName = "first",
       dateOfBirth = LocalDate.of(1980, 2, 1),
+      deceasedDate = null,
       contactAddressId = 1L,
       primaryAddress = true,
       verified = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersServiceTest.kt
@@ -287,6 +287,7 @@ class LinkedPrisonersServiceTest {
     middleNames = "Any",
     lastName = "Last",
     dateOfBirth = null,
+    deceasedDate = null,
     contactAddressId = 3L,
     flat = "2B",
     property = "123",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactRelationshipServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactRelationshipServiceTest.kt
@@ -99,6 +99,7 @@ class PrisonerContactRelationshipServiceTest {
     middleNames = "Any",
     lastName = lastName,
     dateOfBirth = dateOfBirth,
+    deceasedDate = null,
     contactAddressId = 3L,
     flat = "2B",
     property = "123",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactServiceTest.kt
@@ -203,6 +203,7 @@ class PrisonerContactServiceTest {
     middleNames = "Any",
     lastName = lastName,
     dateOfBirth = dateOfBirth,
+    deceasedDate = null,
     contactAddressId = 3L,
     flat = "2B",
     property = "123",


### PR DESCRIPTION
For contact search and prisoner contact search to allow showing if the contact is deceased or not in the results tables.