### PR TITLE
PRC-614: Relationship count API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactRelationshipCountEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactRelationshipCountEntity.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "v_prisoner_contact_count")
+data class PrisonerContactRelationshipCountEntity(
+  @Id
+  val prisonerNumber: String,
+
+  val active: Long,
+
+  val inactive: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactRelationshipCount.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactRelationshipCount.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "A count of a prisoners contact relationships")
+data class PrisonerContactRelationshipCount(
+  @Schema(description = "The number of relationships with active status")
+  val active: Long,
+  @Schema(description = "The number of relationships with inactive status")
+  val inactive: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRelationshipCountRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRelationshipCountRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactRelationshipCountEntity
+
+@Repository
+interface PrisonerContactRelationshipCountRepository : JpaRepository<PrisonerContactRelationshipCountEntity, String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.internal.PrisonerContactSearchParams
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipCount
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.PrisonerContactService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
@@ -31,12 +32,12 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 @AuthApiResponses
 class PrisonerController(private val prisonerContactService: PrisonerContactService) {
 
-  @Operation(summary = "Endpoint to fetch all contacts for a specific prisoner by prisoner number and active status")
+  @Operation(summary = "Fetch contact relationships by prisoner number with the requested filtering applied with pagination")
   @ApiResponses(
     value = [
       ApiResponse(
         responseCode = "200",
-        description = "List of all contacts for the prisoner",
+        description = "A page of matching contact relationships for the prisoner",
       ),
       ApiResponse(
         responseCode = "404",
@@ -100,4 +101,17 @@ class PrisonerController(private val prisonerContactService: PrisonerContactServ
     )
     return prisonerContactService.getAllContacts(params)
   }
+
+  @Operation(summary = "Count of a prisoners contact relationships for their current term by active and inactive status")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Count of prisoner contact relationships",
+      ),
+    ],
+  )
+  @GetMapping(value = ["/{prisonNumber}/contact/count"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
+  fun getContactRelationshipCount(@PathVariable("prisonNumber") @PrisonNumberDoc prisonerNumber: String): PrisonerContactRelationshipCount = prisonerContactService.countContactRelationships(prisonerNumber)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactService.kt
@@ -6,18 +6,22 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactRestrictionCountsEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.internal.PrisonerContactSearchParams
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipCount
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.RestrictionTypeDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.RestrictionsSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.RestrictionsSummary.Companion.NO_RESTRICTIONS
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRelationshipCountRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRestrictionCountsRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactSearchRepository
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 class PrisonerContactService(
   private val prisonerContactSearchRepository: PrisonerContactSearchRepository,
   private val prisonerContactRestrictionCountsRepository: PrisonerContactRestrictionCountsRepository,
   private val prisonerService: PrisonerService,
+  private val prisonerContactRelationshipCountRepository: PrisonerContactRelationshipCountRepository,
 ) {
   fun getAllContacts(params: PrisonerContactSearchParams): PagedModel<PrisonerContactSummary> {
     prisonerService.getPrisoner(params.prisonerNumber)
@@ -37,6 +41,11 @@ class PrisonerContactService(
       },
     )
   }
+
+  fun countContactRelationships(prisonerNumber: String): PrisonerContactRelationshipCount = prisonerContactRelationshipCountRepository.findById(prisonerNumber)
+    .getOrNull()
+    ?.let { PrisonerContactRelationshipCount(it.active, it.inactive) }
+    ?: PrisonerContactRelationshipCount(0, 0)
 
   private fun toRestrictionSummary(restrictionCounts: List<PrisonerContactRestrictionCountsEntity>) = if (restrictionCounts.isEmpty()) {
     NO_RESTRICTIONS

--- a/src/main/resources/migrations/common/R__v_prisoner_contact_count.sql
+++ b/src/main/resources/migrations/common/R__v_prisoner_contact_count.sql
@@ -1,0 +1,16 @@
+--
+-- Creates a view over the prisoner_contact table which counts the number of active and inactive contacts from the
+-- prisoners current term.
+-- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
+DROP VIEW IF EXISTS v_prisoner_contact_count;
+CREATE VIEW v_prisoner_contact_count
+AS
+SELECT prisoner_number,
+       count(*) FILTER (WHERE active)     AS active,
+       count(*) FILTER (WHERE NOT active) AS inactive
+FROM prisoner_contact
+WHERE current_term = true
+GROUP BY prisoner_number;
+
+-- End

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearc
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.EmploymentDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.LinkedPrisonerDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PatchContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipCount
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRestrictionDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRestrictionsResponse
@@ -141,6 +142,16 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
     .isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBody(PrisonerContactSummaryResponse::class.java)
+    .returnResult().responseBody!!
+
+  fun getPrisonerContactRelationshipCount(prisonerNumber: String): PrisonerContactRelationshipCount = webTestClient.get()
+    .uri("/prisoner/$prisonerNumber/contact/count")
+    .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+    .exchange()
+    .expectStatus()
+    .isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody(PrisonerContactRelationshipCount::class.java)
     .returnResult().responseBody!!
 
   fun getReferenceCodes(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRelationshipCountIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRelationshipCountIntegrationTest.kt
@@ -1,0 +1,113 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.openapitools.jackson.nullable.JsonNullable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchRelationshipRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipCount
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
+import kotlin.jvm.optionals.getOrNull
+
+class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationTestBase() {
+  override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
+
+  override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.get()
+    .uri("/prisoner/P001/contact/count")
+
+  @Autowired
+  private lateinit var prisonerContactRepository: PrisonerContactRepository
+
+  @Test
+  fun `should return zeroes if no prisoner found as this will be called from prisoner profile so to make it fast we don't verify the prisoner`() {
+    stubPrisonSearchWithNotFoundResponse("A0000AA")
+    assertThat(testAPIClient.getPrisonerContactRelationshipCount("A0000AA")).isEqualTo(
+      PrisonerContactRelationshipCount(
+        0,
+        0,
+      ),
+    )
+  }
+
+  @Test
+  fun `should count contact relationships for the current term`() {
+    val prisonerNumber = "X0123XX"
+    stubPrisonSearchWithResponse(prisonerNumber)
+
+    val relationship = ContactRelationship(
+      prisonerNumber = prisonerNumber,
+      relationshipTypeCode = "S",
+      relationshipToPrisonerCode = "FRI",
+      isNextOfKin = false,
+      isEmergencyContact = false,
+      isApprovedVisitor = false,
+    )
+    val contactOne = testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "Contact",
+        firstName = "One",
+        createdBy = "USER1",
+      ),
+    )
+    testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "Contact",
+        firstName = "Two",
+        createdBy = "USER1",
+        relationship = ContactRelationship(
+          prisonerNumber = prisonerNumber,
+          relationshipTypeCode = "S",
+          relationshipToPrisonerCode = "MOT",
+          isNextOfKin = false,
+          isEmergencyContact = false,
+          isApprovedVisitor = false,
+        ),
+      ),
+    )
+    val relationshipFromPreviousTerm = testAPIClient.addAContactRelationship(
+      AddContactRelationshipRequest(
+        contactOne.id,
+        relationship.copy(relationshipToPrisonerCode = "FRI"),
+        "USER1",
+      ),
+    )
+    // Make from previous term
+    val entity = prisonerContactRepository.findById(relationshipFromPreviousTerm.prisonerContactId).getOrNull()!!
+    prisonerContactRepository.saveAndFlush(entity.copy(currentTerm = false))
+
+    val relationshipToMakeInactive = testAPIClient.addAContactRelationship(
+      AddContactRelationshipRequest(
+        contactOne.id,
+        relationship.copy(relationshipToPrisonerCode = "GIF"),
+        "USER1",
+      ),
+    )
+    testAPIClient.updateRelationship(
+      relationshipToMakeInactive.prisonerContactId,
+      PatchRelationshipRequest(
+        isRelationshipActive = JsonNullable.of(false),
+        updatedBy = "USER1",
+      ),
+    )
+
+    testAPIClient.addAContactRelationship(
+      AddContactRelationshipRequest(
+        contactOne.id,
+        relationship.copy(relationshipToPrisonerCode = "WIFE"),
+        "USER1",
+      ),
+    )
+
+    assertThat(testAPIClient.getPrisonerContactRelationshipCount(prisonerNumber)).isEqualTo(
+      PrisonerContactRelationshipCount(
+        2,
+        1,
+      ),
+    )
+  }
+}


### PR DESCRIPTION
New view to count prisoner contacts by active and inactive status for their current term with an API to match. This is for DPS connects new widget to link into contacts.

Tested the view in dev and it's very fast. It does not bother to verify that the prisoner exists and returns 0 by default.