### PR TITLE
PRC-614: Change relationship count API to relationship type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactRelationshipCountEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactRelationshipCountEntity.kt
@@ -10,7 +10,7 @@ data class PrisonerContactRelationshipCountEntity(
   @Id
   val prisonerNumber: String,
 
-  val active: Long,
+  val social: Long,
 
-  val inactive: Long,
+  val official: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactRelationshipCount.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactRelationshipCount.kt
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "A count of a prisoners contact relationships")
 data class PrisonerContactRelationshipCount(
-  @Schema(description = "The number of relationships with active status")
-  val active: Long,
-  @Schema(description = "The number of relationships with inactive status")
-  val inactive: Long,
+  @Schema(description = "The number of active social relationships")
+  val social: Long,
+  @Schema(description = "The number of active official relationships")
+  val official: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
@@ -102,12 +102,12 @@ class PrisonerController(private val prisonerContactService: PrisonerContactServ
     return prisonerContactService.getAllContacts(params)
   }
 
-  @Operation(summary = "Count of a prisoners contact relationships for their current term by active and inactive status")
+  @Operation(summary = "Count of a prisoner's active contact relationships for their current term by relationship type")
   @ApiResponses(
     value = [
       ApiResponse(
         responseCode = "200",
-        description = "Count of prisoner contact relationships",
+        description = "Count of active prisoner contact relationships",
       ),
     ],
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactService.kt
@@ -44,7 +44,7 @@ class PrisonerContactService(
 
   fun countContactRelationships(prisonerNumber: String): PrisonerContactRelationshipCount = prisonerContactRelationshipCountRepository.findById(prisonerNumber)
     .getOrNull()
-    ?.let { PrisonerContactRelationshipCount(it.active, it.inactive) }
+    ?.let { PrisonerContactRelationshipCount(it.social, it.official) }
     ?: PrisonerContactRelationshipCount(0, 0)
 
   private fun toRestrictionSummary(restrictionCounts: List<PrisonerContactRestrictionCountsEntity>) = if (restrictionCounts.isEmpty()) {

--- a/src/main/resources/migrations/common/R__v_prisoner_contact_count.sql
+++ b/src/main/resources/migrations/common/R__v_prisoner_contact_count.sql
@@ -1,5 +1,5 @@
 --
--- Creates a view over the prisoner_contact table which counts the number of active and inactive contacts from the
+-- Creates a view over the prisoner_contact table which counts the number of active social and and official contacts from the
 -- prisoners current term.
 -- Note: the view is only dropped if the checksum of this migration changes
 -- Internal version to bump if you need to force recreation: 1
@@ -7,8 +7,8 @@ DROP VIEW IF EXISTS v_prisoner_contact_count;
 CREATE VIEW v_prisoner_contact_count
 AS
 SELECT prisoner_number,
-       count(*) FILTER (WHERE active)     AS active,
-       count(*) FILTER (WHERE NOT active) AS inactive
+       count(*) FILTER (WHERE active AND relationship_type = 'S') AS social,
+       count(*) FILTER (WHERE active AND relationship_type = 'O') AS official
 FROM prisoner_contact
 WHERE current_term = true
 GROUP BY prisoner_number;


### PR DESCRIPTION
What was actually required was not active/inactive but split on social/official. To keep the view fast I've just removed the active/inactive rather than including lots of metrics no-one cares about.