### PR TITLE
PRC-582: speedy contact reconciliation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactAdd
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactEmailService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactIdentityService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactPhoneService
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactReconciliationService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactRestrictionService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncEmploymentService
@@ -72,6 +73,7 @@ class SyncFacade(
   private val syncPrisonerContactRestrictionService: SyncPrisonerContactRestrictionService,
   private val syncEmploymentService: SyncEmploymentService,
   private val syncAdminService: SyncAdminService,
+  private val syncContactReconciliationService: SyncContactReconciliationService,
   private val outboundEventsService: OutboundEventsService,
 ) {
   // ================================================================
@@ -443,6 +445,13 @@ class SyncFacade(
         source = Source.NOMIS,
       )
     }
+
+  // ===============================================================================
+  // RECONCILE - a single contact by ID - returns a very basic summary of data for
+  // one contact and its sub-entities to reconcile against.
+  // ===============================================================================
+
+  fun reconcileSingleContact(contactId: Long) = syncContactReconciliationService.getContactDetailsById(contactId)
 
   // =====================================================================================
   //  MERGE - Replace the full set of relationships and restrictions for two prisoners

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/SyncContactReconcile.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/SyncContactReconcile.kt
@@ -1,0 +1,176 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+/**
+ * These are slimmed-down versions of the models used purely for reconciling
+ * contacts and their sub-entities against values in NOMIS. This is used
+ * by Syscon to run a no-frills check that the main data items are aligned.
+ */
+
+data class SyncContactReconcile(
+  val contactId: Long,
+  val firstName: String,
+  val lastName: String,
+  val middleNames: String? = null,
+  val dateOfBirth: LocalDate? = null,
+  val staffFlag: Boolean = false,
+  val phones: List<ReconcilePhone> = emptyList(),
+  val addresses: List<ReconcileAddress> = emptyList(),
+  val emails: List<ReconcileEmail> = emptyList(),
+  val identities: List<ReconcileIdentity> = emptyList(),
+  val restrictions: List<ReconcileRestriction> = emptyList(),
+  val relationships: List<ReconcileRelationship> = emptyList(),
+  val employments: List<ReconcileEmployment> = emptyList(),
+)
+
+@Schema(description = "Contact phone reconciliation")
+data class ReconcilePhone(
+  @Schema(description = "Unique identifier for the contact phone", example = "1")
+  val contactPhoneId: Long,
+
+  @Schema(description = "Type of phone", example = "MOB")
+  val phoneType: String,
+
+  @Schema(description = "Phone number", example = "+1234567890")
+  val phoneNumber: String,
+
+  @Schema(description = "Extension number", example = "123")
+  val extNumber: String?,
+)
+
+@Schema(description = "Contact address phone reconciliation")
+data class ReconcileAddressPhone(
+  @Schema(description = "Unique identifier for the contact address phone", example = "1")
+  val contactAddressPhoneId: Long,
+
+  @Schema(description = "Type of phone", example = "MOB")
+  val phoneType: String,
+
+  @Schema(description = "Phone number", example = "+1234567890")
+  val phoneNumber: String,
+
+  @Schema(description = "Extension number", example = "123")
+  val extNumber: String?,
+)
+
+@Schema(description = "Contact email reconciliation")
+data class ReconcileEmail(
+  @Schema(description = "Unique identifier for the contact email", example = "1")
+  val contactEmailId: Long,
+
+  @Schema(description = "Email address", example = "test@example.com")
+  val emailAddress: String,
+)
+
+@Schema(description = "Contact identity reconciliation")
+data class ReconcileIdentity(
+  @Schema(description = "Unique identifier for the contact identity", example = "1")
+  val contactIdentityId: Long,
+
+  @Schema(description = "Type of identity", example = "DL")
+  val identityType: String,
+
+  @Schema(description = "Identity ", example = "DL090 0909 909")
+  val identityValue: String,
+
+  @Schema(description = "Issuing authority", example = "DVLA")
+  val issuingAuthority: String?,
+)
+
+@Schema(description = "Contact address reconciliation")
+data class ReconcileAddress(
+  @Schema(description = "The id of the contact address", example = "123456")
+  val contactAddressId: Long = 0,
+
+  @Schema(description = "The coded value for type of address", example = "HOME", nullable = true)
+  val addressType: String? = null,
+
+  @Schema(description = "True if this is the primary address otherwise false", example = "true")
+  val primaryAddress: Boolean,
+
+  @Schema(description = "Building or house number or name", example = "Mansion House", nullable = true)
+  val property: String? = null,
+
+  @Schema(description = "Street or road name", example = "Acacia Avenue", nullable = true)
+  val street: String? = null,
+
+  @Schema(description = "Area", example = "Morton Heights", nullable = true)
+  val area: String? = null,
+
+  @Schema(description = "Address-specific phone numbers")
+  val addressPhones: List<ReconcileAddressPhone> = emptyList(),
+)
+
+@Schema(description = "Contact restriction reconciliation")
+data class ReconcileRestriction(
+  @Schema(description = "The ID of the contact restriction", example = "12345")
+  val contactRestrictionId: Long,
+
+  @Schema(description = "Type of restriction", example = "MOBILE")
+  val restrictionType: String,
+
+  @Schema(description = "Restriction created date", example = "2024-01-01")
+  val startDate: LocalDate? = null,
+
+  @Schema(description = "Restriction end date ", example = "2024-01-01")
+  val expiryDate: LocalDate? = null,
+)
+
+@Schema(description = "Contact employment reconciliation")
+data class ReconcileEmployment(
+  @Schema(description = "The ID of the employment", example = "12345")
+  val employmentId: Long,
+
+  @Schema(description = "The ID of the organization associated with the employment", example = "12345")
+  val organisationId: Long,
+
+  @Schema(description = "If the employment is active", example = "true")
+  val active: Boolean,
+)
+
+@Schema(description = "Prisoner contact relationship reconciliation")
+data class ReconcileRelationship(
+  @Schema(description = "The ID of the prisoner contact", example = "12345")
+  val prisonerContactId: Long,
+
+  @Schema(description = "The prisoner number", example = "A1234BC")
+  val prisonerNumber: String,
+
+  @Schema(description = "Social or official contact", example = "S")
+  val contactType: String,
+
+  @Schema(description = "The relationship code from reference data", example = "Friend")
+  val relationshipType: String,
+
+  @Schema(description = "Indicates if the prisoner contact is next of kin", example = "true")
+  val nextOfKin: Boolean,
+
+  @Schema(description = "Indicates if the prisoner contact is an emergency contact", example = "true")
+  val emergencyContact: Boolean,
+
+  @Schema(description = "Indicates if the prisoner contact is active", example = "true")
+  val active: Boolean,
+
+  @Schema(description = "Indicates if the prisoner contact is an approved visitor", example = "true")
+  val approvedVisitor: Boolean,
+
+  @Schema(description = "The list of restrictions on this relationship")
+  val relationshipRestrictions: List<ReconcileRelationshipRestriction> = emptyList(),
+)
+
+@Schema(description = "Contact relationship restriction reconciliation")
+data class ReconcileRelationshipRestriction(
+  @Schema(description = "The ID of the prisoner contact restriction", example = "12345")
+  val prisonerContactRestrictionId: Long,
+
+  @Schema(description = "Type of restriction", example = "MOBILE")
+  val restrictionType: String,
+
+  @Schema(description = "Restriction created date", example = "2024-01-01")
+  val startDate: LocalDate? = null,
+
+  @Schema(description = "Restriction end date ", example = "2024-01-01")
+  val expiryDate: LocalDate? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactAddressRepository.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressEntity
 
 @Repository
 interface ContactAddressRepository : JpaRepository<ContactAddressEntity, Long> {
+  fun findByContactId(contactId: Long): List<ContactAddressEntity>
 
   @Modifying
   @Query("delete from ContactAddressEntity ca where ca.contactId = :contactId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactIdentityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactIdentityRepository.kt
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactIdentityEntity
 
 interface ContactIdentityRepository : JpaRepository<ContactIdentityEntity, Long> {
+  fun findByContactId(contactId: Long): List<ContactIdentityEntity>
+
   @Modifying
   @Query("delete from ContactIdentityEntity ci where ci.contactId = :contactId")
   fun deleteAllByContactId(contactId: Long): Int

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactPhoneRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactPhoneRepository.kt
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactPhoneEntity
 
 interface ContactPhoneRepository : JpaRepository<ContactPhoneEntity, Long> {
+  fun findByContactId(contactId: Long): List<ContactPhoneEntity>
+
   @Modifying
   @Query("delete from ContactPhoneEntity cp where cp.contactId = :contactId")
   fun deleteAllByContactId(contactId: Long): Int

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactRestrictionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactRestrictionRepository.kt
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactRestrictionEntity
 
 interface ContactRestrictionRepository : JpaRepository<ContactRestrictionEntity, Long> {
+  fun findByContactId(contactId: Long): List<ContactRestrictionEntity>
+
   @Modifying
   @Query("delete from ContactRestrictionEntity cr where cr.contactId = :contactId")
   fun deleteAllByContactId(contactId: Long): Int

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCrea
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactId
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactReconcile
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
@@ -193,4 +194,30 @@ class ContactSyncController(
     @PageableDefault(sort = ["contactId"], size = 100, direction = Direction.ASC)
     pageable: Pageable,
   ): PagedModel<SyncContactId> = syncFacade.getContactIds(pageable)
+
+  @GetMapping("/contact/{contactId}/reconcile")
+  @Operation(
+    summary = "Reconciliation endpoint for a single contact by ID",
+    description = "Get a minimal version of a contact and its main sub-entities to reconcile against",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = SyncContactReconcile::class),
+          ),
+        ],
+        description = "Reconciliation object for one contact",
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('PERSONAL_RELATIONSHIPS_MIGRATION')")
+  @PageableAsQueryParam
+  fun reconcileSingleContact(
+    @Parameter(description = "The internal ID for the contact.", required = true)
+    @PathVariable contactId: Long,
+  ) = syncFacade.reconcileSingleContact(contactId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncContactReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncContactReconciliationService.kt
@@ -1,0 +1,152 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync
+
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressPhoneEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactPhoneEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ReconcileAddress
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ReconcileAddressPhone
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ReconcileEmail
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ReconcileEmployment
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ReconcileIdentity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ReconcilePhone
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ReconcileRelationship
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ReconcileRelationshipRestriction
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.ReconcileRestriction
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactReconcile
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactAddressPhoneRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactAddressRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactEmailRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactIdentityRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactPhoneRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRestrictionRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactWithFixedIdRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.EmploymentRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRestrictionRepository
+
+@Transactional(readOnly = true)
+@Service
+class SyncContactReconciliationService(
+  private val contactRepository: ContactWithFixedIdRepository,
+  private val contactEmailRepository: ContactEmailRepository,
+  private val contactEmploymentRepository: EmploymentRepository,
+  private val contactIdentityRepository: ContactIdentityRepository,
+  private val contactPhoneRepository: ContactPhoneRepository,
+  private val contactAddressRepository: ContactAddressRepository,
+  private val contactAddressPhoneRepository: ContactAddressPhoneRepository,
+  private val contactRestrictionRepository: ContactRestrictionRepository,
+  private val prisonerContactRepository: PrisonerContactRepository,
+  private val prisonerContactRestrictionRepository: PrisonerContactRestrictionRepository,
+) {
+  fun getContactDetailsById(contactId: Long): SyncContactReconcile {
+    val contactEntity = contactRepository.findById(contactId)
+      .orElseThrow { EntityNotFoundException("Contact with ID $contactId not found") }
+
+    // Get all the phone numbers and address phone numbers for this contact
+    val phoneNumbers = contactPhoneRepository.findByContactId(contactId)
+    val addressPhoneNumbers = contactAddressPhoneRepository.findByContactId(contactEntity.id())
+
+    // Filter address-specific phone numbers out of the "global" phone number list
+    val globalPhoneNumbers = phoneNumbers.filterNot { phone ->
+      addressPhoneNumbers.any { addressPhone -> addressPhone.contactPhoneId == phone.contactPhoneId }
+    }
+
+    return SyncContactReconcile(
+      contactId = contactEntity.id(),
+      firstName = contactEntity.firstName,
+      lastName = contactEntity.lastName,
+      middleNames = contactEntity?.middleNames,
+      dateOfBirth = contactEntity?.dateOfBirth,
+      staffFlag = contactEntity.staffFlag,
+      phones = globalPhoneNumbers.map { phone ->
+        ReconcilePhone(
+          contactPhoneId = phone.contactPhoneId,
+          phoneType = phone.phoneType,
+          phoneNumber = phone.phoneNumber,
+          extNumber = phone.extNumber,
+        )
+      },
+      addresses = contactAddressRepository.findByContactId(contactId).map { address ->
+        ReconcileAddress(
+          contactAddressId = address.contactAddressId,
+          addressType = address.addressType,
+          primaryAddress = address.primaryAddress,
+          property = address.property,
+          street = address.street,
+          area = address.area,
+          addressPhones = getAddressPhoneNumbers(address.contactAddressId, addressPhoneNumbers, phoneNumbers),
+        )
+      },
+      emails = contactEmailRepository.findByContactId(contactId).map { email ->
+        ReconcileEmail(
+          contactEmailId = email.contactEmailId,
+          emailAddress = email.emailAddress,
+        )
+      },
+      identities = contactIdentityRepository.findByContactId(contactId).map { identity ->
+        ReconcileIdentity(
+          contactIdentityId = identity.contactIdentityId,
+          identityType = identity.identityType,
+          identityValue = identity.identityValue,
+          issuingAuthority = identity.issuingAuthority,
+        )
+      },
+      restrictions = contactRestrictionRepository.findByContactId(contactId).map { restriction ->
+        ReconcileRestriction(
+          contactRestrictionId = restriction.contactRestrictionId,
+          restrictionType = restriction.restrictionType,
+          startDate = restriction.startDate,
+          expiryDate = restriction.expiryDate,
+        )
+      },
+      employments = contactEmploymentRepository.findByContactId(contactId).map { employment ->
+        ReconcileEmployment(
+          employmentId = employment.employmentId,
+          organisationId = employment.organisationId,
+          active = employment.active,
+        )
+      },
+      relationships = prisonerContactRepository.findAllByContactId(contactId)
+        .filter { it.currentTerm }
+        .map { relationship ->
+          ReconcileRelationship(
+            prisonerContactId = relationship.prisonerContactId,
+            prisonerNumber = relationship.prisonerNumber,
+            contactType = relationship.relationshipType,
+            relationshipType = relationship.relationshipToPrisoner,
+            nextOfKin = relationship.nextOfKin,
+            emergencyContact = relationship.emergencyContact,
+            approvedVisitor = relationship.approvedVisitor,
+            active = relationship.active,
+            relationshipRestrictions = prisonerContactRestrictionRepository.findAllByPrisonerContactId(relationship.prisonerContactId)
+              .map { restriction ->
+                ReconcileRelationshipRestriction(
+                  prisonerContactRestrictionId = restriction.prisonerContactRestrictionId,
+                  restrictionType = restriction.restrictionType,
+                  startDate = restriction.startDate,
+                  expiryDate = restriction.expiryDate,
+                )
+              },
+          )
+        },
+    )
+  }
+
+  private fun getAddressPhoneNumbers(
+    contactAddressId: Long,
+    addressPhoneNumbers: List<ContactAddressPhoneEntity>,
+    phoneNumbers: List<ContactPhoneEntity>,
+  ): List<ReconcileAddressPhone> = addressPhoneNumbers.filter { it.contactAddressId == contactAddressId }
+    .mapNotNull { addressPhone ->
+      phoneNumbers.find { it.contactPhoneId == addressPhone.contactPhoneId }?.let { phoneNumber ->
+        ReconcileAddressPhone(
+          contactAddressPhoneId = addressPhone.contactAddressPhoneId,
+          phoneType = phoneNumber.phoneType,
+          phoneNumber = phoneNumber.phoneNumber,
+          extNumber = phoneNumber.extNumber,
+        )
+      }
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
@@ -48,6 +48,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactAdd
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactEmailService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactIdentityService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactPhoneService
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactReconciliationService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactRestrictionService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncContactService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync.SyncEmploymentService
@@ -68,6 +69,7 @@ class SyncFacadeTest {
   private val syncPrisonerContactRestrictionService: SyncPrisonerContactRestrictionService = mock()
   private val syncEmploymentService: SyncEmploymentService = mock()
   private val syncAdminService: SyncAdminService = mock()
+  private val syncContactReconciliationService: SyncContactReconciliationService = mock()
   private val outboundEventsService: OutboundEventsService = mock()
 
   private val facade = SyncFacade(
@@ -82,6 +84,7 @@ class SyncFacadeTest {
     syncPrisonerContactRestrictionService,
     syncEmploymentService,
     syncAdminService,
+    syncContactReconciliationService,
     outboundEventsService,
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncReconcileIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncReconcileIntegrationTest.kt
@@ -1,0 +1,130 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.sync
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.PostgresIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactReconcile
+import java.time.LocalDate
+
+@Sql("classpath:reconcile.tests/data-for-reconcile-test.sql")
+@Sql(
+  scripts = ["classpath:reconcile.tests/cleanup-reconcile-test.sql"],
+  executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
+)
+class SyncReconcileIntegrationTest : PostgresIntegrationTestBase() {
+
+  @BeforeEach
+  fun resetEvents() {
+    stubEvents.reset()
+  }
+
+  @Test
+  fun `should return unauthorized if no token provided`() {
+    webTestClient.get()
+      .uri("/sync/contact/1/reconcile")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `should return forbidden if incorrect role`() {
+    webTestClient.get()
+      .uri("/sync/contact/1/reconcile")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `reconcile should return the correct details for the contact`() {
+    val reconcileResponse = webTestClient.get()
+      .uri("/sync/contact/30001/reconcile")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactReconcile::class.java)
+      .returnResult().responseBody!!
+
+    with(reconcileResponse) {
+      assertThat(contactId).isEqualTo(30001)
+      assertThat(firstName).isEqualTo("John")
+      assertThat(lastName).isEqualTo("Ma")
+      assertThat(middleNames).isNullOrEmpty()
+      assertThat(dateOfBirth).isEqualTo(LocalDate.of(2000, 11, 21))
+
+      assertThat(phones).hasSize(2)
+      assertThat(phones).extracting("phoneType", "phoneNumber").containsAll(
+        listOf(
+          Tuple("MOB", "01111 666666"),
+          Tuple("HOME", "01111 777777"),
+        ),
+      )
+
+      assertThat(emails).hasSize(2)
+      assertThat(emails).extracting("emailAddress").contains("mr.last@example.com", "miss.last@example.com")
+
+      assertThat(identities).hasSize(2)
+      assertThat(identities).extracting("identityType").contains("DL", "PASS")
+
+      assertThat(employments).hasSize(1)
+      assertThat(employments).extracting("organisationId").containsOnly(57L)
+
+      assertThat(restrictions).hasSize(2)
+      assertThat(restrictions).extracting("restrictionType").contains("ACC", "BAN")
+
+      assertThat(addresses).hasSize(3)
+
+      assertThat(relationships).hasSize(4)
+      assertThat(relationships).extracting("prisonerNumber", "contactType", "relationshipType")
+        .containsAll(
+          listOf(
+            Tuple("A3333AA", "S", "BRO"),
+            Tuple("A3333AA", "O", "POL"),
+            Tuple("A4444AA", "S", "MOT"),
+            Tuple("A4444AA", "S", "SIS"),
+          ),
+        )
+
+      addresses.map { address ->
+        if (address.contactAddressId == 40003L) {
+          assertThat(address.addressPhones)
+            .extracting("phoneNumber", "extNumber")
+            .containsExactly(Tuple("01111 888888", "+0123"))
+        }
+      }
+
+      relationships.map { rel ->
+        when (rel.prisonerContactId) {
+          40001L -> {
+            assertThat(rel.relationshipRestrictions)
+              .extracting("restrictionType", "startDate", "expiryDate")
+              .containsExactly(
+                Tuple("BAN", LocalDate.of(2025, 1, 1), LocalDate.of(2025, 5, 2)),
+              )
+          }
+
+          40002L -> {
+            assertThat(rel.relationshipRestrictions)
+              .extracting("restrictionType", "startDate", "expiryDate")
+              .containsExactly(
+                Tuple("BAN", LocalDate.of(2025, 1, 2), LocalDate.of(2025, 5, 3)),
+              )
+          }
+
+          else -> null
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/reconcile.tests/cleanup-reconcile-test.sql
+++ b/src/test/resources/reconcile.tests/cleanup-reconcile-test.sql
@@ -1,0 +1,24 @@
+-- Tidy up data after merge tests.
+-- Remove all prisoner_contact_restriction, prisoner_contact, and contact
+-- rows created from the tests
+
+delete from prisoner_contact_restriction where prisoner_contact_id in (
+    select prisoner_contact_id
+    from prisoner_contact pc
+    where pc.contact_id in (30001, 30002)
+);
+
+delete from prisoner_contact where prisoner_contact_id in (
+    select prisoner_contact_id
+    from prisoner_contact pc
+    where pc.contact_id in (30001, 30002)
+);
+
+delete from contact_email where contact_id in (30001, 30002);
+delete from contact_identity where contact_id in (30001, 30002);
+delete from contact_restriction where contact_id in (30001, 30002);
+delete from employment where contact_id in (30001, 30002);
+delete from contact_address_phone where contact_id in (30001, 30002);
+delete from contact_address where contact_id in (30001, 30002);
+delete from contact_phone where contact_id in (30001, 30002);
+delete from contact where contact_id in (30001, 30002);

--- a/src/test/resources/reconcile.tests/data-for-reconcile-test.sql
+++ b/src/test/resources/reconcile.tests/data-for-reconcile-test.sql
@@ -1,0 +1,53 @@
+-- ==================================================================
+-- Test data for prisoner reconciliation integration test
+-- Requires the fixed IDs to tie the data together
+-- (might be better to create these as part of the test using the API)
+-- ==================================================================
+
+insert into contact(contact_id, title, last_name, first_name, date_of_birth, gender, domestic_status, language_code, created_by, interpreter_required, staff_flag)
+values (30001,  'MR', 'Ma', 'John', '2000-11-21', 'M', 'M', 'ENG', 'TIM', false, false),
+       (30002,  'MR', 'Mb', 'Jack', '2000-11-22', 'M', 'D', 'ENG', 'TIM', false, false);
+
+insert into prisoner_contact (prisoner_contact_id, contact_id, prisoner_number, relationship_type, active, relationship_to_prisoner, created_at_prison, created_by, created_time)
+values (40001, 30001, 'A3333AA', 'S', true, 'BRO', 'MDI', 'TIM', current_timestamp),
+       (40002, 30001, 'A3333AA', 'O', true, 'POL', 'MDI', 'TIM', current_timestamp),
+       (40003, 30001, 'A4444AA', 'S', true, 'MOT', 'MDI', 'TIM', current_timestamp),
+       (40004, 30001, 'A4444AA', 'S', true, 'SIS', 'MDI', 'TIM', current_timestamp),
+       (40005, 30002, 'A4444AA', 'O', true, 'POL', 'MDI', 'TIM', current_timestamp);
+
+insert into prisoner_contact_restriction (prisoner_contact_id, restriction_type, start_date, expiry_date, comments, created_by, created_time)
+values (40001, 'BAN', '2025-01-01', '2025-05-02', 'Restriction A', 'TIM', current_timestamp),
+       (40002, 'BAN', '2025-01-02', '2025-05-03', 'Restriction B', 'TIM', current_timestamp);
+
+insert into contact_identity(contact_identity_id, contact_id, identity_type, identity_value, issuing_authority,created_by)
+values (40001, 30001, 'DL', 'LAST-87736799M', 'DVLA', 'TIM'),
+       (40002, 30001, 'PASS', 'PP87878787878', 'UKBORDER', 'TIM');
+
+insert into contact_restriction(contact_id, restriction_type, start_date, expiry_date, comments, created_by)
+values ( 30001, 'ACC', '2000-11-21','2000-11-21','comment', 'TIM'),
+       ( 30001, 'BAN', '2000-11-21','2005-11-21','comment',  'TIM'),
+       ( 30002, 'CCTV', '2000-11-21','2001-11-21','comment','TIM');
+
+insert into contact_email(contact_id, email_address, created_by)
+values (30001, 'mr.last@example.com', 'TIM'),
+       (30001, 'miss.last@example.com',  'TIM'),
+       (30002, 'mrs.last@example.com', 'TIM');
+
+insert into contact_address(contact_address_id, contact_id, address_type, primary_address, flat, property, street, area, city_code, county_code, post_code, country_code, comments, created_by, verified, verified_by, verified_time, mail_flag, start_date, end_date, no_fixed_address)
+values (40001,  30001,  'HOME', true,  null, '24','Acacia Avenue', 'Bunting', '25343', 'S.YORKSHIRE', 'S2 3LK', 'ENG', 'Some comments', 'TIM', false, null, null, false, null, null, false),
+       (40002,  30001,  'WORK', false, 'Flat 1', '42','My Work Place', 'Bunting', '25343', 'S.YORKSHIRE', 'S2 3LK', 'ENG', 'Some comments', 'TIM', true, 'BOB', '2020-01-01 10:30:00', true, '2020-01-02', '2029-03-04', true),
+       (40003,  30001,  'HOME', true,  null, '24','Acacia Avenue', 'Bunting', '25343', 'S.YORKSHIRE', 'S2 3LK', 'ENG', 'Some comments', 'TIM', false, null, null, false, null, null, false),
+       (40004,  30002,  'HOME', true,  null, '24','Acacia Avenue', 'Bunting', '25343', 'S.YORKSHIRE', 'S2 3LK', 'ENG', 'Some comments', 'TIM', false, null, null, false, null, null, false);
+
+insert into contact_phone(contact_phone_id, contact_id, phone_type, phone_number, ext_number, created_by, created_time)
+values (40001, 30001, 'MOB', '01111 666666', null, 'TIM', '2024-10-01 12:00:00'),
+       (40002, 30001, 'HOME', '01111 777777', '+0123', 'JAMES', '2024-10-01 13:00:00'),
+       (40003, 30001, 'HOME', '01111 888888', '+0123', 'JAMES', '2024-10-01 13:00:00'),
+       (40004, 30002, 'MOB', '07878 222222', null, 'TIM', '2024-10-01 12:00:00');
+
+insert into contact_address_phone(contact_address_phone_id, contact_id, contact_address_id, contact_phone_id, created_by)
+values (40001, 30001, 40003, 40003, 'TIM'),
+       (40002, 30002, 40004, 40004, 'TIM');
+
+insert into employment(contact_id, organisation_id, active, created_by, created_time)
+values (30001, 57, true, 'TIM', '2024-10-01 12:00:00');


### PR DESCRIPTION
Syscon had an issue with the length of time it was taking to reconcile data from a single contact's perspective - 5 hours or so for a reconciliation to run, and issues in time-outs/retries when other services were involved.

This was because they were calling the 3 of the API endpoints meant for the UI and other consumers - which included lookups for reference data, prisoner details, organisation names/descriptions and gathering full data for each.

This endpoint goes straight to the data - no other external calls or lookups - and provides the minimal (but core) data which Andy needs to check that NOMIS and our DB are in line.