### PR TITLE
PRC-546 : reduce noise on sentry related to entity not found errors caused as part of reconciliation of new prisoners.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/SentryConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/SentryConfig.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.config
 
 import io.sentry.SentryOptions
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 @Configuration
@@ -14,5 +15,13 @@ class SentryConfig {
         else -> transaction
       }
     } ?: transaction
+  }
+
+  @Bean
+  fun ignoreEntityNotFoundExceptions() = SentryOptions.BeforeSendCallback { event, _ ->
+    when {
+      event.exceptions?.any { it.type == EntityNotFoundException::class.qualifiedName } == true -> null
+      else -> event
+    }
   }
 }


### PR DESCRIPTION
There are a large number of events on the sentry due to the daily reconciliation process, which calls domestic status and number of children sync GET endpoints for every active prisoner and sends entity not found exception error log into the sentry. This is using the sentry quota significantly, So the aim is to reduce this noise reported to the sentry, 