### PR TITLE
PRC-651: Use user token instead of request field

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/manage/users/ManageUsersApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/manage/users/ManageUsersApiClient.kt
@@ -14,11 +14,11 @@ class ManageUsersApiClient(private val manageUsersApiWebClient: WebClient) {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getUserByUsername(username: String): User? = manageUsersApiWebClient
+  fun getUserByUsername(username: String): UserDetails? = manageUsersApiWebClient
     .get()
     .uri("/users/{username}", username)
     .retrieve()
-    .bodyToMono(User::class.java)
+    .bodyToMono(UserDetails::class.java)
     .onErrorResume(WebClientResponseException.NotFound::class.java) {
       log.debug("Couldn't find user with username: {}", username)
       Mono.empty()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/manage/users/UserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/manage/users/UserDetails.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users
 
-data class User(
+data class UserDetails(
   val username: String,
   val name: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/User.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/User.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.config
+
+data class User(val username: String) {
+  companion object {
+    val SYS_USER = User("SYS")
+    const val REQUEST_ATTRIBUTE = "user"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/UserRequestContextConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/UserRequestContextConfiguration.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.config
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import uk.gov.justice.hmpps.kotlin.auth.AuthAwareAuthenticationToken
+
+@Configuration
+class UserRequestContextConfiguration(private val userRequestContextInterceptor: UserRequestContextInterceptor) : WebMvcConfigurer {
+  override fun addInterceptors(registry: InterceptorRegistry) {
+    registry.addInterceptor(userRequestContextInterceptor)
+      .addPathPatterns("/contact/**")
+      .addPathPatterns("/prisoner/**")
+      .addPathPatterns("/prisoner-contact/**")
+  }
+}
+
+@Configuration
+class UserRequestContextInterceptor : HandlerInterceptor {
+  override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+    val username = authentication().name?.trim()
+    // Require a valid username for all modifying methods
+    if (username === null && request.method in arrayOf("POST", "PUT", "PATCH", "DELETE")) {
+      throw AccessDeniedException("Username is missing from token")
+    }
+    val user = username?.let { User(username = it) } ?: User.SYS_USER
+    request.setAttribute(User.REQUEST_ATTRIBUTE, user)
+    return true
+  }
+
+  private fun authentication(): AuthAwareAuthenticationToken = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken?
+    ?: throw AccessDeniedException("User is not authenticated")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
@@ -4,6 +4,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactSearchRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
@@ -30,12 +31,13 @@ class ContactFacade(
     private val logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun createContact(request: CreateContactRequest): ContactCreationResult = contactService.createContact(request)
+  fun createContact(request: CreateContactRequest, user: User): ContactCreationResult = contactService.createContact(request, user)
     .also { creationResult ->
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_CREATED,
         identifier = creationResult.createdContact.id,
         contactId = creationResult.createdContact.id,
+        user = user,
       )
 
       creationResult.createdRelationship?.let {
@@ -44,6 +46,7 @@ class ContactFacade(
           identifier = it.prisonerContactId,
           contactId = creationResult.createdContact.id,
           noms = request.relationship?.prisonerNumber.let { request.relationship!!.prisonerNumber },
+          user = user,
         )
       }
 
@@ -52,6 +55,7 @@ class ContactFacade(
           outboundEvent = OutboundEvent.CONTACT_IDENTITY_CREATED,
           identifier = it.contactIdentityId,
           contactId = creationResult.createdContact.id,
+          user = user,
         )
       }
 
@@ -60,6 +64,7 @@ class ContactFacade(
           outboundEvent = OutboundEvent.CONTACT_ADDRESS_CREATED,
           identifier = createdAddress.contactAddressId,
           contactId = creationResult.createdContact.id,
+          user = user,
         )
         createdAddress.phoneNumbers.forEach {
           outboundEventsService.send(
@@ -67,6 +72,7 @@ class ContactFacade(
             identifier = it.contactAddressPhoneId,
             secondIdentifier = it.contactAddressId,
             contactId = creationResult.createdContact.id,
+            user = user,
           )
         }
       }
@@ -76,6 +82,7 @@ class ContactFacade(
           outboundEvent = OutboundEvent.CONTACT_PHONE_CREATED,
           identifier = it.contactPhoneId,
           contactId = creationResult.createdContact.id,
+          user = user,
         )
       }
 
@@ -84,6 +91,7 @@ class ContactFacade(
           outboundEvent = OutboundEvent.CONTACT_EMAIL_CREATED,
           identifier = it.contactEmailId,
           contactId = creationResult.createdContact.id,
+          user = user,
         )
       }
 
@@ -92,28 +100,31 @@ class ContactFacade(
           outboundEvent = OutboundEvent.EMPLOYMENT_CREATED,
           identifier = it.employmentId,
           contactId = creationResult.createdContact.id,
+          user = user,
         )
       }
     }
 
-  fun addContactRelationship(request: AddContactRelationshipRequest): PrisonerContactRelationshipDetails {
-    val createdRelationship = contactService.addContactRelationship(request)
+  fun addContactRelationship(request: AddContactRelationshipRequest, user: User): PrisonerContactRelationshipDetails {
+    val createdRelationship = contactService.addContactRelationship(request, user)
     outboundEventsService.send(
       outboundEvent = OutboundEvent.PRISONER_CONTACT_CREATED,
       identifier = createdRelationship.prisonerContactId,
       contactId = createdRelationship.contactId,
       noms = request.relationship.prisonerNumber,
+      user = user,
     )
     return createdRelationship
   }
 
-  fun patch(id: Long, request: PatchContactRequest): PatchContactResponse = contactPatchService.patch(id, request)
+  fun patch(id: Long, request: PatchContactRequest, user: User): PatchContactResponse = contactPatchService.patch(id, request, user)
     .also {
       logger.info("Send patch domain event to {} {} ", OutboundEvent.CONTACT_UPDATED, id)
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_UPDATED,
         identifier = id,
         contactId = id,
+        user = user,
       )
     }
 
@@ -123,8 +134,8 @@ class ContactFacade(
 
   fun searchContacts(pageable: Pageable, request: ContactSearchRequest): PagedModel<ContactSearchResultItem> = PagedModel(contactService.searchContacts(pageable, request))
 
-  fun patchRelationship(prisonerContactId: Long, request: PatchRelationshipRequest) {
-    contactService.updateContactRelationship(prisonerContactId, request)
+  fun patchRelationship(prisonerContactId: Long, request: PatchRelationshipRequest, user: User) {
+    contactService.updateContactRelationship(prisonerContactId, request, user)
       .also {
         logger.info("Send patch relationship domain event to {} {} ", OutboundEvent.PRISONER_CONTACT_UPDATED, it.contactId)
         outboundEventsService.send(
@@ -132,6 +143,7 @@ class ContactFacade(
           identifier = it.prisonerContactId,
           contactId = it.contactId,
           noms = it.prisonerNumber,
+          user = user,
         )
       }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactsServiceMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactsServiceMappers.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping
 
 import org.springframework.data.domain.Page
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactWithAddressEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntity
@@ -57,7 +58,7 @@ fun ContactRelationship.toEntity(
   currentTerm = true,
 )
 
-fun CreateContactRequest.toModel() = ContactEntity(
+fun CreateContactRequest.toModel(user: User) = ContactEntity(
   contactId = null,
   title = this.titleCode,
   firstName = this.firstName,
@@ -65,7 +66,7 @@ fun CreateContactRequest.toModel() = ContactEntity(
   middleNames = this.middleNames,
   dateOfBirth = this.dateOfBirth,
   deceasedDate = null,
-  createdBy = this.createdBy,
+  createdBy = user.username,
   createdTime = LocalDateTime.now(),
   staffFlag = this.isStaff,
   remitterFlag = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/AddContactRelationshipRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/AddContactRelationshipRequest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
-import jakarta.validation.constraints.Size
 
 data class AddContactRelationshipRequest(
   @Schema(description = "The id of the contact this relationship is for", example = "123456")
@@ -11,8 +10,4 @@ data class AddContactRelationshipRequest(
   @Schema(description = "A description of the contacts relationship to a prisoner", exampleClasses = [ContactRelationship::class])
   @field:Valid
   val relationship: ContactRelationship,
-
-  @Schema(description = "The id of the user creating the contact", example = "JD000001", maxLength = 100)
-  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
-  val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
@@ -86,7 +86,11 @@ data class CreateContactRequest(
   @field:Size(max = 12, message = "genderCode must be <= 12 characters")
   val genderCode: String? = null,
 
-  @Schema(description = "A description of the relationship if the contact should be linked to a prisoner", nullable = true, exampleClasses = [ContactRelationship::class])
+  @Schema(
+    description = "A description of the relationship if the contact should be linked to a prisoner",
+    nullable = true,
+    exampleClasses = [ContactRelationship::class],
+  )
   @field:Valid
   val relationship: ContactRelationship? = null,
 
@@ -109,8 +113,4 @@ data class CreateContactRequest(
   @Schema(description = "Employments", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @field:Valid
   val employments: List<Employment> = emptyList(),
-
-  @Schema(description = "The id of the user creating the contact", example = "JD000001", maxLength = 100)
-  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
-  val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/PatchContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/PatchContactRequest.kt
@@ -54,6 +54,4 @@ data class PatchContactRequest(
   @Schema(description = "The date the contact deceased, if known", example = "1980-01-01", type = "string", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   var deceasedDate: JsonNullable<LocalDate?> = JsonNullable.undefined(),
 
-  @Schema(description = "The id of the user who updated the contact", example = "JD000001", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
-  val updatedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/PatchRelationshipRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/PatchRelationshipRequest.kt
@@ -34,8 +34,4 @@ data class PatchRelationshipRequest(
   @field:Size(max = 240, message = "comments must be <= 240 characters")
   val comments: JsonNullable<String?> = JsonNullable.undefined(),
 
-  @Schema(description = "The id of the user who updated the contact", example = "JD000001", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
-  @field:Size(max = 100, message = "updatedBy must be <= 100 characters")
-  val updatedBy: String,
-
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -22,9 +22,11 @@ import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactSearchRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
@@ -86,8 +88,8 @@ class ContactController(
     ],
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__RW')")
-  fun createContact(@Valid @RequestBody createContactRequest: CreateContactRequest): ResponseEntity<Any> {
-    val created = contactFacade.createContact(createContactRequest)
+  fun createContact(@Valid @RequestBody createContactRequest: CreateContactRequest, @RequestAttribute user: User): ResponseEntity<Any> {
+    val created = contactFacade.createContact(createContactRequest, user)
     return ResponseEntity
       .created(URI.create("/contact/${created.createdContact.id}"))
       .body(created)
@@ -240,5 +242,6 @@ class ContactController(
       example = "123456",
     ) contactId: Long,
     @Valid @RequestBody patchContactRequest: PatchContactRequest,
-  ) = contactFacade.patch(contactId, patchContactRequest)
+    @RequestAttribute user: User,
+  ) = contactFacade.patch(contactId, patchContactRequest, user)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
@@ -17,10 +17,12 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.PrisonerContactRestrictionsFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
@@ -112,8 +114,9 @@ class PrisonerContactController(
       example = "123456",
     ) prisonerContactId: Long,
     @Valid @RequestBody relationshipRequest: PatchRelationshipRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    contactFacade.patchRelationship(prisonerContactId, relationshipRequest)
+    contactFacade.patchRelationship(prisonerContactId, relationshipRequest, user)
     return ResponseEntity.noContent().build()
   }
 
@@ -151,7 +154,8 @@ class PrisonerContactController(
   @ResponseStatus(HttpStatus.CREATED)
   fun addContactRelationship(
     @Valid @RequestBody relationshipRequest: AddContactRelationshipRequest,
-  ): PrisonerContactRelationshipDetails = contactFacade.addContactRelationship(relationshipRequest)
+    @RequestAttribute user: User,
+  ): PrisonerContactRelationshipDetails = contactFacade.addContactRelationship(relationshipRequest, user)
 
   @Operation(
     summary = "Get the prisoner contact restrictions",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ManageUsersService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ManageUsersService.kt
@@ -2,9 +2,9 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.ManageUsersApiClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 
 @Service
 class ManageUsersService(private val manageUsersClient: ManageUsersApiClient) {
-  fun getUserByUsername(username: String): User? = manageUsersClient.getUserByUsername(username)
+  fun getUserByUsername(username: String): UserDetails? = manageUsersClient.getUserByUsername(username)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -313,14 +313,14 @@ data class OutboundHMPPSDomainEvent(
  * The additional information is mapped into JSON by the ObjectMapper as part of the event body.
  */
 
-data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
-data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class EmploymentInfo(val employmentId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class PrisonerDomesticStatus(val domesticStatusId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 
 @Service
 class OutboundEventsService(
@@ -21,6 +22,7 @@ class OutboundEventsService(
     noms: String = "",
     source: Source = Source.DPS,
     secondIdentifier: Long? = 0,
+    user: User = User.SYS_USER,
   ) {
     if (featureSwitches.isEnabled(outboundEvent)) {
       log.info("Sending outbound event $outboundEvent with source $source for identifier $identifier (contactId $contactId, noms $noms, secondIdentifier ${secondIdentifier ?: "N/A"})")
@@ -32,7 +34,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactInfo(identifier, source),
+            ContactInfo(identifier, source, user.username),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }
@@ -109,7 +111,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            PrisonerContactInfo(identifier, source),
+            PrisonerContactInfo(identifier, source, user.username),
             contactId?.let { PersonReference(dpsContactId = it, nomsNumber = noms) },
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/prisonersearch/ManageUsersApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/prisonersearch/ManageUsersApiClientTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.ManageUsersApiClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.wiremock.ManageUsersApiMockServer
 
 class ManageUsersApiClientTest {
@@ -15,9 +15,9 @@ class ManageUsersApiClientTest {
 
   @Test
   fun `should get user`() {
-    server.stubGetUser(User("USER1", "User One"))
+    server.stubGetUser(UserDetails("USER1", "User One"))
 
-    assertThat(client.getUserByUsername("USER1")).isEqualTo(User("USER1", "User One"))
+    assertThat(client.getUserByUsername("USER1")).isEqualTo(UserDetails("USER1", "User One"))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacadeTest.kt
@@ -37,7 +37,7 @@ class ContactAddressFacadeTest {
     val response = contactAddressResponse(contactAddressId, contactId, phoneNumberIds = listOf(addressSpecificPhoneId1, addressSpecificPhoneId2))
 
     whenever(addressService.create(any(), any())).thenReturn(CreateAddressResponse(response, emptySet()))
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.create(contactId, request)
 
@@ -72,7 +72,7 @@ class ContactAddressFacadeTest {
     val request = createContactAddressRequest()
 
     whenever(addressService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.create(contactId, request)
@@ -81,7 +81,7 @@ class ContactAddressFacadeTest {
     assertThat(exception.message).isEqualTo(expectedException.message)
 
     verify(addressService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -90,7 +90,7 @@ class ContactAddressFacadeTest {
     val request = updateContactAddressRequest()
 
     whenever(addressService.update(any(), any(), any())).thenReturn(UpdateAddressResponse(response, emptySet()))
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.update(
       contactId = contactId,
@@ -114,7 +114,7 @@ class ContactAddressFacadeTest {
     val request = updateContactAddressRequest()
 
     whenever(addressService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.update(contactId, contactAddressId, request)
@@ -122,7 +122,7 @@ class ContactAddressFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(addressService).update(contactId, contactAddressId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -131,7 +131,7 @@ class ContactAddressFacadeTest {
     val request = patchContactAddressRequest()
 
     whenever(addressService.patch(any(), any(), any())).thenReturn(UpdateAddressResponse(response, emptySet()))
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.patch(
       contactId = contactId,
@@ -155,7 +155,7 @@ class ContactAddressFacadeTest {
     val request = patchContactAddressRequest()
 
     whenever(addressService.patch(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.patch(contactId, contactAddressId, request)
@@ -163,7 +163,7 @@ class ContactAddressFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(addressService).patch(contactId, contactAddressId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -175,7 +175,7 @@ class ContactAddressFacadeTest {
 
     assertThat(result).isEqualTo(response)
     verify(addressService).get(contactId, contactAddressId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -189,14 +189,14 @@ class ContactAddressFacadeTest {
 
     assertThat(exception.message).isEqualTo(expectedException.message)
     verify(addressService).get(contactId, contactAddressId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     val response = contactAddressResponse(contactAddressId, contactId)
     whenever(addressService.delete(any(), any())).thenReturn(response)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactAddressId)
 
@@ -208,7 +208,7 @@ class ContactAddressFacadeTest {
   fun `should not send event if delete throws exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(addressService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactAddressId)
@@ -216,6 +216,6 @@ class ContactAddressFacadeTest {
 
     assertThat(exception.message).isEqualTo(expectedException.message)
     verify(addressService).delete(contactId, contactAddressId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacadeTest.kt
@@ -36,7 +36,7 @@ class ContactAddressPhoneFacadeTest {
     val response = createContactAddressPhoneDetails(contactAddressPhoneId, contactAddressId, contactPhoneId, contactId)
 
     whenever(addressPhoneService.create(any(), any(), any())).thenReturn(response)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.create(contactId, contactAddressId, request)
 
@@ -57,7 +57,7 @@ class ContactAddressPhoneFacadeTest {
     val request = createContactAddressPhoneRequest(contactAddressId)
 
     whenever(addressPhoneService.create(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.create(contactId, contactAddressId, request)
@@ -66,7 +66,7 @@ class ContactAddressPhoneFacadeTest {
     assertThat(exception.message).isEqualTo(expectedException.message)
 
     verify(addressPhoneService).create(contactId, contactAddressId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -93,7 +93,7 @@ class ContactAddressPhoneFacadeTest {
     )
 
     whenever(addressPhoneService.createMultiple(any(), any(), any())).thenReturn(response)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.createMultiple(contactId, contactAddressId, request)
 
@@ -121,7 +121,7 @@ class ContactAddressPhoneFacadeTest {
     val request = updateContactAddressPhoneRequest()
 
     whenever(addressPhoneService.update(any(), any(), any())).thenReturn(response)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.update(
       contactId = contactId,
@@ -146,7 +146,7 @@ class ContactAddressPhoneFacadeTest {
     val request = updateContactAddressPhoneRequest()
 
     whenever(addressPhoneService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.update(contactId, contactAddressPhoneId, request)
@@ -154,7 +154,7 @@ class ContactAddressPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(addressPhoneService).update(contactId, contactAddressPhoneId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -166,7 +166,7 @@ class ContactAddressPhoneFacadeTest {
 
     assertThat(result).isEqualTo(response)
     verify(addressPhoneService).get(contactId, contactAddressPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -180,14 +180,14 @@ class ContactAddressPhoneFacadeTest {
 
     assertThat(exception.message).isEqualTo(expectedException.message)
     verify(addressPhoneService).get(contactId, contactAddressPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     val response = createContactAddressPhoneDetails(contactAddressPhoneId, contactAddressId, contactPhoneId, contactId)
     whenever(addressPhoneService.delete(any(), any())).thenReturn(response)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactAddressPhoneId)
 
@@ -205,7 +205,7 @@ class ContactAddressPhoneFacadeTest {
   fun `should not send event if delete throws exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(addressPhoneService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactAddressPhoneId)
@@ -213,6 +213,6 @@ class ContactAddressPhoneFacadeTest {
 
     assertThat(exception.message).isEqualTo(expectedException.message)
     verify(addressPhoneService).delete(contactId, contactAddressPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacadeTest.kt
@@ -30,7 +30,7 @@ class ContactEmailFacadeTest {
   @Test
   fun `should send event if create success`() {
     whenever(emailService.create(any(), any())).thenReturn(contactEmailDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = CreateEmailRequest(
       emailAddress = "test@example.com",
       createdBy = "created",
@@ -52,7 +52,7 @@ class ContactEmailFacadeTest {
   fun `should not send event if create throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(emailService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = CreateEmailRequest(
       emailAddress = "test@example.com",
       createdBy = "created",
@@ -64,13 +64,13 @@ class ContactEmailFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(emailService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if update success`() {
     whenever(emailService.update(any(), any(), any())).thenReturn(contactEmailDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = UpdateEmailRequest(
       emailAddress = "test@example.com",
       updatedBy = "updated",
@@ -92,7 +92,7 @@ class ContactEmailFacadeTest {
   fun `should not send event if update throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(emailService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = UpdateEmailRequest(
       emailAddress = "test@example.com",
       updatedBy = "updated",
@@ -104,7 +104,7 @@ class ContactEmailFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(emailService).update(contactId, contactEmailId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -115,7 +115,7 @@ class ContactEmailFacadeTest {
 
     assertThat(result).isEqualTo(contactEmailDetails)
     verify(emailService).get(contactId, contactEmailId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -128,13 +128,13 @@ class ContactEmailFacadeTest {
 
     assertThat(exception.message).isEqualTo("Contact email with id (99) not found for contact (11)")
     verify(emailService).get(contactId, contactEmailId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     whenever(emailService.delete(any(), any())).then {}
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactEmailId)
 
@@ -146,7 +146,7 @@ class ContactEmailFacadeTest {
   fun `should not send event if delete throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(emailService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactEmailId)
@@ -154,6 +154,6 @@ class ContactEmailFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(emailService).delete(contactId, contactEmailId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactGlobalRestrictionsFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactGlobalRestrictionsFacadeTest.kt
@@ -86,7 +86,7 @@ class ContactGlobalRestrictionsFacadeTest {
 
     assertThat(result).isEqualTo(expected)
     verify(restrictionService).createContactGlobalRestriction(contactId, request)
-    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -148,6 +148,6 @@ class ContactGlobalRestrictionsFacadeTest {
 
     assertThat(result).isEqualTo(expected)
     verify(restrictionService).updateContactGlobalRestriction(contactId, contactRestrictionId, request)
-    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacadeTest.kt
@@ -32,7 +32,7 @@ class ContactIdentityFacadeTest {
   @Test
   fun `should send event if create success`() {
     whenever(identityService.create(any(), any())).thenReturn(contactIdentityDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = CreateIdentityRequest(
       identityType = "DL",
       identityValue = "DL123456789",
@@ -55,7 +55,7 @@ class ContactIdentityFacadeTest {
   fun `should not send event if create throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(identityService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = CreateIdentityRequest(
       identityType = "DL",
       identityValue = "DL123456789",
@@ -68,7 +68,7 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(identityService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -77,7 +77,7 @@ class ContactIdentityFacadeTest {
     val second = createContactIdentityDetails(id = 8888, contactId = contactId)
 
     whenever(identityService.createMultiple(any(), any())).thenReturn(listOf(first, second))
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = CreateMultipleIdentitiesRequest(
       identities = listOf(
         IdentityDocument(
@@ -115,7 +115,7 @@ class ContactIdentityFacadeTest {
   @Test
   fun `should send event if update success`() {
     whenever(identityService.update(any(), any(), any())).thenReturn(contactIdentityDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = UpdateIdentityRequest(
       identityType = "PASS",
       identityValue = "P978654312",
@@ -138,7 +138,7 @@ class ContactIdentityFacadeTest {
   fun `should not send event if update throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(identityService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = UpdateIdentityRequest(
       identityType = "PASS",
       identityValue = "P978654312",
@@ -151,7 +151,7 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(identityService).update(contactId, contactIdentityId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -162,7 +162,7 @@ class ContactIdentityFacadeTest {
 
     assertThat(result).isEqualTo(contactIdentityDetails)
     verify(identityService).get(contactId, contactIdentityId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -175,13 +175,13 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception.message).isEqualTo("Contact identity with id (99) not found for contact (11)")
     verify(identityService).get(contactId, contactIdentityId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     whenever(identityService.delete(any(), any())).then {}
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactIdentityId)
 
@@ -198,7 +198,7 @@ class ContactIdentityFacadeTest {
   fun `should not send event if delete throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(identityService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactIdentityId)
@@ -206,6 +206,6 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(identityService).delete(contactId, contactIdentityId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
@@ -31,7 +31,7 @@ class ContactPhoneFacadeTest {
   @Test
   fun `should send event if create success`() {
     whenever(phoneService.create(any(), any())).thenReturn(contactPhoneDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = CreatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -54,7 +54,7 @@ class ContactPhoneFacadeTest {
   fun `should not send event if create throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(phoneService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = CreatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -67,7 +67,7 @@ class ContactPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(phoneService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -77,7 +77,7 @@ class ContactPhoneFacadeTest {
       contactPhoneDetails.copy(contactPhoneId = 123456789),
     )
     whenever(phoneService.createMultiple(any(), any(), any())).thenReturn(expectedCreated)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = CreateMultiplePhoneNumbersRequest(
       listOf(
         PhoneNumber(
@@ -113,7 +113,7 @@ class ContactPhoneFacadeTest {
   @Test
   fun `should send event if update success`() {
     whenever(phoneService.update(any(), any(), any())).thenReturn(contactPhoneDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = UpdatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -136,7 +136,7 @@ class ContactPhoneFacadeTest {
   fun `should not send event if update throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(phoneService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
     val request = UpdatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -149,13 +149,13 @@ class ContactPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(phoneService).update(contactId, contactPhoneId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     whenever(phoneService.delete(any(), any())).then {}
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactPhoneId)
 
@@ -172,7 +172,7 @@ class ContactPhoneFacadeTest {
   fun `should not send event if delete throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(phoneService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactPhoneId)
@@ -180,7 +180,7 @@ class ContactPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(phoneService).delete(contactId, contactPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -191,6 +191,6 @@ class ContactPhoneFacadeTest {
 
     assertThat(result).isEqualTo(contactPhoneDetails)
     verify(phoneService).get(contactId, contactPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerContactRestrictionsFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerContactRestrictionsFacadeTest.kt
@@ -90,7 +90,7 @@ class PrisonerContactRestrictionsFacadeTest {
 
     assertThat(result).isEqualTo(expected)
     verify(restrictionService).createPrisonerContactRestriction(prisonerContactId, request)
-    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -154,6 +154,6 @@ class PrisonerContactRestrictionsFacadeTest {
 
     assertThat(result).isEqualTo(expected)
     verify(restrictionService).updatePrisonerContactRestriction(prisonerContactId, prisonerContactRestrictionId, request)
-    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerDomesticStatusFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerDomesticStatusFacadeTest.kt
@@ -155,7 +155,7 @@ class PrisonerDomesticStatusFacadeTest {
       }.message isEqualTo "Prisoner's domestic status could not updated!"
 
       verify(prisonerDomesticStatusService).createOrUpdateDomesticStatus(prisonerNumber, request)
-      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
+      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerNumberOfChildrenFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerNumberOfChildrenFacadeTest.kt
@@ -157,7 +157,7 @@ class PrisonerNumberOfChildrenFacadeTest {
       }.message isEqualTo "Prisoner's number of children could not updated!"
 
       verify(prisonerNumberOfChildrenService).createOrUpdateNumberOfChildren(prisonerNumber, request)
-      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
+      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
@@ -96,7 +96,7 @@ class SyncFacadeTest {
       val response = contactResponse(1L)
 
       whenever(syncContactService.createContact(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContact(request)
 
@@ -117,7 +117,7 @@ class SyncFacadeTest {
       val expectedException = RuntimeException("Bang!")
 
       whenever(syncContactService.createContact(any())).thenThrow(expectedException)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val exception = assertThrows<RuntimeException> {
         facade.createContact(request)
@@ -126,7 +126,7 @@ class SyncFacadeTest {
       assertThat(exception.message).isEqualTo(expectedException.message)
 
       verify(syncContactService).createContact(request)
-      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
+      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
     }
 
     @Test
@@ -135,7 +135,7 @@ class SyncFacadeTest {
       val response = contactResponse(3L)
 
       whenever(syncContactService.updateContact(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContact(3L, request)
 
@@ -157,7 +157,7 @@ class SyncFacadeTest {
       val expectedException = RuntimeException("Bang!")
 
       whenever(syncContactService.updateContact(any(), any())).thenThrow(expectedException)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val exception = assertThrows<RuntimeException> {
         facade.updateContact(4L, request)
@@ -166,13 +166,13 @@ class SyncFacadeTest {
       assertThat(exception.message).isEqualTo(expectedException.message)
 
       verify(syncContactService).updateContact(4L, request)
-      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
+      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
     }
 
     @Test
     fun `should send domain event on contact delete success`() {
       whenever(syncContactService.deleteContact(any())).then {}
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       facade.deleteContact(1L)
 
@@ -191,7 +191,7 @@ class SyncFacadeTest {
       val expectedException = RuntimeException("Bang!")
 
       whenever(syncContactService.deleteContact(any())).thenThrow(expectedException)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val exception = assertThrows<RuntimeException> {
         facade.deleteContact(1L)
@@ -199,7 +199,7 @@ class SyncFacadeTest {
 
       assertThat(exception.message).isEqualTo(expectedException.message)
       verify(syncContactService).deleteContact(1L)
-      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
+      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
     }
 
     private fun createSyncContactRequest(personId: Long) = SyncCreateContactRequest(
@@ -236,7 +236,7 @@ class SyncFacadeTest {
       val response = contactPhoneResponse(contactId = 1L, contactPhoneId = 1L)
 
       whenever(syncContactPhoneService.createContactPhone(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactPhone(request)
 
@@ -255,7 +255,7 @@ class SyncFacadeTest {
       val response = contactPhoneResponse(contactId = 2L, contactPhoneId = 3L)
 
       whenever(syncContactPhoneService.updateContactPhone(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactPhone(3L, request)
 
@@ -273,7 +273,7 @@ class SyncFacadeTest {
       val response = contactPhoneResponse(contactId = 3L, contactPhoneId = 4L)
 
       whenever(syncContactPhoneService.deleteContactPhone(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactPhone(4L)
 
@@ -323,7 +323,7 @@ class SyncFacadeTest {
       val response = contactEmailResponse(contactId = 1L, contactEmailId = 1L)
 
       whenever(syncContactEmailService.createContactEmail(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactEmail(request)
 
@@ -342,7 +342,7 @@ class SyncFacadeTest {
       val response = contactEmailResponse(contactId = 2L, contactEmailId = 3L)
 
       whenever(syncContactEmailService.updateContactEmail(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactEmail(3L, request)
 
@@ -360,7 +360,7 @@ class SyncFacadeTest {
       val response = contactEmailResponse(contactId = 3L, contactEmailId = 4L)
 
       whenever(syncContactEmailService.deleteContactEmail(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactEmail(4L)
 
@@ -406,7 +406,7 @@ class SyncFacadeTest {
       val response = contactIdentityResponse(contactId = 1L, contactIdentityId = 1L)
 
       whenever(syncContactIdentityService.createContactIdentity(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactIdentity(request)
 
@@ -425,7 +425,7 @@ class SyncFacadeTest {
       val response = contactIdentityResponse(contactId = 2L, contactIdentityId = 3L)
 
       whenever(syncContactIdentityService.updateContactIdentity(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactIdentity(3L, request)
 
@@ -443,7 +443,7 @@ class SyncFacadeTest {
       val response = contactIdentityResponse(contactId = 3L, contactIdentityId = 4L)
 
       whenever(syncContactIdentityService.deleteContactIdentity(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactIdentity(4L)
 
@@ -495,7 +495,7 @@ class SyncFacadeTest {
       val response = contactRestrictionResponse(contactId = 1L, contactRestrictionId = 1L)
 
       whenever(syncContactRestrictionService.createContactRestriction(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactRestriction(request)
 
@@ -514,7 +514,7 @@ class SyncFacadeTest {
       val response = contactRestrictionResponse(contactId = 2L, contactRestrictionId = 3L)
 
       whenever(syncContactRestrictionService.updateContactRestriction(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactRestriction(3L, request)
 
@@ -532,7 +532,7 @@ class SyncFacadeTest {
       val response = contactRestrictionResponse(contactId = 3L, contactRestrictionId = 4L)
 
       whenever(syncContactRestrictionService.deleteContactRestriction(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactRestriction(4L)
 
@@ -587,7 +587,7 @@ class SyncFacadeTest {
       val response = contactAddressResponse(contactId = 1L, contactAddressId = 1L)
 
       whenever(syncContactAddressService.createContactAddress(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactAddress(request)
 
@@ -606,7 +606,7 @@ class SyncFacadeTest {
       val response = contactAddressResponse(contactId = 2L, contactAddressId = 3L)
 
       whenever(syncContactAddressService.updateContactAddress(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactAddress(3L, request)
 
@@ -624,7 +624,7 @@ class SyncFacadeTest {
       val response = contactAddressResponse(contactId = 3L, contactAddressId = 4L)
 
       whenever(syncContactAddressService.deleteContactAddress(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactAddress(4L)
 
@@ -684,7 +684,7 @@ class SyncFacadeTest {
       val response = contactAddressPhoneResponse()
 
       whenever(syncContactAddressPhoneService.createContactAddressPhone(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactAddressPhone(request)
 
@@ -704,7 +704,7 @@ class SyncFacadeTest {
       val response = contactAddressPhoneResponse()
 
       whenever(syncContactAddressPhoneService.updateContactAddressPhone(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactAddressPhone(4L, request)
 
@@ -723,7 +723,7 @@ class SyncFacadeTest {
       val response = contactAddressPhoneResponse()
 
       whenever(syncContactAddressPhoneService.deleteContactAddressPhone(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactAddressPhone(4L)
 
@@ -777,7 +777,7 @@ class SyncFacadeTest {
       val response = prisonerContactResponse(contactId = 1L, prisonerContactId = 1L)
 
       whenever(syncPrisonerContactService.createPrisonerContact(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createPrisonerContact(request)
 
@@ -797,7 +797,7 @@ class SyncFacadeTest {
       val response = prisonerContactResponse(contactId = 2L, prisonerContactId = 3L)
 
       whenever(syncPrisonerContactService.updatePrisonerContact(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updatePrisonerContact(3L, request)
 
@@ -816,7 +816,7 @@ class SyncFacadeTest {
       val response = prisonerContactResponse(contactId = 3L, prisonerContactId = 4L)
 
       whenever(syncPrisonerContactService.deletePrisonerContact(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deletePrisonerContact(4L)
 
@@ -887,7 +887,7 @@ class SyncFacadeTest {
       val response = prisonerContactRestrictionResponse()
 
       whenever(syncPrisonerContactRestrictionService.createPrisonerContactRestriction(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createPrisonerContactRestriction(request)
 
@@ -907,7 +907,7 @@ class SyncFacadeTest {
       val response = prisonerContactRestrictionResponse()
 
       whenever(syncPrisonerContactRestrictionService.updatePrisonerContactRestriction(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updatePrisonerContactRestriction(3L, request)
 
@@ -926,7 +926,7 @@ class SyncFacadeTest {
       val response = prisonerContactRestrictionResponse()
 
       whenever(syncPrisonerContactRestrictionService.deletePrisonerContactRestriction(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deletePrisonerContactRestriction(3L)
 
@@ -983,7 +983,7 @@ class SyncFacadeTest {
       val response = employmentSyncResponse()
 
       whenever(syncEmploymentService.createEmployment(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createEmployment(request)
 
@@ -1002,7 +1002,7 @@ class SyncFacadeTest {
       val response = employmentSyncResponse()
 
       whenever(syncEmploymentService.updateEmployment(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateEmployment(3L, request)
 
@@ -1020,7 +1020,7 @@ class SyncFacadeTest {
       val response = employmentSyncResponse()
 
       whenever(syncEmploymentService.deleteEmployment(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteEmployment(3L)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers
 import org.openapitools.jackson.nullable.JsonNullable
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.organisationsapi.model.OrganisationSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.Prisoner
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressDetailsEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEmailEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactIdentityDetailsEntity
@@ -714,3 +715,5 @@ fun createOrganisationSummary(
   businessPhoneNumber,
   businessPhoneNumberExtension,
 )
+
+fun aUser(username: String = "USER1"): User = User(username)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.organisationsapi.model.OrganisationSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createOrganisationSummary
@@ -74,7 +74,7 @@ abstract class IntegrationTestBase {
     prisonerSearchApiServer.stubGetPrisonerReturnNoResults(prisonerNumber)
   }
 
-  protected fun stubGetUserByUsername(user: User) {
+  protected fun stubGetUserByUsername(user: UserDetails) {
     manageUsersApiMockServer.stubGetUser(user)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/db/MostRelevantAddressTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/db/MostRelevantAddressTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.PostgresIntegra
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactAddressRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -27,6 +28,7 @@ class MostRelevantAddressTest : PostgresIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     stubPrisonSearchWithResponse(prisonerNumber)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
@@ -43,6 +45,7 @@ class MostRelevantAddressTest : PostgresIntegrationTestBase() {
         ),
       ),
     ).id
+    setCurrentUser(StubUser.READ_ONLY_USER)
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/db/MostRelevantAddressTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/db/MostRelevantAddressTest.kt
@@ -41,7 +41,6 @@ class MostRelevantAddressTest : PostgresIntegrationTestBase() {
           isApprovedVisitor = false,
           comments = null,
         ),
-        createdBy = "created",
       ),
     ).id
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
@@ -32,9 +32,8 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
   fun setUp() {
     contact = testAPIClient.createAContact(
       CreateContactRequest(
-        firstName = RandomStringUtils.secure().nextAlphabetic(10),
         lastName = RandomStringUtils.secure().nextAlphabetic(10),
-        createdBy = "USER",
+        firstName = RandomStringUtils.secure().nextAlphabetic(10),
       ),
     )
   }
@@ -52,8 +51,6 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
       "relationship must not be null;{\"contactId\": 99, \"createdBy\": \"USER\"}",
       "contactId must not be null;{\"contactId\": null, \"relationship\": {\"prisonerNumber\": \"A1324BC\", \"relationshipTypeCode\": \"S\", \"relationshipToPrisonerCode\": \"MOT\", \"isNextOfKin\": false, \"isEmergencyContact\": false, \"isApprovedVisitor\": false}, \"createdBy\": \"USER\"}",
       "contactId must not be null;{\"relationship\": {\"prisonerNumber\": \"A1324BC\", \"relationshipTypeCode\": \"S\", \"relationshipToPrisonerCode\": \"MOT\", \"isNextOfKin\": false, \"isEmergencyContact\": false, \"isApprovedVisitor\": false}, \"createdBy\": \"USER\"}",
-      "createdBy must not be null;{\"contactId\": 99, \"relationship\": {\"prisonerNumber\": \"A1324BC\", \"relationshipTypeCode\": \"S\", \"relationshipToPrisonerCode\": \"MOT\", \"isNextOfKin\": false, \"isEmergencyContact\": false, \"isApprovedVisitor\": false}, \"createdBy\": null}",
-      "createdBy must not be null;{\"contactId\": 99, \"relationship\": {\"prisonerNumber\": \"A1324BC\", \"relationshipTypeCode\": \"S\", \"relationshipToPrisonerCode\": \"MOT\", \"isNextOfKin\": false, \"isEmergencyContact\": false, \"isApprovedVisitor\": false}}",
       "relationship.prisonerNumber must not be null;{\"contactId\": 99, \"relationship\": {\"prisonerNumber\": null, \"relationshipTypeCode\": \"S\", \"relationshipToPrisonerCode\": \"MOT\", \"isNextOfKin\": false, \"isEmergencyContact\": false, \"isApprovedVisitor\": false}, \"createdBy\": \"USER\"}",
       "relationship.prisonerNumber must not be null;{\"contactId\": 99, \"relationship\": {\"relationshipTypeCode\": \"S\", \"relationshipToPrisonerCode\": \"MOT\", \"isNextOfKin\": false, \"isEmergencyContact\": false, \"isApprovedVisitor\": false}, \"createdBy\": \"USER\"}",
       "relationship.relationshipTypeCode must not be null;{\"contactId\": 99, \"relationship\": {\"prisonerNumber\": \"A1324BC\", \"relationshipToPrisonerCode\": \"MOT\", \"isNextOfKin\": false, \"isEmergencyContact\": false, \"isApprovedVisitor\": false}, \"createdBy\": \"USER\"}",
@@ -136,7 +133,6 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
         isEmergencyContact = false,
         isApprovedVisitor = false,
       ),
-      createdBy = "USER",
     )
 
     val createdRelationship = testAPIClient.addAContactRelationship(request, role)
@@ -149,7 +145,7 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
-      additionalInfo = PrisonerContactInfo(createdRelationship.prisonerContactId, source = Source.DPS),
+      additionalInfo = PrisonerContactInfo(createdRelationship.prisonerContactId, source = Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = contact.id, nomsNumber = request.relationship.prisonerNumber),
     )
   }
@@ -191,7 +187,6 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
         isApprovedVisitor = true,
         comments = "Some comments",
       ),
-      createdBy = "USER",
     )
 
     val createdRelationship = testAPIClient.addAContactRelationship(request)
@@ -204,7 +199,7 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
-      additionalInfo = PrisonerContactInfo(createdRelationship.prisonerContactId, source = Source.DPS),
+      additionalInfo = PrisonerContactInfo(createdRelationship.prisonerContactId, source = Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = contact.id, nomsNumber = request.relationship.prisonerNumber),
     )
   }
@@ -240,6 +235,5 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
       isEmergencyContact = false,
       isApprovedVisitor = false,
     ),
-    createdBy = "USER",
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
@@ -33,7 +33,6 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "address",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -29,6 +30,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address",
@@ -42,19 +44,6 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
     .accept(MediaType.APPLICATION_JSON)
     .contentType(MediaType.APPLICATION_JSON)
     .bodyValue(aMinimalAddressRequest())
-
-  @Test
-  fun `should return forbidden if wrong role`() {
-    webTestClient.post()
-      .uri("/contact/$savedContactId/address")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(aMinimalAddressRequest())
-      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-      .exchange()
-      .expectStatus()
-      .isForbidden
-  }
 
   @ParameterizedTest
   @CsvSource(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
@@ -33,7 +33,6 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
       CreateContactRequest(
         lastName = "address-phone",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -29,6 +30,7 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address-phone",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactEmailIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactEmail
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -28,6 +29,7 @@ class CreateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "email",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactEmailIntegrationTest.kt
@@ -32,7 +32,6 @@ class CreateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "email",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactIdent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -27,6 +28,7 @@ class CreateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "identity",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
@@ -31,7 +31,6 @@ class CreateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "identity",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -27,11 +28,17 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.EmploymentIn
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
 class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.CREATING_USER)
+  }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW")
 
@@ -192,7 +199,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "AUTH_ADM"),
+      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactReturnedOnCreate.id),
     )
   }
@@ -224,7 +231,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "AUTH_ADM"),
+      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactReturnedOnCreate.id),
     )
 
@@ -340,7 +347,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -438,7 +445,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -494,7 +501,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -554,7 +561,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -618,7 +625,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contact.id, Source.DPS, "AUTH_ADM"),
+      additionalInfo = ContactInfo(contact.id, Source.DPS, "created"),
       personReference = PersonReference(contact.id),
     )
   }
@@ -630,7 +637,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       assertThat(firstName).isEqualTo(request.firstName)
       assertThat(middleNames).isEqualTo(request.middleNames)
       assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
-      assertThat(createdBy).isEqualTo("AUTH_ADM")
+      assertThat(createdBy).isEqualTo("created")
       assertThat(isStaff).isEqualTo(request.isStaff)
       assertThat(languageCode).isEqualTo(request.languageCode)
       assertThat(interpreterRequired).isEqualTo(request.interpreterRequired)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -48,8 +48,6 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       "firstName must not be null;{\"lastName\": \"last\", \"createdBy\": \"created\"}",
       "lastName must not be null;{\"firstName\": \"first\", \"lastName\": null, \"createdBy\": \"created\"}",
       "lastName must not be null;{\"firstName\": \"first\", \"createdBy\": \"created\"}",
-      "createdBy must not be null;{\"firstName\": \"first\", \"lastName\": \"last\", \"createdBy\": null}",
-      "createdBy must not be null;{\"firstName\": \"first\", \"lastName\": \"last\"}",
     ],
     delimiter = ';',
   )
@@ -194,7 +192,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS),
+      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = contactReturnedOnCreate.id),
     )
   }
@@ -226,7 +224,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS),
+      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = contactReturnedOnCreate.id),
     )
 
@@ -342,7 +340,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -440,7 +438,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -496,7 +494,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -556,7 +554,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -612,7 +610,6 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       interpreterRequired = true,
       domesticStatusCode = "S",
       genderCode = "M",
-      createdBy = "created",
     )
 
     val contact = testAPIClient.createAContact(request, role)
@@ -621,7 +618,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contact.id, Source.DPS),
+      additionalInfo = ContactInfo(contact.id, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(contact.id),
     )
   }
@@ -633,7 +630,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       assertThat(firstName).isEqualTo(request.firstName)
       assertThat(middleNames).isEqualTo(request.middleNames)
       assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
-      assertThat(createdBy).isEqualTo(request.createdBy)
+      assertThat(createdBy).isEqualTo("AUTH_ADM")
       assertThat(isStaff).isEqualTo(request.isStaff)
       assertThat(languageCode).isEqualTo(request.languageCode)
       assertThat(interpreterRequired).isEqualTo(request.interpreterRequired)
@@ -695,10 +692,6 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
         Arguments.of(
           "middleNames must be <= 35 characters",
           aMinimalCreateContactRequest().copy(middleNames = "".padStart(36, 'X')),
-        ),
-        Arguments.of(
-          "createdBy must be <= 100 characters",
-          aMinimalCreateContactRequest().copy(createdBy = "".padStart(101, 'X')),
         ),
         Arguments.of(
           "identities[0].identityType must be <= 12 characters",
@@ -937,7 +930,6 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
     private fun aMinimalCreateContactRequest(identityDocuments: List<IdentityDocument> = emptyList()) = CreateContactRequest(
       lastName = "last",
       firstName = "first",
-      createdBy = "created",
       identities = identityDocuments,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactPhone
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -27,6 +28,7 @@ class CreateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "phone",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
@@ -31,7 +31,6 @@ class CreateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "phone",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactRestrictionIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRestrictionRequest
@@ -18,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactRestr
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 
@@ -28,13 +28,14 @@ class CreateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "last",
         firstName = "first",
       ),
     ).id
-    stubGetUserByUsername(UserDetails("created", "Created User"))
+    setCurrentUser(StubUser.CREATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.post()
@@ -157,7 +158,7 @@ class CreateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
       assertThat(expiryDate).isNull()
       assertThat(comments).isNull()
       assertThat(enteredByUsername).isEqualTo("created")
-      assertThat(enteredByDisplayName).isEqualTo("Created User")
+      assertThat(enteredByDisplayName).isEqualTo("Created")
       assertThat(createdBy).isEqualTo(request.createdBy)
       assertThat(createdTime).isNotNull()
     }
@@ -190,7 +191,7 @@ class CreateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
       assertThat(expiryDate).isEqualTo(request.expiryDate)
       assertThat(comments).isEqualTo(request.comments)
       assertThat(enteredByUsername).isEqualTo("created")
-      assertThat(enteredByDisplayName).isEqualTo("Created User")
+      assertThat(enteredByDisplayName).isEqualTo("Created")
       assertThat(createdBy).isEqualTo(request.createdBy)
       assertThat(createdTime).isNotNull()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactRestrictionIntegrationTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRestrictionRequest
@@ -32,10 +32,9 @@ class CreateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "last",
         firstName = "first",
-        createdBy = "created",
       ),
     ).id
-    stubGetUserByUsername(User("created", "Created User"))
+    stubGetUserByUsername(UserDetails("created", "Created User"))
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
@@ -88,7 +88,6 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
     val request = CreateContactRequest(
       lastName = RandomStringUtils.secure().nextAlphabetic(35),
       firstName = "a new guy",
-      createdBy = "created",
       relationship = ContactRelationship(
         prisonerNumber = prisonerNumber,
         relationshipTypeCode = "S",
@@ -134,7 +133,6 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
     val request = CreateContactRequest(
       lastName = RandomStringUtils.secure().nextAlphabetic(35),
       firstName = "a new guy",
-      createdBy = "created",
       relationship = requestedRelationship,
     )
 
@@ -176,7 +174,6 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
     val request = CreateContactRequest(
       lastName = RandomStringUtils.secure().nextAlphabetic(35),
       firstName = "a new guy",
-      createdBy = "created",
       relationship = requestedRelationship,
     )
 
@@ -187,13 +184,13 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS),
+      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = created.createdContact.id),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
-      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = created.createdContact.id, nomsNumber = request.relationship!!.prisonerNumber),
     )
   }
@@ -215,7 +212,6 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
     val request = CreateContactRequest(
       lastName = RandomStringUtils.secure().nextAlphabetic(35),
       firstName = "a new guy",
-      createdBy = "created",
       relationship = requestedRelationship,
     )
 
@@ -226,13 +222,13 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS),
+      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = created.createdContact.id),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
-      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(dpsContactId = created.createdContact.id, nomsNumber = request.relationship!!.prisonerNumber),
     )
   }
@@ -269,7 +265,6 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
           CreateContactRequest(
             lastName = RandomStringUtils.secure().nextAlphabetic(35),
             firstName = "a new guy",
-            createdBy = "created",
             relationship = relationship.copy(comments = "".padStart(241, 'X')),
           ),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.apache.commons.lang3.RandomStringUtils
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -20,12 +21,18 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEven
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PrisonerContactInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase() {
 
   @Autowired
   protected lateinit var contactRepository: ContactRepository
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.CREATING_USER)
+  }
 
   @ParameterizedTest
   @CsvSource(
@@ -40,7 +47,7 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
   )
   fun `should return bad request if required fields are null`(expectedMessage: String, relationShipJson: String) {
     val json =
-      "{\"firstName\": \"first\", \"lastName\": \"last\", \"createdBy\": \"created\", \"relationship\": $relationShipJson}"
+      "{\"firstName\": \"first\", \"lastName\": \"last\", \"relationship\": $relationShipJson}"
     val errors = webTestClient.post()
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
@@ -184,13 +191,13 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "AUTH_ADM"),
+      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.createdContact.id),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
-      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.createdContact.id, nomsNumber = request.relationship!!.prisonerNumber),
     )
   }
@@ -222,13 +229,13 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "AUTH_ADM"),
+      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.createdContact.id),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
-      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.createdContact.id, nomsNumber = request.relationship!!.prisonerNumber),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateEmploymentIntegrationTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.EmploymentIn
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -24,6 +25,7 @@ class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "employment",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateEmploymentIntegrationTest.kt
@@ -28,7 +28,6 @@ class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "employment",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
     stubOrganisationSummary(999)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -29,6 +30,7 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "phone",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
@@ -33,7 +33,6 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
       CreateContactRequest(
         lastName = "phone",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleContactPhoneIntegrationTest.kt
@@ -31,7 +31,6 @@ class CreateMultipleContactPhoneIntegrationTest : SecureAPIIntegrationTestBase()
       CreateContactRequest(
         lastName = "phone",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleContactPhoneIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactPhone
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateMultipleContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -27,6 +28,7 @@ class CreateMultipleContactPhoneIntegrationTest : SecureAPIIntegrationTestBase()
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "phone",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleEmailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleEmailsIntegrationTest.kt
@@ -32,7 +32,6 @@ class CreateMultipleEmailsIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "email",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleEmailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleEmailsIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactEmail
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateMultipleEmailsIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -28,6 +29,7 @@ class CreateMultipleEmailsIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "email",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleIdentityIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactIdent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class CreateMultipleIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -27,6 +28,7 @@ class CreateMultipleIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "identity",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleIdentityIntegrationTest.kt
@@ -31,7 +31,6 @@ class CreateMultipleIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "identity",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreatePrisonerContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreatePrisonerContactRestrictionIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEven
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PrisonerContactRestrictionInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 
@@ -31,6 +32,7 @@ class CreatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     stubPrisonSearchWithResponse(prisonerNumberCreatedAgainst)
     val created = testAPIClient.createAContactWithARelationship(
       CreateContactRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreatePrisonerContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreatePrisonerContactRestrictionIntegrationTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
@@ -45,7 +45,6 @@ class CreatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
           isApprovedVisitor = false,
           comments = "Some comments",
         ),
-        createdBy = "created",
       ),
     )
     savedPrisonerContactId = created.createdRelationship!!.prisonerContactId
@@ -152,7 +151,7 @@ class CreatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
   @Test
   fun `should create the restriction with minimal fields`() {
-    stubGetUserByUsername(User("created", "Created User"))
+    stubGetUserByUsername(UserDetails("created", "Created User"))
     val request = CreatePrisonerContactRestrictionRequest(
       restrictionType = "BAN",
       startDate = LocalDate.of(2020, 1, 1),
@@ -188,7 +187,7 @@ class CreatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
   @ParameterizedTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW"])
   fun `should create the restriction with all fields`(role: String) {
-    stubGetUserByUsername(User("created", "Created User"))
+    stubGetUserByUsername(UserDetails("created", "Created User"))
     val request = CreatePrisonerContactRestrictionRequest(
       restrictionType = "BAN",
       startDate = LocalDate.of(2020, 1, 1),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class DeleteContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -24,6 +25,7 @@ class DeleteContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
@@ -28,7 +28,6 @@ class DeleteContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "address",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class DeleteContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -26,6 +27,7 @@ class DeleteContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address-phone",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
@@ -30,7 +30,6 @@ class DeleteContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
       CreateContactRequest(
         lastName = "address-phone",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactEmailIntegrationTest.kt
@@ -28,7 +28,6 @@ class DeleteContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "email",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
     savedContactEmailId = testAPIClient.createAContactEmail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactEmailIntegrationTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactEmail
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class DeleteContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -24,6 +25,7 @@ class DeleteContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "email",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactIdentityIntegrationTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactIdent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class DeleteContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -24,6 +25,7 @@ class DeleteContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "identity",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactIdentityIntegrationTest.kt
@@ -28,7 +28,6 @@ class DeleteContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "identity",
         firstName = "has",
-        createdBy = "created",
       ),
 
     ).id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactPhoneIntegrationTest.kt
@@ -40,7 +40,6 @@ class DeleteContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "phone",
         firstName = "has",
-        createdBy = "created",
       ),
 
     ).id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactPhoneIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactPhone
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDateTime
 
@@ -36,6 +37,7 @@ class DeleteContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "phone",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteEmploymentIntegrationTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.EmploymentIn
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class DeleteEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -24,14 +25,16 @@ class DeleteEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    stubOrganisationSummary(999)
+    stubOrganisationSummary(666)
+
+    setCurrentUser(StubUser.READ_WRITE_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "employment",
         firstName = "has",
       ),
     ).id
-    stubOrganisationSummary(999)
-    stubOrganisationSummary(666)
     savedEmploymentId = testAPIClient.createAnEmployment(
       savedContactId,
       CreateEmploymentRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteEmploymentIntegrationTest.kt
@@ -28,7 +28,6 @@ class DeleteEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "employment",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
     stubOrganisationSummary(999)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactAddressPhoneIntegrationTest.kt
@@ -28,7 +28,6 @@ class GetContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "address-phone",
         firstName = "has",
-        createdBy = "created",
       ),
 
     ).id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactAddressPhoneIntegrationTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.address.CreateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressPhoneDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDateTime
 
@@ -24,38 +25,41 @@ class GetContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
-    savedContactId = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "address-phone",
-        firstName = "has",
-      ),
+    doWithTemporaryWritePermission {
+      savedContactId = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "address-phone",
+          firstName = "has",
+        ),
 
-    ).id
+      ).id
 
-    savedAddressId = testAPIClient.createAContactAddress(
-      savedContactId,
-      CreateContactAddressRequest(
-        addressType = "HOME",
-        primaryAddress = true,
-        property = "27",
-        street = "Hello Road",
-        createdBy = "created",
-      ),
+      savedAddressId = testAPIClient.createAContactAddress(
+        savedContactId,
+        CreateContactAddressRequest(
+          addressType = "HOME",
+          primaryAddress = true,
+          property = "27",
+          street = "Hello Road",
+          createdBy = "created",
+        ),
 
-    ).contactAddressId
+      ).contactAddressId
 
-    savedAddressPhoneId = testAPIClient.createAContactAddressPhone(
-      savedContactId,
-      savedAddressId,
-      CreateContactAddressPhoneRequest(
-        contactAddressId = savedAddressId,
-        phoneType = "HOME",
-        phoneNumber = "123456",
-        extNumber = "2",
-        createdBy = "CREATED",
-      ),
+      savedAddressPhoneId = testAPIClient.createAContactAddressPhone(
+        savedContactId,
+        savedAddressId,
+        CreateContactAddressPhoneRequest(
+          contactAddressId = savedAddressId,
+          phoneType = "HOME",
+          phoneNumber = "123456",
+          extNumber = "2",
+          createdBy = "CREATED",
+        ),
 
-    ).contactAddressPhoneId
+      ).contactAddressPhoneId
+    }
+    setCurrentUser(StubUser.READ_ONLY_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
@@ -242,7 +242,7 @@ class GetContactByIdIntegrationTest : SecureAPIIntegrationTestBase() {
   @Test
   fun `should get the contact with employments`() {
     val newContact =
-      testAPIClient.createAContact(CreateContactRequest(firstName = "First", lastName = "Bob", createdBy = "TEST"))
+      testAPIClient.createAContact(CreateContactRequest(lastName = "Bob", firstName = "First"))
     val org1 = createOrg()
     val org2 = createOrg()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.apache.commons.lang3.RandomUtils
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -13,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.EmploymentEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.EmploymentRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -23,6 +25,11 @@ class GetContactByIdIntegrationTest : SecureAPIIntegrationTestBase() {
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
+
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.get()
     .uri("/contact/123456")
     .accept(MediaType.APPLICATION_JSON)
@@ -32,7 +39,7 @@ class GetContactByIdIntegrationTest : SecureAPIIntegrationTestBase() {
     webTestClient.get()
       .uri("/contact/123456")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound
@@ -241,8 +248,7 @@ class GetContactByIdIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @Test
   fun `should get the contact with employments`() {
-    val newContact =
-      testAPIClient.createAContact(CreateContactRequest(lastName = "Bob", firstName = "First"))
+    val newContact = doWithTemporaryWritePermission { testAPIClient.createAContact(CreateContactRequest(lastName = "Bob", firstName = "First")) }
     val org1 = createOrg()
     val org2 = createOrg()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactEmailIntegrationTest.kt
@@ -1,13 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 
 class GetContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactGlobalRestrictionsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactGlobalRestrictionsIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -8,9 +9,15 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDate
 
 class GetContactGlobalRestrictionsIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 
@@ -59,10 +66,9 @@ class GetContactGlobalRestrictionsIntegrationTest : SecureAPIIntegrationTestBase
 
   @Test
   fun `should return empty list if no restrictions for a contact`() {
-    val createdContact = testAPIClient.createAContact(
-      CreateContactRequest(lastName = "Last", firstName = "First"),
-
-    )
+    val createdContact = doWithTemporaryWritePermission {
+      testAPIClient.createAContact(CreateContactRequest(lastName = "Last", firstName = "First"))
+    }
     val restrictions = testAPIClient.getContactGlobalRestrictions(createdContact.id)
     assertThat(restrictions).isEmpty()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactGlobalRestrictionsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactGlobalRestrictionsIntegrationTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import java.time.LocalDate
@@ -30,7 +30,7 @@ class GetContactGlobalRestrictionsIntegrationTest : SecureAPIIntegrationTestBase
   @ParameterizedTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
   fun `should return all global restrictions for a contact`(role: String) {
-    stubGetUserByUsername(User("JBAKER_GEN", "James Baker"))
+    stubGetUserByUsername(UserDetails("JBAKER_GEN", "James Baker"))
     val restrictions = testAPIClient.getContactGlobalRestrictions(3, role)
     assertThat(restrictions).hasSize(2)
     with(restrictions[0]) {
@@ -60,7 +60,7 @@ class GetContactGlobalRestrictionsIntegrationTest : SecureAPIIntegrationTestBase
   @Test
   fun `should return empty list if no restrictions for a contact`() {
     val createdContact = testAPIClient.createAContact(
-      CreateContactRequest(firstName = "First", lastName = "Last", createdBy = "USER1"),
+      CreateContactRequest(lastName = "Last", firstName = "First"),
 
     )
     val restrictions = testAPIClient.getContactGlobalRestrictions(createdContact.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactIdentityIntegrationTest.kt
@@ -1,13 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 
 class GetContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelati
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.LinkedPrisonerDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 
 class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
   private var savedContactId = 0L
@@ -38,12 +39,15 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
-    savedContactId = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "Contact",
-        firstName = "Linked",
-      ),
-    ).id
+    setCurrentUser(StubUser.READ_ONLY_USER)
+    doWithTemporaryWritePermission {
+      savedContactId = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "Contact",
+          firstName = "Linked",
+        ),
+      ).id
+    }
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.get()
@@ -54,9 +58,9 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
     stubPrisonerSearch(prisoner1)
     stubPrisonerSearch(prisoner2)
 
-    val prisoner1FriendRelationship = addRelationship(prisoner1, "FRI")
-    val prisoner1OtherRelationship = addRelationship(prisoner1, "OTHER")
-    val prisoner2FatherRelationship = addRelationship(prisoner2, "FA")
+    val prisoner1FriendRelationship = doWithTemporaryWritePermission { addRelationship(prisoner1, "FRI") }
+    val prisoner1OtherRelationship = doWithTemporaryWritePermission { addRelationship(prisoner1, "OTHER") }
+    val prisoner2FatherRelationship = doWithTemporaryWritePermission { addRelationship(prisoner2, "FA") }
 
     stubSearchPrisonersByPrisonerNumbers(
       setOf(prisoner1.prisonerNumber, prisoner2.prisonerNumber),
@@ -120,8 +124,8 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
     stubPrisonerSearch(prisoner1)
     stubPrisonerSearch(prisoner2)
 
-    val prisoner1Relationship = addRelationship(prisoner1, "OTHER")
-    val prisoner2Relationship = addRelationship(prisoner2, "FA")
+    val prisoner1Relationship = doWithTemporaryWritePermission { addRelationship(prisoner1, "OTHER") }
+    val prisoner2Relationship = doWithTemporaryWritePermission { addRelationship(prisoner2, "FA") }
 
     stubSearchPrisonersByPrisonerNumbers(setOf(prisoner1.prisonerNumber, prisoner2.prisonerNumber), listOf(prisoner1))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
@@ -42,7 +42,6 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "Contact",
         firstName = "Linked",
-        createdBy = "created",
       ),
     ).id
   }
@@ -173,7 +172,6 @@ class GetContactLinkedPrisonerIntegrationTest : SecureAPIIntegrationTestBase() {
         isEmergencyContact = true,
         isApprovedVisitor = false,
       ),
-      createdBy = "created",
     ),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactNameIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactNameIntegrationTest.kt
@@ -34,7 +34,6 @@ class GetContactNameIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = "Last",
         firstName = "First",
         middleNames = "Middle Names",
-        createdBy = "USER1",
       ),
     )
 
@@ -57,7 +56,6 @@ class GetContactNameIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = "Last",
         firstName = "First",
         middleNames = null,
-        createdBy = "USER1",
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactNameIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactNameIntegrationTest.kt
@@ -1,13 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 
 class GetContactNameIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 
@@ -28,14 +35,16 @@ class GetContactNameIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @Test
   fun `should get the contact name with all fields if they have a title`() {
-    val contact = testAPIClient.createAContact(
-      CreateContactRequest(
-        titleCode = "MR",
-        lastName = "Last",
-        firstName = "First",
-        middleNames = "Middle Names",
-      ),
-    )
+    val contact = doWithTemporaryWritePermission {
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          titleCode = "MR",
+          lastName = "Last",
+          firstName = "First",
+          middleNames = "Middle Names",
+        ),
+      )
+    }
 
     val name = testAPIClient.getContactName(contact.id)
 
@@ -50,14 +59,16 @@ class GetContactNameIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @Test
   fun `should get the contact name with only optional fields`() {
-    val contact = testAPIClient.createAContact(
-      CreateContactRequest(
-        titleCode = null,
-        lastName = "Last",
-        firstName = "First",
-        middleNames = null,
-      ),
-    )
+    val contact = doWithTemporaryWritePermission {
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          titleCode = null,
+          lastName = "Last",
+          firstName = "First",
+          middleNames = null,
+        ),
+      )
+    }
 
     val name = testAPIClient.getContactName(contact.id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactPhoneIntegrationTest.kt
@@ -1,13 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 
 class GetContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetEmploymentIntegrationTest.kt
@@ -24,7 +24,6 @@ class GetEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "employment",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
     stubOrganisationSummary(999)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetEmploymentIntegrationTest.kt
@@ -10,6 +10,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.CreateEmploymentRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class GetEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -20,21 +21,24 @@ class GetEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
-    savedContactId = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "employment",
-        firstName = "has",
-      ),
-    ).id
-    stubOrganisationSummary(999)
-    savedEmploymentId = testAPIClient.createAnEmployment(
-      savedContactId,
-      CreateEmploymentRequest(
-        organisationId = 999,
-        isActive = true,
-        createdBy = "created",
-      ),
-    ).employmentId
+    setCurrentUser(StubUser.READ_ONLY_USER)
+    doWithTemporaryWritePermission {
+      savedContactId = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "employment",
+          firstName = "has",
+        ),
+      ).id
+      stubOrganisationSummary(999)
+      savedEmploymentId = testAPIClient.createAnEmployment(
+        savedContactId,
+        CreateEmploymentRequest(
+          organisationId = 999,
+          isActive = true,
+          createdBy = "created",
+        ),
+      ).employmentId
+    }
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRelationshipCountIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRelationshipCountIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.openapitools.jackson.nullable.JsonNullable
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,9 +13,16 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipCount
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import kotlin.jvm.optionals.getOrNull
 
 class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
+
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.get()
@@ -47,85 +55,87 @@ class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationT
       isEmergencyContact = false,
       isApprovedVisitor = false,
     )
-    // Contact one has one active social and one active official relationship plus an inactive social relationship and
-    // another from a previous term
-    val contactOne = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "Contact",
-        firstName = "One",
-      ),
-    )
-    // Make from previous term
-    val relationshipFromPreviousTerm = testAPIClient.addAContactRelationship(
-      AddContactRelationshipRequest(
-        contactOne.id,
-        relationship.copy(relationshipToPrisonerCode = "FRI"),
-      ),
-    )
-    val entity = prisonerContactRepository.findById(relationshipFromPreviousTerm.prisonerContactId).getOrNull()!!
-    prisonerContactRepository.saveAndFlush(entity.copy(currentTerm = false))
-
-    // Inactive
-    val relationshipToMakeInactive = testAPIClient.addAContactRelationship(
-      AddContactRelationshipRequest(
-        contactOne.id,
-        relationship.copy(relationshipToPrisonerCode = "GIF"),
-      ),
-    )
-    testAPIClient.updateRelationship(
-      relationshipToMakeInactive.prisonerContactId,
-      PatchRelationshipRequest(
-        isRelationshipActive = JsonNullable.of(false),
-      ),
-    )
-
-    // Active social
-    testAPIClient.addAContactRelationship(
-      AddContactRelationshipRequest(
-        contactOne.id,
-        relationship.copy(relationshipToPrisonerCode = "WIFE"),
-      ),
-    )
-
-    // Active official
-    testAPIClient.addAContactRelationship(
-      AddContactRelationshipRequest(
-        contactOne.id,
-        relationship.copy(relationshipTypeCode = "O", relationshipToPrisonerCode = "DR"),
-      ),
-    )
-
-    // Another contact active social
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "Contact",
-        firstName = "Two",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "S",
-          relationshipToPrisonerCode = "MOT",
-          isNextOfKin = false,
-          isEmergencyContact = false,
-          isApprovedVisitor = false,
+    doWithTemporaryWritePermission {
+      // Contact one has one active social and one active official relationship plus an inactive social relationship and
+      // another from a previous term
+      val contactOne = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "Contact",
+          firstName = "One",
         ),
-      ),
-    )
-
-    // Another contact with active official
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "Contact",
-        firstName = "Three",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "O",
-          relationshipToPrisonerCode = "POM",
-          isNextOfKin = false,
-          isEmergencyContact = false,
-          isApprovedVisitor = false,
+      )
+      // Make from previous term
+      val relationshipFromPreviousTerm = testAPIClient.addAContactRelationship(
+        AddContactRelationshipRequest(
+          contactOne.id,
+          relationship.copy(relationshipToPrisonerCode = "FRI"),
         ),
-      ),
-    )
+      )
+      val entity = prisonerContactRepository.findById(relationshipFromPreviousTerm.prisonerContactId).getOrNull()!!
+      prisonerContactRepository.saveAndFlush(entity.copy(currentTerm = false))
+
+      // Inactive
+      val relationshipToMakeInactive = testAPIClient.addAContactRelationship(
+        AddContactRelationshipRequest(
+          contactOne.id,
+          relationship.copy(relationshipToPrisonerCode = "GIF"),
+        ),
+      )
+      testAPIClient.updateRelationship(
+        relationshipToMakeInactive.prisonerContactId,
+        PatchRelationshipRequest(
+          isRelationshipActive = JsonNullable.of(false),
+        ),
+      )
+
+      // Active social
+      testAPIClient.addAContactRelationship(
+        AddContactRelationshipRequest(
+          contactOne.id,
+          relationship.copy(relationshipToPrisonerCode = "WIFE"),
+        ),
+      )
+
+      // Active official
+      testAPIClient.addAContactRelationship(
+        AddContactRelationshipRequest(
+          contactOne.id,
+          relationship.copy(relationshipTypeCode = "O", relationshipToPrisonerCode = "DR"),
+        ),
+      )
+
+      // Another contact active social
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "Contact",
+          firstName = "Two",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "MOT",
+            isNextOfKin = false,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+          ),
+        ),
+      )
+
+      // Another contact with active official
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "Contact",
+          firstName = "Three",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "O",
+            relationshipToPrisonerCode = "POM",
+            isNextOfKin = false,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+          ),
+        ),
+      )
+    }
 
     assertThat(testAPIClient.getPrisonerContactRelationshipCount(prisonerNumber)).isEqualTo(
       PrisonerContactRelationshipCount(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRelationshipCountIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRelationshipCountIntegrationTest.kt
@@ -53,7 +53,6 @@ class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationT
       CreateContactRequest(
         lastName = "Contact",
         firstName = "One",
-        createdBy = "USER1",
       ),
     )
     // Make from previous term
@@ -61,7 +60,6 @@ class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationT
       AddContactRelationshipRequest(
         contactOne.id,
         relationship.copy(relationshipToPrisonerCode = "FRI"),
-        "USER1",
       ),
     )
     val entity = prisonerContactRepository.findById(relationshipFromPreviousTerm.prisonerContactId).getOrNull()!!
@@ -72,14 +70,12 @@ class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationT
       AddContactRelationshipRequest(
         contactOne.id,
         relationship.copy(relationshipToPrisonerCode = "GIF"),
-        "USER1",
       ),
     )
     testAPIClient.updateRelationship(
       relationshipToMakeInactive.prisonerContactId,
       PatchRelationshipRequest(
         isRelationshipActive = JsonNullable.of(false),
-        updatedBy = "USER1",
       ),
     )
 
@@ -88,7 +84,6 @@ class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationT
       AddContactRelationshipRequest(
         contactOne.id,
         relationship.copy(relationshipToPrisonerCode = "WIFE"),
-        "USER1",
       ),
     )
 
@@ -97,7 +92,6 @@ class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationT
       AddContactRelationshipRequest(
         contactOne.id,
         relationship.copy(relationshipTypeCode = "O", relationshipToPrisonerCode = "DR"),
-        "USER1",
       ),
     )
 
@@ -106,7 +100,6 @@ class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationT
       CreateContactRequest(
         lastName = "Contact",
         firstName = "Two",
-        createdBy = "USER1",
         relationship = ContactRelationship(
           prisonerNumber = prisonerNumber,
           relationshipTypeCode = "S",
@@ -123,7 +116,6 @@ class GetPrisonerContactRelationshipCountIntegrationTest : SecureAPIIntegrationT
       CreateContactRequest(
         lastName = "Contact",
         firstName = "Three",
-        createdBy = "USER1",
         relationship = ContactRelationship(
           prisonerNumber = prisonerNumber,
           relationshipTypeCode = "O",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRestrictionsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRestrictionsIntegrationTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
@@ -32,9 +32,9 @@ class GetPrisonerContactRestrictionsIntegrationTest : SecureAPIIntegrationTestBa
   @ParameterizedTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
   fun `should return all relationship and global restrictions for a contact`(role: String) {
-    stubGetUserByUsername(User("officer", "The Officer"))
-    stubGetUserByUsername(User("editor", "The Editor"))
-    stubGetUserByUsername(User("JBAKER_GEN", "James Test"))
+    stubGetUserByUsername(UserDetails("officer", "The Officer"))
+    stubGetUserByUsername(UserDetails("editor", "The Editor"))
+    stubGetUserByUsername(UserDetails("JBAKER_GEN", "James Test"))
 
     val restrictions = testAPIClient.getPrisonerContactRestrictions(10, role)
 
@@ -103,9 +103,8 @@ class GetPrisonerContactRestrictionsIntegrationTest : SecureAPIIntegrationTestBa
     stubPrisonSearchWithResponse(prisonerNumber)
     val created = testAPIClient.createAContactWithARelationship(
       CreateContactRequest(
-        firstName = "First",
         lastName = "Last",
-        createdBy = "USER1",
+        firstName = "First",
         relationship = ContactRelationship(
           prisonerNumber = prisonerNumber,
           relationshipTypeCode = "S",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRestrictionsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRestrictionsIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -9,10 +10,16 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDet
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 class GetPrisonerContactRestrictionsIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 
@@ -101,22 +108,23 @@ class GetPrisonerContactRestrictionsIntegrationTest : SecureAPIIntegrationTestBa
   fun `should return empty list if no restrictions for a contact`() {
     val prisonerNumber = "G4793VF"
     stubPrisonSearchWithResponse(prisonerNumber)
-    val created = testAPIClient.createAContactWithARelationship(
-      CreateContactRequest(
-        lastName = "Last",
-        firstName = "First",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "S",
-          relationshipToPrisonerCode = "FRI",
-          isNextOfKin = false,
-          isEmergencyContact = false,
-          isApprovedVisitor = false,
-          comments = null,
+    val created = doWithTemporaryWritePermission {
+      testAPIClient.createAContactWithARelationship(
+        CreateContactRequest(
+          lastName = "Last",
+          firstName = "First",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "FRI",
+            isNextOfKin = false,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+            comments = null,
+          ),
         ),
-      ),
-
-    )
+      )
+    }
     val restrictions = testAPIClient.getPrisonerContactRestrictions(
       created.createdRelationship!!.prisonerContactId,
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
@@ -169,7 +169,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
           isEmergencyContact = false,
           isApprovedVisitor = false,
         ),
-        createdBy = "USER1",
       ),
     )
     val prisonerContactIdToDeactivate = testAPIClient.createAContactWithARelationship(
@@ -184,12 +183,11 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
           isEmergencyContact = false,
           isApprovedVisitor = false,
         ),
-        createdBy = "USER1",
       ),
     ).createdRelationship!!.prisonerContactId
     testAPIClient.updateRelationship(
       prisonerContactIdToDeactivate,
-      PatchRelationshipRequest(isRelationshipActive = JsonNullable.of(false), updatedBy = "USER1"),
+      PatchRelationshipRequest(isRelationshipActive = JsonNullable.of(false)),
     )
 
     val withActiveOnly = getForUrl("/prisoner/$prisonerNumber/contact?active=true")
@@ -222,7 +220,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
           isEmergencyContact = false,
           isApprovedVisitor = false,
         ),
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContactWithARelationship(
@@ -237,7 +234,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
           isEmergencyContact = false,
           isApprovedVisitor = false,
         ),
-        createdBy = "USER1",
       ),
     )
 
@@ -271,7 +267,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
           isEmergencyContact = false,
           isApprovedVisitor = false,
         ),
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContactWithARelationship(
@@ -286,7 +281,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
           isEmergencyContact = true,
           isApprovedVisitor = false,
         ),
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContactWithARelationship(
@@ -301,7 +295,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
           isEmergencyContact = true,
           isApprovedVisitor = false,
         ),
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContactWithARelationship(
@@ -316,7 +309,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
           isEmergencyContact = false,
           isApprovedVisitor = false,
         ),
-        createdBy = "USER1",
       ),
     )
 
@@ -391,7 +383,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "Youngest",
         dateOfBirth = LocalDate.of(2025, 1, 1),
         relationship = relationship,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -400,7 +391,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "Eldest",
         dateOfBirth = LocalDate.of(1990, 1, 1),
         relationship = relationship,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -409,7 +399,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "None",
         dateOfBirth = null,
         relationship = relationship,
-        createdBy = "USER1",
       ),
     )
 
@@ -445,7 +434,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         middleNames = "C",
         dateOfBirth = randomDob,
         relationship = relationship,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -454,7 +442,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "B",
         dateOfBirth = randomDob,
         relationship = relationship,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -463,7 +450,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "A",
         dateOfBirth = randomDob,
         relationship = relationship,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -472,7 +458,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "B",
         dateOfBirth = randomDob,
         relationship = relationship,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -482,7 +467,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         middleNames = "A",
         dateOfBirth = randomDob,
         relationship = relationship,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -492,7 +476,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         middleNames = "B",
         dateOfBirth = randomDob,
         relationship = relationship,
-        createdBy = "USER1",
       ),
     )
 
@@ -535,7 +518,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "B",
         dateOfBirth = randomDob,
         relationship = relationship,
-        createdBy = "USER1",
       ),
     ).id
     val highestId = testAPIClient.createAContact(
@@ -544,7 +526,6 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "B",
         dateOfBirth = randomDob,
         relationship = relationship,
-        createdBy = "USER1",
       ),
     ).id
 
@@ -581,21 +562,18 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "Has Global Restriction",
         firstName = "Contact",
-        createdBy = "USER1",
       ),
     )
     val relationshipToPrisonerOne = testAPIClient.addAContactRelationship(
       AddContactRelationshipRequest(
         contact.id,
         relationship.copy(prisonerNumber = prisonerOneNumber),
-        "USER1",
       ),
     )
     val relationshipToPrisonerTwo = testAPIClient.addAContactRelationship(
       AddContactRelationshipRequest(
         contact.id,
         relationship.copy(prisonerNumber = prisonerTwoNumber),
-        "USER1",
       ),
     )
 
@@ -670,14 +648,12 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "Has Global Restriction",
         firstName = "Contact",
-        createdBy = "USER1",
       ),
     )
     val relationshipToPrisonerOne = testAPIClient.addAContactRelationship(
       AddContactRelationshipRequest(
         contact.id,
         relationship.copy(prisonerNumber = prisonerOneNumber),
-        "USER1",
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.RandomStringUtils
 import org.apache.commons.lang3.RandomUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -20,11 +21,17 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePrisone
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.RestrictionTypeDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.RestrictionsSummary
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDate
 
 class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     private const val GET_PRISONER_CONTACT = "/prisoner/A4385DZ/contact"
+  }
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
   }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
@@ -38,7 +45,7 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
 
     webTestClient.get()
       .uri("/prisoner/A4385DZ/contact")
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound
@@ -157,38 +164,40 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   fun `should return with active or inactive correctly`() {
     val prisonerNumber = "Z1234ZZ"
     stubPrisonSearchWithResponse(prisonerNumber)
-    testAPIClient.createAContactWithARelationship(
-      CreateContactRequest(
-        lastName = "Active",
-        firstName = "Contact",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "S",
-          relationshipToPrisonerCode = "MOT",
-          isNextOfKin = false,
-          isEmergencyContact = false,
-          isApprovedVisitor = false,
+    doWithTemporaryWritePermission {
+      testAPIClient.createAContactWithARelationship(
+        CreateContactRequest(
+          lastName = "Active",
+          firstName = "Contact",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "MOT",
+            isNextOfKin = false,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+          ),
         ),
-      ),
-    )
-    val prisonerContactIdToDeactivate = testAPIClient.createAContactWithARelationship(
-      CreateContactRequest(
-        lastName = "Inactive",
-        firstName = "Contact",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "S",
-          relationshipToPrisonerCode = "MOT",
-          isNextOfKin = false,
-          isEmergencyContact = false,
-          isApprovedVisitor = false,
+      )
+      val prisonerContactIdToDeactivate = testAPIClient.createAContactWithARelationship(
+        CreateContactRequest(
+          lastName = "Inactive",
+          firstName = "Contact",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "MOT",
+            isNextOfKin = false,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+          ),
         ),
-      ),
-    ).createdRelationship!!.prisonerContactId
-    testAPIClient.updateRelationship(
-      prisonerContactIdToDeactivate,
-      PatchRelationshipRequest(isRelationshipActive = JsonNullable.of(false)),
-    )
+      ).createdRelationship!!.prisonerContactId
+      testAPIClient.updateRelationship(
+        prisonerContactIdToDeactivate,
+        PatchRelationshipRequest(isRelationshipActive = JsonNullable.of(false)),
+      )
+    }
 
     val withActiveOnly = getForUrl("/prisoner/$prisonerNumber/contact?active=true")
     assertThat(withActiveOnly.content).hasSize(1)
@@ -208,34 +217,36 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   fun `should return with relationship type filtered correctly`() {
     val prisonerNumber = "Z4567ZZ"
     stubPrisonSearchWithResponse(prisonerNumber)
-    testAPIClient.createAContactWithARelationship(
-      CreateContactRequest(
-        lastName = "Social",
-        firstName = "Contact",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "S",
-          relationshipToPrisonerCode = "MOT",
-          isNextOfKin = false,
-          isEmergencyContact = false,
-          isApprovedVisitor = false,
+    doWithTemporaryWritePermission {
+      testAPIClient.createAContactWithARelationship(
+        CreateContactRequest(
+          lastName = "Social",
+          firstName = "Contact",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "MOT",
+            isNextOfKin = false,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+          ),
         ),
-      ),
-    )
-    testAPIClient.createAContactWithARelationship(
-      CreateContactRequest(
-        lastName = "Official",
-        firstName = "Contact",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "O",
-          relationshipToPrisonerCode = "DR",
-          isNextOfKin = false,
-          isEmergencyContact = false,
-          isApprovedVisitor = false,
+      )
+      testAPIClient.createAContactWithARelationship(
+        CreateContactRequest(
+          lastName = "Official",
+          firstName = "Contact",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "O",
+            relationshipToPrisonerCode = "DR",
+            isNextOfKin = false,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+          ),
         ),
-      ),
-    )
+      )
+    }
 
     val withNoTypeSpecified = getForUrl("/prisoner/$prisonerNumber/contact?sort=lastName")
     assertThat(withNoTypeSpecified.content).hasSize(2)
@@ -255,62 +266,64 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   fun `should return with emergency contact and next of kin filtered correctly`() {
     val prisonerNumber = "X4567XX"
     stubPrisonSearchWithResponse(prisonerNumber)
-    testAPIClient.createAContactWithARelationship(
-      CreateContactRequest(
-        lastName = "NOK Only",
-        firstName = "Contact",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "S",
-          relationshipToPrisonerCode = "MOT",
-          isNextOfKin = true,
-          isEmergencyContact = false,
-          isApprovedVisitor = false,
+    doWithTemporaryWritePermission {
+      testAPIClient.createAContactWithARelationship(
+        CreateContactRequest(
+          lastName = "NOK Only",
+          firstName = "Contact",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "MOT",
+            isNextOfKin = true,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+          ),
         ),
-      ),
-    )
-    testAPIClient.createAContactWithARelationship(
-      CreateContactRequest(
-        lastName = "EC Only",
-        firstName = "Contact",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "S",
-          relationshipToPrisonerCode = "FRI",
-          isNextOfKin = false,
-          isEmergencyContact = true,
-          isApprovedVisitor = false,
+      )
+      testAPIClient.createAContactWithARelationship(
+        CreateContactRequest(
+          lastName = "EC Only",
+          firstName = "Contact",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "FRI",
+            isNextOfKin = false,
+            isEmergencyContact = true,
+            isApprovedVisitor = false,
+          ),
         ),
-      ),
-    )
-    testAPIClient.createAContactWithARelationship(
-      CreateContactRequest(
-        lastName = "NOK And EC",
-        firstName = "Contact",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "S",
-          relationshipToPrisonerCode = "FRI",
-          isNextOfKin = true,
-          isEmergencyContact = true,
-          isApprovedVisitor = false,
+      )
+      testAPIClient.createAContactWithARelationship(
+        CreateContactRequest(
+          lastName = "NOK And EC",
+          firstName = "Contact",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "FRI",
+            isNextOfKin = true,
+            isEmergencyContact = true,
+            isApprovedVisitor = false,
+          ),
         ),
-      ),
-    )
-    testAPIClient.createAContactWithARelationship(
-      CreateContactRequest(
-        lastName = "Neither",
-        firstName = "Contact",
-        relationship = ContactRelationship(
-          prisonerNumber = prisonerNumber,
-          relationshipTypeCode = "S",
-          relationshipToPrisonerCode = "FRI",
-          isNextOfKin = false,
-          isEmergencyContact = false,
-          isApprovedVisitor = false,
+      )
+      testAPIClient.createAContactWithARelationship(
+        CreateContactRequest(
+          lastName = "Neither",
+          firstName = "Contact",
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "FRI",
+            isNextOfKin = false,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+          ),
         ),
-      ),
-    )
+      )
+    }
 
     val withNoTypeSpecified = getForUrl("/prisoner/$prisonerNumber/contact")
     assertThat(withNoTypeSpecified.content).hasSize(4)
@@ -377,30 +390,32 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
       isApprovedVisitor = false,
     )
     val randomLastName = RandomStringUtils.secure().nextAlphabetic(35)
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = randomLastName,
-        firstName = "Youngest",
-        dateOfBirth = LocalDate.of(2025, 1, 1),
-        relationship = relationship,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = randomLastName,
-        firstName = "Eldest",
-        dateOfBirth = LocalDate.of(1990, 1, 1),
-        relationship = relationship,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = randomLastName,
-        firstName = "None",
-        dateOfBirth = null,
-        relationship = relationship,
-      ),
-    )
+    doWithTemporaryWritePermission {
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = randomLastName,
+          firstName = "Youngest",
+          dateOfBirth = LocalDate.of(2025, 1, 1),
+          relationship = relationship,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = randomLastName,
+          firstName = "Eldest",
+          dateOfBirth = LocalDate.of(1990, 1, 1),
+          relationship = relationship,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = randomLastName,
+          firstName = "None",
+          dateOfBirth = null,
+          relationship = relationship,
+        ),
+      )
+    }
 
     val resultsEldestFirst = getForUrl("/prisoner/$prisonerNumber/contact?sort=dateOfBirth,asc")
     assertThat(resultsEldestFirst.content).extracting("firstName").isEqualTo(
@@ -427,57 +442,59 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     )
 
     val randomDob = LocalDate.now().minusDays(RandomUtils.secure().randomLong(100, 2000))
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AA",
-        firstName = "B",
-        middleNames = "C",
-        dateOfBirth = randomDob,
-        relationship = relationship,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AA",
-        firstName = "B",
-        dateOfBirth = randomDob,
-        relationship = relationship,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AB",
-        firstName = "A",
-        dateOfBirth = randomDob,
-        relationship = relationship,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AB",
-        firstName = "B",
-        dateOfBirth = randomDob,
-        relationship = relationship,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AC",
-        firstName = "C",
-        middleNames = "A",
-        dateOfBirth = randomDob,
-        relationship = relationship,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AC",
-        firstName = "C",
-        middleNames = "B",
-        dateOfBirth = randomDob,
-        relationship = relationship,
-      ),
-    )
+    doWithTemporaryWritePermission {
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AA",
+          firstName = "B",
+          middleNames = "C",
+          dateOfBirth = randomDob,
+          relationship = relationship,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AA",
+          firstName = "B",
+          dateOfBirth = randomDob,
+          relationship = relationship,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AB",
+          firstName = "A",
+          dateOfBirth = randomDob,
+          relationship = relationship,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AB",
+          firstName = "B",
+          dateOfBirth = randomDob,
+          relationship = relationship,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AC",
+          firstName = "C",
+          middleNames = "A",
+          dateOfBirth = randomDob,
+          relationship = relationship,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AC",
+          firstName = "C",
+          middleNames = "B",
+          dateOfBirth = randomDob,
+          relationship = relationship,
+        ),
+      )
+    }
 
     val expectedOrder = listOf(
       "AA, B C",
@@ -512,27 +529,29 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
       isApprovedVisitor = false,
     )
     val randomDob = LocalDate.now().minusDays(RandomUtils.secure().randomLong(100, 2000))
-    val lowestId = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AA",
-        firstName = "B",
-        dateOfBirth = randomDob,
-        relationship = relationship,
-      ),
-    ).id
-    val highestId = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AA",
-        firstName = "B",
-        dateOfBirth = randomDob,
-        relationship = relationship,
-      ),
-    ).id
 
-    val expectedOrder = listOf(
-      lowestId,
-      highestId,
-    )
+    val expectedOrder = doWithTemporaryWritePermission {
+      val lowestId = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AA",
+          firstName = "B",
+          dateOfBirth = randomDob,
+          relationship = relationship,
+        ),
+      ).id
+      val highestId = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AA",
+          firstName = "B",
+          dateOfBirth = randomDob,
+          relationship = relationship,
+        ),
+      ).id
+      listOf(
+        lowestId,
+        highestId,
+      )
+    }
 
     val ascendingName =
       getForUrl("/prisoner/$prisonerNumber/contact?sort=lastName,asc&sort=firstName,asc&sort=middleNames,asc&sort=contactId,asc")
@@ -550,65 +569,67 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     stubPrisonSearchWithResponse(prisonerOneNumber)
     stubPrisonSearchWithResponse(prisonerTwoNumber)
 
-    val relationship = ContactRelationship(
-      prisonerNumber = "temp",
-      relationshipTypeCode = "S",
-      relationshipToPrisonerCode = "FRI",
-      isNextOfKin = false,
-      isEmergencyContact = false,
-      isApprovedVisitor = false,
-    )
-    val contact = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "Has Global Restriction",
-        firstName = "Contact",
-      ),
-    )
-    val relationshipToPrisonerOne = testAPIClient.addAContactRelationship(
-      AddContactRelationshipRequest(
+    doWithTemporaryWritePermission {
+      val relationship = ContactRelationship(
+        prisonerNumber = "temp",
+        relationshipTypeCode = "S",
+        relationshipToPrisonerCode = "FRI",
+        isNextOfKin = false,
+        isEmergencyContact = false,
+        isApprovedVisitor = false,
+      )
+      val contact = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "Has Global Restriction",
+          firstName = "Contact",
+        ),
+      )
+      val relationshipToPrisonerOne = testAPIClient.addAContactRelationship(
+        AddContactRelationshipRequest(
+          contact.id,
+          relationship.copy(prisonerNumber = prisonerOneNumber),
+        ),
+      )
+      val relationshipToPrisonerTwo = testAPIClient.addAContactRelationship(
+        AddContactRelationshipRequest(
+          contact.id,
+          relationship.copy(prisonerNumber = prisonerTwoNumber),
+        ),
+      )
+
+      testAPIClient.createContactGlobalRestriction(
         contact.id,
-        relationship.copy(prisonerNumber = prisonerOneNumber),
-      ),
-    )
-    val relationshipToPrisonerTwo = testAPIClient.addAContactRelationship(
-      AddContactRelationshipRequest(
-        contact.id,
-        relationship.copy(prisonerNumber = prisonerTwoNumber),
-      ),
-    )
+        CreateContactRestrictionRequest(
+          "BAN",
+          LocalDate.now().minusDays(1),
+          null,
+          "global",
+          "USER1",
+        ),
+      )
 
-    testAPIClient.createContactGlobalRestriction(
-      contact.id,
-      CreateContactRestrictionRequest(
-        "BAN",
-        LocalDate.now().minusDays(1),
-        null,
-        "global",
-        "USER1",
-      ),
-    )
+      testAPIClient.createPrisonerContactRestriction(
+        relationshipToPrisonerOne.prisonerContactId,
+        CreatePrisonerContactRestrictionRequest(
+          "CCTV",
+          LocalDate.now().minusDays(1),
+          null,
+          "rel1",
+          "USER1",
+        ),
+      )
 
-    testAPIClient.createPrisonerContactRestriction(
-      relationshipToPrisonerOne.prisonerContactId,
-      CreatePrisonerContactRestrictionRequest(
-        "CCTV",
-        LocalDate.now().minusDays(1),
-        null,
-        "rel1",
-        "USER1",
-      ),
-    )
-
-    testAPIClient.createPrisonerContactRestriction(
-      relationshipToPrisonerTwo.prisonerContactId,
-      CreatePrisonerContactRestrictionRequest(
-        "NONCON",
-        LocalDate.now().minusDays(1),
-        null,
-        "rel2",
-        "USER1",
-      ),
-    )
+      testAPIClient.createPrisonerContactRestriction(
+        relationshipToPrisonerTwo.prisonerContactId,
+        CreatePrisonerContactRestrictionRequest(
+          "NONCON",
+          LocalDate.now().minusDays(1),
+          null,
+          "rel2",
+          "USER1",
+        ),
+      )
+    }
 
     val prisonerOneContacts = testAPIClient.getPrisonerContacts(prisonerOneNumber)
     assertThat(prisonerOneContacts.content).hasSize(1)
@@ -644,62 +665,63 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
       isEmergencyContact = false,
       isApprovedVisitor = false,
     )
-    val contact = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "Has Global Restriction",
-        firstName = "Contact",
-      ),
-    )
-    val relationshipToPrisonerOne = testAPIClient.addAContactRelationship(
-      AddContactRelationshipRequest(
+    doWithTemporaryWritePermission {
+      val contact = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "Has Global Restriction",
+          firstName = "Contact",
+        ),
+      )
+      val relationshipToPrisonerOne = testAPIClient.addAContactRelationship(
+        AddContactRelationshipRequest(
+          contact.id,
+          relationship.copy(prisonerNumber = prisonerOneNumber),
+        ),
+      )
+
+      testAPIClient.createContactGlobalRestriction(
         contact.id,
-        relationship.copy(prisonerNumber = prisonerOneNumber),
-      ),
-    )
+        CreateContactRestrictionRequest(
+          "BAN",
+          LocalDate.now().minusDays(2),
+          LocalDate.now().minusDays(1),
+          "expired",
+          "USER1",
+        ),
+      )
+      testAPIClient.createContactGlobalRestriction(
+        contact.id,
+        CreateContactRestrictionRequest(
+          "BAN",
+          LocalDate.now().minusDays(2),
+          LocalDate.now().plusDays(1),
+          "active",
+          "USER1",
+        ),
+      )
 
-    testAPIClient.createContactGlobalRestriction(
-      contact.id,
-      CreateContactRestrictionRequest(
-        "BAN",
-        LocalDate.now().minusDays(2),
-        LocalDate.now().minusDays(1),
-        "expired",
-        "USER1",
-      ),
-    )
-    testAPIClient.createContactGlobalRestriction(
-      contact.id,
-      CreateContactRestrictionRequest(
-        "BAN",
-        LocalDate.now().minusDays(2),
-        LocalDate.now().plusDays(1),
-        "active",
-        "USER1",
-      ),
-    )
+      testAPIClient.createPrisonerContactRestriction(
+        relationshipToPrisonerOne.prisonerContactId,
+        CreatePrisonerContactRestrictionRequest(
+          "CCTV",
+          LocalDate.now().minusDays(2),
+          LocalDate.now().minusDays(1),
+          "expired cctb",
+          "USER1",
+        ),
+      )
 
-    testAPIClient.createPrisonerContactRestriction(
-      relationshipToPrisonerOne.prisonerContactId,
-      CreatePrisonerContactRestrictionRequest(
-        "CCTV",
-        LocalDate.now().minusDays(2),
-        LocalDate.now().minusDays(1),
-        "expired cctb",
-        "USER1",
-      ),
-    )
-
-    testAPIClient.createPrisonerContactRestriction(
-      relationshipToPrisonerOne.prisonerContactId,
-      CreatePrisonerContactRestrictionRequest(
-        "BAN",
-        LocalDate.now().minusDays(2),
-        LocalDate.now().minusDays(1),
-        "expired ban",
-        "USER1",
-      ),
-    )
-
+      testAPIClient.createPrisonerContactRestriction(
+        relationshipToPrisonerOne.prisonerContactId,
+        CreatePrisonerContactRestrictionRequest(
+          "BAN",
+          LocalDate.now().minusDays(2),
+          LocalDate.now().minusDays(1),
+          "expired ban",
+          "USER1",
+        ),
+      )
+    }
     val prisonerOneContacts = testAPIClient.getPrisonerContacts(prisonerOneNumber)
     assertThat(prisonerOneContacts.content).hasSize(1)
     assertThat(prisonerOneContacts.content[0].restrictionSummary).isEqualTo(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetReferenceCodesByGroupIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetReferenceCodesByGroupIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -12,11 +13,17 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegr
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.ReferenceCodeGroup
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ReferenceCodeRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class GetReferenceCodesByGroupIntegrationTest : SecureAPIIntegrationTestBase() {
   @Autowired
   private lateinit var referenceCodeRepository: ReferenceCodeRepository
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
@@ -34,7 +34,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "address",
         firstName = "has",
-        createdBy = "created",
       ),
 
     ).id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 
@@ -30,6 +31,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address",
@@ -53,6 +55,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       ),
 
     ).contactAddressId
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.patch()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactIntegrationTest.kt
@@ -18,17 +18,23 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDate
 
 class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
   private val contactId = 21L
-  private val updatedByUser = "AUTH_ADM"
+  private val updatedByUser = "read_write_user"
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW")
 
   @Autowired
   lateinit var contactRepository: ContactRepository
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
+  }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.patch()
     .uri("/contact/123456")
@@ -52,7 +58,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -72,7 +78,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -89,7 +95,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported language (FOO)")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "AUTH_ADM"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user"))
     }
 
     @Test
@@ -107,7 +113,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -144,7 +150,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -162,7 +168,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -182,7 +188,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported interpreter required type null.")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "AUTH_ADM"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user"))
     }
 
     private fun resetInterpreterRequired(resetValue: Boolean) {
@@ -215,7 +221,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -234,7 +240,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -254,7 +260,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -271,7 +277,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported domestic status (FOO)")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "AUTH_ADM"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user"))
     }
 
     private fun resetDomesticStatus() {
@@ -306,7 +312,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -324,7 +330,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -344,7 +350,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported staff flag value null.")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "AUTH_ADM"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user"))
     }
 
     private fun resetStaffFlag(resetValue: Boolean) {
@@ -387,7 +393,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactIdThatHasDOB),
       )
     }
@@ -405,7 +411,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactIdThatHasDOB),
       )
     }
@@ -423,7 +429,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactIdThatHasDOB),
       )
     }
@@ -434,7 +440,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
     private var contactThatHasAllNameFields = 0L
 
     @BeforeEach
-    fun createContactWithDob() {
+    fun createContact() {
       contactThatHasAllNameFields = testAPIClient.createAContact(
         CreateContactRequest(
           titleCode = "MR",
@@ -459,7 +465,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactThatHasAllNameFields),
       )
     }
@@ -470,10 +476,10 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
         .uri("/contact/$contactThatHasAllNameFields")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+        .headers(setAuthorisationUsingCurrentUser())
         .bodyValue(
           """
-          { "firstName": "update first", "lastName": "update last", "middleNames": "update middle", "titleCode": "MRS", "updatedBy": "$updatedByUser" }
+          { "firstName": "update first", "lastName": "update last", "middleNames": "update middle", "titleCode": "MRS" }
           """.trimIndent(),
         )
         .exchange()
@@ -491,7 +497,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactThatHasAllNameFields),
       )
     }
@@ -512,7 +518,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactThatHasAllNameFields),
       )
     }
@@ -533,7 +539,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactThatHasAllNameFields),
       )
     }
@@ -552,7 +558,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasNoEvents(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
       )
     }
 
@@ -570,7 +576,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasNoEvents(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
       )
     }
   }
@@ -580,7 +586,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
     private var contactWithAGender = 0L
 
     @BeforeEach
-    fun createContactWithDob() {
+    fun createContact() {
       contactWithAGender = testAPIClient.createAContact(
         CreateContactRequest(
           lastName = "Last",
@@ -602,7 +608,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactWithAGender),
       )
     }
@@ -619,7 +625,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactWithAGender),
       )
     }
@@ -636,7 +642,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactWithAGender),
       )
     }
@@ -653,7 +659,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported gender (FOO)")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactWithAGender, Source.DPS, "AUTH_ADM"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactWithAGender, Source.DPS, "read_write_user"))
     }
   }
 
@@ -690,7 +696,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactWithDeceasedDate),
       )
     }
@@ -709,7 +715,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactWithDeceasedDate),
       )
     }
@@ -727,7 +733,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "AUTH_ADM"),
+        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "read_write_user"),
         personReference = PersonReference(dpsContactId = contactWithDeceasedDate),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactRelationshipIntegrationTest.kt
@@ -30,7 +30,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     .uri("/prisoner-contact/99")
     .accept(MediaType.APPLICATION_JSON)
     .contentType(MediaType.APPLICATION_JSON)
-    .bodyValue(PatchRelationshipRequest(updatedBy = "Admin"))
+    .bodyValue(PatchRelationshipRequest())
 
   @ParameterizedTest
   @CsvSource(
@@ -102,7 +102,6 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
 
     val updateRequest = PatchRelationshipRequest(
       relationshipToPrisonerCode = JsonNullable.of("SIS"),
-      updatedBy = "Admin",
     )
 
     val prisonerContactId = prisonerContact.prisonerContactId
@@ -114,7 +113,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].relationshipToPrisonerCode).isEqualTo("SIS")
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -128,7 +127,6 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     val updateRequest = PatchRelationshipRequest(
       relationshipTypeCode = JsonNullable.of("O"),
       relationshipToPrisonerCode = JsonNullable.of("DR"),
-      updatedBy = "Admin",
     )
 
     val prisonerContactId = prisonerContact.prisonerContactId
@@ -141,7 +139,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].relationshipToPrisonerCode).isEqualTo("DR")
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -154,7 +152,6 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
 
     val updateRequest = PatchRelationshipRequest(
       isNextOfKin = JsonNullable.of(true),
-      updatedBy = "Admin",
     )
 
     val prisonerContactId = prisonerContact.prisonerContactId
@@ -166,7 +163,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isNextOfKin).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -179,7 +176,6 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
 
     val updateRequest = PatchRelationshipRequest(
       isApprovedVisitor = JsonNullable.of(true),
-      updatedBy = "Admin",
     )
 
     val prisonerContactId = prisonerContact.prisonerContactId
@@ -191,7 +187,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isApprovedVisitor).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -204,7 +200,6 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
 
     val updateRequest = PatchRelationshipRequest(
       isEmergencyContact = JsonNullable.of(true),
-      updatedBy = "Admin",
     )
 
     val prisonerContactId = prisonerContact.prisonerContactId
@@ -216,7 +211,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isEmergencyContact).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -229,7 +224,6 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
 
     val updateRequest = PatchRelationshipRequest(
       isRelationshipActive = JsonNullable.of(true),
-      updatedBy = "Admin",
     )
 
     val prisonerContactId = prisonerContact.prisonerContactId
@@ -241,7 +235,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isRelationshipActive).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -254,7 +248,6 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
 
     val updateRequest = PatchRelationshipRequest(
       comments = JsonNullable.of("New comment"),
-      updatedBy = "Admin",
     )
 
     val prisonerContactId = prisonerContact.prisonerContactId
@@ -266,7 +259,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].comments).isEqualTo("New comment")
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -277,9 +270,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     stubPrisonSearchWithResponse(prisonerNumber)
     val prisonerContact = cretePrisonerContact(prisonerNumber)
 
-    val updateRequest = PatchRelationshipRequest(
-      updatedBy = "Admin",
-    )
+    val updateRequest = PatchRelationshipRequest()
 
     val prisonerContactId = prisonerContact.prisonerContactId
 
@@ -289,7 +280,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts).hasSize(1)
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -308,7 +299,6 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
       isEmergencyContact = JsonNullable.of(true),
       isRelationshipActive = JsonNullable.of(true),
       comments = JsonNullable.of("comments added"),
-      updatedBy = "Admin",
     )
 
     val prisonerContactId = prisonerContact.prisonerContactId
@@ -321,7 +311,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertUpdatedPrisonerContactEquals(updatedPrisonerContacts[0], updateRequest)
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -360,7 +350,6 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     val request = CreateContactRequest(
       lastName = RandomStringUtils.secure().next(35),
       firstName = "a new guy",
-      createdBy = "created",
       relationship = requestedRelationship,
     )
 
@@ -395,11 +384,9 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
         isEmergencyContact = JsonNullable.of(true),
         isRelationshipActive = JsonNullable.of(true),
         comments = JsonNullable.of("comments added"),
-        updatedBy = "Admin",
       )
       return listOf(
         Arguments.of("comments must be <= 240 characters", relationship.copy(comments = JsonNullable.of("".padStart(241, 'X')))),
-        Arguments.of("updatedBy must be <= 100 characters", relationship.copy(updatedBy = "".padStart(101, 'X'))),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactRelationshipIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.apache.commons.lang3.RandomStringUtils
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -20,11 +21,17 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEven
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PrisonerContactInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW")
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
+  }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.patch()
     .uri("/prisoner-contact/99")
@@ -113,7 +120,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].relationshipToPrisonerCode).isEqualTo("SIS")
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -139,7 +146,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].relationshipToPrisonerCode).isEqualTo("DR")
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -163,7 +170,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isNextOfKin).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -187,7 +194,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isApprovedVisitor).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -211,7 +218,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isEmergencyContact).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -235,7 +242,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isRelationshipActive).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -259,7 +266,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].comments).isEqualTo("New comment")
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -280,7 +287,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts).hasSize(1)
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -311,7 +318,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertUpdatedPrisonerContactEquals(updatedPrisonerContacts[0], updateRequest)
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "AUTH_ADM"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchEmploymentsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchEmploymentsIntegrationTest.kt
@@ -40,7 +40,6 @@ class PatchEmploymentsIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "employments",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
     stubOrganisationSummary(123)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchEmploymentsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchEmploymentsIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.EmploymentIn
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDateTime
 
@@ -36,6 +37,7 @@ class PatchEmploymentsIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun setUp() {
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "employments",
@@ -83,6 +85,7 @@ class PatchEmploymentsIntegrationTest : SecureAPIIntegrationTestBase() {
         updatedTime = null,
       ),
     )
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.patch()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 import org.apache.commons.lang3.RandomStringUtils
 import org.apache.commons.lang3.RandomUtils
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -11,11 +12,17 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.net.URI
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 
@@ -238,27 +245,29 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   @Test
   fun `should sort by date of birth with nulls as eldest`() {
     val randomLastName = RandomStringUtils.secure().nextAlphabetic(35)
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = randomLastName,
-        firstName = "Youngest",
-        dateOfBirth = LocalDate.of(2025, 1, 1),
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = randomLastName,
-        firstName = "Eldest",
-        dateOfBirth = LocalDate.of(1990, 1, 1),
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = randomLastName,
-        firstName = "None",
-        dateOfBirth = null,
-      ),
-    )
+    doWithTemporaryWritePermission {
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = randomLastName,
+          firstName = "Youngest",
+          dateOfBirth = LocalDate.of(2025, 1, 1),
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = randomLastName,
+          firstName = "Eldest",
+          dateOfBirth = LocalDate.of(1990, 1, 1),
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = randomLastName,
+          firstName = "None",
+          dateOfBirth = null,
+        ),
+      )
+    }
 
     val resultsEldestFirst = testAPIClient.getSearchContactResults(
       UriComponentsBuilder.fromPath("contact/search")
@@ -286,52 +295,53 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   @Test
   fun `should sort by names is specified order`() {
     val randomDob = LocalDate.now().minusDays(RandomUtils.secure().randomLong(100, 2000))
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AA",
-        firstName = "B",
-        middleNames = "C",
-        dateOfBirth = randomDob,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AA",
-        firstName = "B",
-        dateOfBirth = randomDob,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AB",
-        firstName = "A",
-        dateOfBirth = randomDob,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AB",
-        firstName = "B",
-        dateOfBirth = randomDob,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AC",
-        firstName = "C",
-        middleNames = "A",
-        dateOfBirth = randomDob,
-      ),
-    )
-    testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AC",
-        firstName = "C",
-        middleNames = "B",
-        dateOfBirth = randomDob,
-      ),
-    )
-
+    doWithTemporaryWritePermission {
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AA",
+          firstName = "B",
+          middleNames = "C",
+          dateOfBirth = randomDob,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AA",
+          firstName = "B",
+          dateOfBirth = randomDob,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AB",
+          firstName = "A",
+          dateOfBirth = randomDob,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AB",
+          firstName = "B",
+          dateOfBirth = randomDob,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AC",
+          firstName = "C",
+          middleNames = "A",
+          dateOfBirth = randomDob,
+        ),
+      )
+      testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AC",
+          firstName = "C",
+          middleNames = "B",
+          dateOfBirth = randomDob,
+        ),
+      )
+    }
     val expectedOrder = listOf(
       "AA, B C",
       "AA, B",
@@ -371,25 +381,27 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
   @Test
   fun `secondary sort by id should work`() {
     val randomDob = LocalDate.now().minusDays(RandomUtils.secure().randomLong(100, 2000))
-    val lowestId = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AA",
-        firstName = "B",
-        dateOfBirth = randomDob,
-      ),
-    ).id
-    val highestId = testAPIClient.createAContact(
-      CreateContactRequest(
-        lastName = "AA",
-        firstName = "B",
-        dateOfBirth = randomDob,
-      ),
-    ).id
+    val expectedOrder = doWithTemporaryWritePermission {
+      val lowestId = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AA",
+          firstName = "B",
+          dateOfBirth = randomDob,
+        ),
+      ).id
+      val highestId = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "AA",
+          firstName = "B",
+          dateOfBirth = randomDob,
+        ),
+      ).id
 
-    val expectedOrder = listOf(
-      lowestId,
-      highestId,
-    )
+      listOf(
+        lowestId,
+        highestId,
+      )
+    }
 
     val ascendingName = testAPIClient.getSearchContactResults(
       UriComponentsBuilder.fromPath("contact/search")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchContactsIntegrationTest.kt
@@ -243,7 +243,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = randomLastName,
         firstName = "Youngest",
         dateOfBirth = LocalDate.of(2025, 1, 1),
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -251,7 +250,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = randomLastName,
         firstName = "Eldest",
         dateOfBirth = LocalDate.of(1990, 1, 1),
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -259,7 +257,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = randomLastName,
         firstName = "None",
         dateOfBirth = null,
-        createdBy = "USER1",
       ),
     )
 
@@ -295,7 +292,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "B",
         middleNames = "C",
         dateOfBirth = randomDob,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -303,7 +299,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = "AA",
         firstName = "B",
         dateOfBirth = randomDob,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -311,7 +306,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = "AB",
         firstName = "A",
         dateOfBirth = randomDob,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -319,7 +313,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = "AB",
         firstName = "B",
         dateOfBirth = randomDob,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -328,7 +321,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "C",
         middleNames = "A",
         dateOfBirth = randomDob,
-        createdBy = "USER1",
       ),
     )
     testAPIClient.createAContact(
@@ -337,7 +329,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         firstName = "C",
         middleNames = "B",
         dateOfBirth = randomDob,
-        createdBy = "USER1",
       ),
     )
 
@@ -385,7 +376,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = "AA",
         firstName = "B",
         dateOfBirth = randomDob,
-        createdBy = "USER1",
       ),
     ).id
     val highestId = testAPIClient.createAContact(
@@ -393,7 +383,6 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
         lastName = "AA",
         firstName = "B",
         dateOfBirth = randomDob,
-        createdBy = "USER1",
       ),
     ).id
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -28,6 +29,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address",
@@ -51,6 +53,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       ),
 
     ).contactAddressId
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
@@ -32,7 +32,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "address",
         firstName = "has",
-        createdBy = "created",
       ),
 
     ).id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdateC
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddressPhoneInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class UpdateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -29,6 +30,7 @@ class UpdateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address-phone",
@@ -61,6 +63,7 @@ class UpdateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
       ),
 
     ).contactAddressPhoneId
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
@@ -33,7 +33,6 @@ class UpdateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
       CreateContactRequest(
         lastName = "address-phone",
         firstName = "has",
-        createdBy = "created",
       ),
 
     ).id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
@@ -34,7 +34,6 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "email",
         firstName = "has",
-        createdBy = "created",
       ),
 
     ).id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactEmail
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -30,6 +31,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "email",
@@ -45,6 +47,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
       ),
 
     ).contactEmailId
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactIdent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -28,6 +29,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "identity",
@@ -45,6 +47,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       ),
 
     ).contactIdentityId
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
@@ -32,7 +32,6 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "identity",
         firstName = "has",
-        createdBy = "created",
       ),
 
     ).id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
@@ -31,7 +31,6 @@ class UpdateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "phone",
         firstName = "has",
-        createdBy = "created",
       ),
 
     ).id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdateP
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactPhoneInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class UpdateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -27,6 +28,7 @@ class UpdateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "phone",
@@ -44,6 +46,7 @@ class UpdateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
       ),
 
     ).contactPhoneId
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactRestrictionIntegrationTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRestrictionRequest
@@ -34,7 +34,6 @@ class UpdateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "last",
         firstName = "first",
-        createdBy = "created",
       ),
 
     ).id
@@ -49,8 +48,8 @@ class UpdateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
       ),
 
     ).contactRestrictionId
-    stubGetUserByUsername(User("created", "Created User"))
-    stubGetUserByUsername(User("updated", "Updated User"))
+    stubGetUserByUsername(UserDetails("created", "Created User"))
+    stubGetUserByUsername(UserDetails("updated", "Updated User"))
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactRestrictionIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRestrictionRequest
@@ -19,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactRestr
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 
@@ -30,6 +30,7 @@ class UpdateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "last",
@@ -48,8 +49,7 @@ class UpdateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
       ),
 
     ).contactRestrictionId
-    stubGetUserByUsername(UserDetails("created", "Created User"))
-    stubGetUserByUsername(UserDetails("updated", "Updated User"))
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.put()
@@ -194,7 +194,7 @@ class UpdateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
       assertThat(expiryDate).isNull()
       assertThat(comments).isNull()
       assertThat(enteredByUsername).isEqualTo("updated")
-      assertThat(enteredByDisplayName).isEqualTo("Updated User")
+      assertThat(enteredByDisplayName).isEqualTo("Updated")
       assertThat(createdBy).isEqualTo("created")
       assertThat(createdTime).isNotNull()
       assertThat(updatedBy).isEqualTo("updated")
@@ -234,7 +234,7 @@ class UpdateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
       assertThat(expiryDate).isEqualTo(request.expiryDate)
       assertThat(comments).isEqualTo(request.comments)
       assertThat(enteredByUsername).isEqualTo("updated")
-      assertThat(enteredByDisplayName).isEqualTo("Updated User")
+      assertThat(enteredByDisplayName).isEqualTo("Updated")
       assertThat(createdBy).isEqualTo("created")
       assertThat(createdTime).isNotNull()
       assertThat(updatedBy).isEqualTo("updated")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateEmploymentIntegrationTest.kt
@@ -30,7 +30,6 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateContactRequest(
         lastName = "employment",
         firstName = "has",
-        createdBy = "created",
       ),
     ).id
     stubOrganisationSummary(999)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateEmploymentIntegrationTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.EmploymentIn
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
@@ -26,6 +27,7 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "employment",
@@ -42,6 +44,7 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
         createdBy = "created",
       ),
     ).employmentId
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdatePrisonerContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdatePrisonerContactRestrictionIntegrationTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEven
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PrisonerContactRestrictionInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 
@@ -33,6 +34,7 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
   @BeforeEach
   fun initialiseData() {
+    setCurrentUser(StubUser.CREATING_USER)
     stubPrisonSearchWithResponse(prisonerNumberCreatedAgainst)
     val created = testAPIClient.createAContactWithARelationship(
       CreateContactRequest(
@@ -63,6 +65,7 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
       ),
 
     ).prisonerContactRestrictionId
+    setCurrentUser(StubUser.UPDATING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdatePrisonerContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdatePrisonerContactRestrictionIntegrationTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
@@ -47,7 +47,6 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
           isApprovedVisitor = false,
           comments = "Some comments",
         ),
-        createdBy = "created",
       ),
 
     )
@@ -197,7 +196,7 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
   @Test
   fun `should update the restriction with minimal fields`() {
-    stubGetUserByUsername(User("updated", "Updated User"))
+    stubGetUserByUsername(UserDetails("updated", "Updated User"))
     val request = UpdatePrisonerContactRestrictionRequest(
       restrictionType = "CCTV",
       startDate = LocalDate.of(1990, 1, 1),
@@ -240,7 +239,7 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
   @ParameterizedTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW"])
   fun `should update the restriction with all fields`(role: String) {
-    stubGetUserByUsername(User("updated", "Updated User"))
+    stubGetUserByUsername(UserDetails("updated", "Updated User"))
     val request = UpdatePrisonerContactRestrictionRequest(
       restrictionType = "CCTV",
       startDate = LocalDate.of(1990, 1, 1),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncAdminIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncAdminIntegrationTest.kt
@@ -336,7 +336,7 @@ class SyncAdminIntegrationTest : PostgresIntegrationTestBase() {
       }
       stubEvents.assertHasEvent(
         event = OutboundEvent.PRISONER_CONTACT_DELETED,
-        additionalInfo = PrisonerContactInfo(relationship.prisonerContactId, Source.NOMIS),
+        additionalInfo = PrisonerContactInfo(relationship.prisonerContactId, Source.NOMIS, "SYS"),
         personReference = PersonReference(
           dpsContactId = relationship.contactId,
           nomsNumber = relationship.prisonerNumber,
@@ -358,7 +358,7 @@ class SyncAdminIntegrationTest : PostgresIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.PRISONER_CONTACT_CREATED,
-        additionalInfo = PrisonerContactInfo(created.relationship.dpsId, Source.NOMIS),
+        additionalInfo = PrisonerContactInfo(created.relationship.dpsId, Source.NOMIS, "SYS"),
         personReference = PersonReference(
           dpsContactId = created.contactId,
           nomsNumber = createdPrisonerNumber,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactAddressIntegrationTest.kt
@@ -326,6 +326,5 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",
     firstName = "first",
-    createdBy = "created",
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactAddressIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.sync
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -18,310 +17,310 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDateTime
 
 class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
   @Autowired
   private lateinit var contactAddressRepository: ContactAddressRepository
 
-  @Nested
-  inner class ContactAddressSyncTests {
-    private var contactId = 0L
+  private var contactId = 0L
 
-    @BeforeEach
-    fun initialiseData() {
-      contactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+  @BeforeEach
+  fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
+    contactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER)
+  }
+
+  @Test
+  fun `Sync endpoints should return unauthorized if no token provided`() {
+    webTestClient.get()
+      .uri("/sync/contact-address/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.put()
+      .uri("/sync/contact-address")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactAddressRequest(contactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.post()
+      .uri("/sync/contact-address/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactAddressRequest(contactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.delete()
+      .uri("/sync/contact-address/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
+  fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
+    webTestClient.get()
+      .uri("/sync/contact-address/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.post()
+      .uri("/sync/contact-address")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactAddressRequest(contactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.put()
+      .uri("/sync/contact-address/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactAddressRequest(contactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.delete()
+      .uri("/sync/contact-address/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should get an existing contact address`() {
+    // From base data
+    val contactAddressId = 1L
+    val contactAddress = webTestClient.get()
+      .uri("/sync/contact-address/{contactAddressId}", contactAddressId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactAddress::class.java)
+      .returnResult().responseBody!!
+
+    with(contactAddress) {
+      assertThat(addressType).isEqualTo("HOME")
+      assertThat(property).isEqualTo("24")
+      assertThat(street).isEqualTo("Acacia Avenue")
+      assertThat(primaryAddress).isTrue()
     }
+  }
 
-    @Test
-    fun `Sync endpoints should return unauthorized if no token provided`() {
-      webTestClient.get()
-        .uri("/sync/contact-address/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+  @Test
+  fun `should create a new contact address`() {
+    val contactAddress = webTestClient.post()
+      .uri("/sync/contact-address")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactAddressRequest(contactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactAddress::class.java)
+      .returnResult().responseBody!!
 
-      webTestClient.put()
-        .uri("/sync/contact-address")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactAddressRequest(contactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.post()
-        .uri("/sync/contact-address/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactAddressRequest(contactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.delete()
-        .uri("/sync/contact-address/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+    // The created address is returned
+    with(contactAddress) {
+      assertThat(flat).isEqualTo("1B")
+      assertThat(addressType).isEqualTo("HOME")
+      assertThat(comments).isEqualTo("Some comments")
+      assertThat(updatedBy).isNullOrEmpty()
+      assertThat(updatedTime).isNull()
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
     }
-
-    @ParameterizedTest
-    @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
-    fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
-      webTestClient.get()
-        .uri("/sync/contact-address/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.post()
-        .uri("/sync/contact-address")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactAddressRequest(contactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.put()
-        .uri("/sync/contact-address/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactAddressRequest(contactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.delete()
-        .uri("/sync/contact-address/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should get an existing contact address`() {
-      // From base data
-      val contactAddressId = 1L
-      val contactAddress = webTestClient.get()
-        .uri("/sync/contact-address/{contactAddressId}", contactAddressId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactAddress::class.java)
-        .returnResult().responseBody!!
-
-      with(contactAddress) {
-        assertThat(addressType).isEqualTo("HOME")
-        assertThat(property).isEqualTo("24")
-        assertThat(street).isEqualTo("Acacia Avenue")
-        assertThat(primaryAddress).isTrue()
-      }
-    }
-
-    @Test
-    fun `should create a new contact address`() {
-      val contactAddress = webTestClient.post()
-        .uri("/sync/contact-address")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactAddressRequest(contactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactAddress::class.java)
-        .returnResult().responseBody!!
-
-      // The created address is returned
-      with(contactAddress) {
-        assertThat(flat).isEqualTo("1B")
-        assertThat(addressType).isEqualTo("HOME")
-        assertThat(comments).isEqualTo("Some comments")
-        assertThat(updatedBy).isNullOrEmpty()
-        assertThat(updatedTime).isNull()
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-        additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = contactId),
-      )
-    }
-
-    @Test
-    fun `should create and then update a contact address`() {
-      val contactAddress = webTestClient.post()
-        .uri("/sync/contact-address")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactAddressRequest(contactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactAddress::class.java)
-        .returnResult().responseBody!!
-
-      with(contactAddress) {
-        assertThat(addressType).isEqualTo("HOME")
-        assertThat(flat).isEqualTo("1B")
-        assertThat(property).isEqualTo("13")
-        assertThat(street).isEqualTo("Main Street")
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      val updatedAddress = webTestClient.put()
-        .uri("/sync/contact-address/{contactAddressId}", contactAddress.contactAddressId)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(updateContactAddressRequest(contactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactAddress::class.java)
-        .returnResult().responseBody!!
-
-      // Check the updated copy
-      with(updatedAddress) {
-        assertThat(flat).isEqualTo("2B")
-        assertThat(addressType).isEqualTo("WORK")
-        assertThat(comments).isEqualTo("Updated comments")
-        assertThat(updatedBy).isEqualTo("UPDATE")
-        assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isNotNull()
-      }
-
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-        additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = contactId),
-      )
-    }
-
-    @Test
-    fun `should set the address verified details if verified on a contact address update`() {
-      // Create a contact address with default - verified = false
-      val contactAddress = webTestClient.post()
-        .uri("/sync/contact-address")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactAddressRequest(contactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactAddress::class.java)
-        .returnResult().responseBody!!
-
-      with(contactAddress) {
-        assertThat(verified).isFalse()
-        assertThat(verifiedBy).isNull()
-        assertThat(verifiedTime).isNull()
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      val updatedAddress = webTestClient.put()
-        .uri("/sync/contact-address/{contactAddressId}", contactAddress.contactAddressId)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(updateContactAddressRequest(contactId, verified = true))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactAddress::class.java)
-        .returnResult().responseBody!!
-
-      // Check the updated address is now verified (with who and when)
-      with(updatedAddress) {
-        assertThat(verified).isTrue()
-        assertThat(verifiedBy).isEqualTo("UPDATE")
-        assertThat(verifiedTime).isAfter(LocalDateTime.now().minusMinutes(5))
-        assertThat(updatedBy).isEqualTo("UPDATE")
-        assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isNotNull()
-      }
-    }
-
-    @Test
-    fun `should delete an existing contact address`() {
-      val beforeCount = contactAddressRepository.count()
-
-      webTestClient.delete()
-        .uri("/sync/contact-address/5")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-
-      val afterCount = contactAddressRepository.count()
-      assertThat(beforeCount).isEqualTo((afterCount + 1))
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_ADDRESS_DELETED,
-        additionalInfo = ContactAddressInfo(5, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = 4),
-      )
-    }
-
-    private fun updateContactAddressRequest(contactId: Long, verified: Boolean = false) = SyncUpdateContactAddressRequest(
-      contactId = contactId,
-      addressType = "WORK",
-      primaryAddress = false,
-      flat = "2B",
-      property = "14",
-      street = "Main Street",
-      area = "Dodworth",
-      cityCode = "CVNTRY",
-      countyCode = "WARWKS",
-      postcode = "CV4 9NJ",
-      countryCode = "UK",
-      comments = "Updated comments",
-      updatedBy = "UPDATE",
-      updatedTime = LocalDateTime.now(),
-      verified = verified,
-    )
-
-    private fun createContactAddressRequest(contactId: Long) = SyncCreateContactAddressRequest(
-      contactId = contactId,
-      addressType = "HOME",
-      primaryAddress = false,
-      flat = "1B",
-      property = "13",
-      street = "Main Street",
-      area = "Dodworth",
-      cityCode = "CVNTRY",
-      countyCode = "WARWKS",
-      postcode = "CV4 9NJ",
-      countryCode = "UK",
-      comments = "Some comments",
-      createdBy = "CREATE",
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_CREATED,
+      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = contactId),
     )
   }
+
+  @Test
+  fun `should create and then update a contact address`() {
+    val contactAddress = webTestClient.post()
+      .uri("/sync/contact-address")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactAddressRequest(contactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactAddress::class.java)
+      .returnResult().responseBody!!
+
+    with(contactAddress) {
+      assertThat(addressType).isEqualTo("HOME")
+      assertThat(flat).isEqualTo("1B")
+      assertThat(property).isEqualTo("13")
+      assertThat(street).isEqualTo("Main Street")
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+    }
+
+    val updatedAddress = webTestClient.put()
+      .uri("/sync/contact-address/{contactAddressId}", contactAddress.contactAddressId)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(updateContactAddressRequest(contactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactAddress::class.java)
+      .returnResult().responseBody!!
+
+    // Check the updated copy
+    with(updatedAddress) {
+      assertThat(flat).isEqualTo("2B")
+      assertThat(addressType).isEqualTo("WORK")
+      assertThat(comments).isEqualTo("Updated comments")
+      assertThat(updatedBy).isEqualTo("UPDATE")
+      assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isNotNull()
+    }
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = contactId),
+    )
+  }
+
+  @Test
+  fun `should set the address verified details if verified on a contact address update`() {
+    // Create a contact address with default - verified = false
+    val contactAddress = webTestClient.post()
+      .uri("/sync/contact-address")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactAddressRequest(contactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactAddress::class.java)
+      .returnResult().responseBody!!
+
+    with(contactAddress) {
+      assertThat(verified).isFalse()
+      assertThat(verifiedBy).isNull()
+      assertThat(verifiedTime).isNull()
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+    }
+
+    val updatedAddress = webTestClient.put()
+      .uri("/sync/contact-address/{contactAddressId}", contactAddress.contactAddressId)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(updateContactAddressRequest(contactId, verified = true))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactAddress::class.java)
+      .returnResult().responseBody!!
+
+    // Check the updated address is now verified (with who and when)
+    with(updatedAddress) {
+      assertThat(verified).isTrue()
+      assertThat(verifiedBy).isEqualTo("UPDATE")
+      assertThat(verifiedTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      assertThat(updatedBy).isEqualTo("UPDATE")
+      assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isNotNull()
+    }
+  }
+
+  @Test
+  fun `should delete an existing contact address`() {
+    val beforeCount = contactAddressRepository.count()
+
+    webTestClient.delete()
+      .uri("/sync/contact-address/5")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    val afterCount = contactAddressRepository.count()
+    assertThat(beforeCount).isEqualTo((afterCount + 1))
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_DELETED,
+      additionalInfo = ContactAddressInfo(5, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = 4),
+    )
+  }
+
+  private fun updateContactAddressRequest(contactId: Long, verified: Boolean = false) = SyncUpdateContactAddressRequest(
+    contactId = contactId,
+    addressType = "WORK",
+    primaryAddress = false,
+    flat = "2B",
+    property = "14",
+    street = "Main Street",
+    area = "Dodworth",
+    cityCode = "CVNTRY",
+    countyCode = "WARWKS",
+    postcode = "CV4 9NJ",
+    countryCode = "UK",
+    comments = "Updated comments",
+    updatedBy = "UPDATE",
+    updatedTime = LocalDateTime.now(),
+    verified = verified,
+  )
+
+  private fun createContactAddressRequest(contactId: Long) = SyncCreateContactAddressRequest(
+    contactId = contactId,
+    addressType = "HOME",
+    primaryAddress = false,
+    flat = "1B",
+    property = "13",
+    street = "Main Street",
+    area = "Dodworth",
+    cityCode = "CVNTRY",
+    countyCode = "WARWKS",
+    postcode = "CV4 9NJ",
+    countryCode = "UK",
+    comments = "Some comments",
+    createdBy = "CREATE",
+  )
 
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactEmailIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.sync
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -16,232 +15,232 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactEmail
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDateTime
 
 class SyncContactEmailIntegrationTest : PostgresIntegrationTestBase() {
 
-  @Nested
-  inner class SyncContactEmailSyncTests {
-    private var savedContactId = 0L
+  private var savedContactId = 0L
 
-    @BeforeEach
-    fun initialiseData() {
-      savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+  @BeforeEach
+  fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
+    savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER)
+  }
+
+  @Test
+  fun `Sync endpoints should return unauthorized if no token provided`() {
+    webTestClient.get()
+      .uri("/sync/contact-email/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.put()
+      .uri("/sync/contact-email")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactEmailRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.post()
+      .uri("/sync/contact-email/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactEmailRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.delete()
+      .uri("/sync/contact-email/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
+  fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
+    webTestClient.get()
+      .uri("/sync/contact-email/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.post()
+      .uri("/sync/contact-email")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactEmailRequest(savedContactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.put()
+      .uri("/sync/contact-email/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactEmailRequest(savedContactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.delete()
+      .uri("/sync/contact-email/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should get an existing contact email`() {
+    // From base data
+    val contactEmailId = 2L
+    val contactEmail = webTestClient.get()
+      .uri("/sync/contact-email/{contactEmailId}", contactEmailId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactEmail::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(contactEmail.emailAddress).isEqualTo("miss.last@example.com")
+  }
+
+  @Test
+  fun `should create a new contact email`() {
+    val contactEmail = webTestClient.post()
+      .uri("/sync/contact-email")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactEmailRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactEmail::class.java)
+      .returnResult().responseBody!!
+
+    // The created email is returned
+    with(contactEmail) {
+      assertThat(contactEmailId).isGreaterThan(3)
+      assertThat(contactId).isEqualTo(savedContactId)
+      assertThat(emailAddress).isEqualTo("test@test.co.uk")
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
     }
-
-    @Test
-    fun `Sync endpoints should return unauthorized if no token provided`() {
-      webTestClient.get()
-        .uri("/sync/contact-email/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.put()
-        .uri("/sync/contact-email")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactEmailRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.post()
-        .uri("/sync/contact-email/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactEmailRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.delete()
-        .uri("/sync/contact-email/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
-    fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
-      webTestClient.get()
-        .uri("/sync/contact-email/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.post()
-        .uri("/sync/contact-email")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactEmailRequest(savedContactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.put()
-        .uri("/sync/contact-email/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactEmailRequest(savedContactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.delete()
-        .uri("/sync/contact-email/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should get an existing contact email`() {
-      // From base data
-      val contactEmailId = 2L
-      val contactEmail = webTestClient.get()
-        .uri("/sync/contact-email/{contactEmailId}", contactEmailId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactEmail::class.java)
-        .returnResult().responseBody!!
-
-      assertThat(contactEmail.emailAddress).isEqualTo("miss.last@example.com")
-    }
-
-    @Test
-    fun `should create a new contact email`() {
-      val contactEmail = webTestClient.post()
-        .uri("/sync/contact-email")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactEmailRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactEmail::class.java)
-        .returnResult().responseBody!!
-
-      // The created email is returned
-      with(contactEmail) {
-        assertThat(contactEmailId).isGreaterThan(3)
-        assertThat(contactId).isEqualTo(savedContactId)
-        assertThat(emailAddress).isEqualTo("test@test.co.uk")
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_EMAIL_CREATED,
-        additionalInfo = ContactEmailInfo(contactEmail.contactEmailId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = contactEmail.contactId),
-      )
-    }
-
-    @Test
-    fun `should create and then update a contact email`() {
-      val contactEmail = webTestClient.post()
-        .uri("/sync/contact-email")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactEmailRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactEmail::class.java)
-        .returnResult().responseBody!!
-
-      with(contactEmail) {
-        assertThat(emailAddress).isEqualTo("test@test.co.uk")
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      val updatedEmail = webTestClient.put()
-        .uri("/sync/contact-email/{contactEmailId}", contactEmail.contactEmailId)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(updateContactEmailRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactEmail::class.java)
-        .returnResult().responseBody!!
-
-      // Check the updated copy
-      with(updatedEmail) {
-        assertThat(contactEmailId).isGreaterThan(4)
-        assertThat(contactId).isEqualTo(savedContactId)
-        assertThat(emailAddress).isEqualTo("test@test.co.uk")
-        assertThat(updatedBy).isEqualTo("UPDATE")
-        assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isNotNull()
-      }
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-        additionalInfo = ContactEmailInfo(contactEmail.contactEmailId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = contactEmail.contactId),
-      )
-    }
-
-    @Test
-    fun `should delete an existing contact email`() {
-      val contactEmailId = 3L
-
-      webTestClient.delete()
-        .uri("/sync/contact-email/{contactEmailId}", contactEmailId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-
-      webTestClient.get()
-        .uri("/sync/contact-email/{contactEmailId}", contactEmailId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isNotFound
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_EMAIL_DELETED,
-        additionalInfo = ContactEmailInfo(contactEmailId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = 3),
-      )
-    }
-
-    private fun updateContactEmailRequest(contactId: Long) = SyncUpdateContactEmailRequest(
-      contactId = contactId,
-      emailAddress = "test@test.co.uk",
-      updatedBy = "UPDATE",
-      updatedTime = LocalDateTime.now(),
-    )
-
-    private fun createContactEmailRequest(contactId: Long) = SyncCreateContactEmailRequest(
-      contactId = contactId,
-      emailAddress = "test@test.co.uk",
-      createdBy = "CREATE",
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_EMAIL_CREATED,
+      additionalInfo = ContactEmailInfo(contactEmail.contactEmailId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = contactEmail.contactId),
     )
   }
+
+  @Test
+  fun `should create and then update a contact email`() {
+    val contactEmail = webTestClient.post()
+      .uri("/sync/contact-email")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactEmailRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactEmail::class.java)
+      .returnResult().responseBody!!
+
+    with(contactEmail) {
+      assertThat(emailAddress).isEqualTo("test@test.co.uk")
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+    }
+
+    val updatedEmail = webTestClient.put()
+      .uri("/sync/contact-email/{contactEmailId}", contactEmail.contactEmailId)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(updateContactEmailRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactEmail::class.java)
+      .returnResult().responseBody!!
+
+    // Check the updated copy
+    with(updatedEmail) {
+      assertThat(contactEmailId).isGreaterThan(4)
+      assertThat(contactId).isEqualTo(savedContactId)
+      assertThat(emailAddress).isEqualTo("test@test.co.uk")
+      assertThat(updatedBy).isEqualTo("UPDATE")
+      assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isNotNull()
+    }
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_EMAIL_UPDATED,
+      additionalInfo = ContactEmailInfo(contactEmail.contactEmailId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = contactEmail.contactId),
+    )
+  }
+
+  @Test
+  fun `should delete an existing contact email`() {
+    val contactEmailId = 3L
+
+    webTestClient.delete()
+      .uri("/sync/contact-email/{contactEmailId}", contactEmailId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    webTestClient.get()
+      .uri("/sync/contact-email/{contactEmailId}", contactEmailId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_EMAIL_DELETED,
+      additionalInfo = ContactEmailInfo(contactEmailId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = 3),
+    )
+  }
+
+  private fun updateContactEmailRequest(contactId: Long) = SyncUpdateContactEmailRequest(
+    contactId = contactId,
+    emailAddress = "test@test.co.uk",
+    updatedBy = "UPDATE",
+    updatedTime = LocalDateTime.now(),
+  )
+
+  private fun createContactEmailRequest(contactId: Long) = SyncCreateContactEmailRequest(
+    contactId = contactId,
+    emailAddress = "test@test.co.uk",
+    createdBy = "CREATE",
+  )
 
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactEmailIntegrationTest.kt
@@ -246,6 +246,5 @@ class SyncContactEmailIntegrationTest : PostgresIntegrationTestBase() {
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",
     firstName = "first",
-    createdBy = "created",
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIdentityIntegrationTest.kt
@@ -264,6 +264,5 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",
     firstName = "first",
-    createdBy = "created",
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIdentityIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.sync
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -17,249 +16,249 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactIdent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDateTime
 
 class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
 
-  @Nested
-  inner class ContactIdentitySyncTests {
-    private var savedContactId = 0L
+  private var savedContactId = 0L
 
-    @BeforeEach
-    fun initialiseData() {
-      savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+  @BeforeEach
+  fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
+    savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER)
+  }
+
+  @Test
+  fun `Sync endpoints should return unauthorized if no token provided`() {
+    webTestClient.get()
+      .uri("/sync/contact-identity/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.put()
+      .uri("/sync/contact-identity")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactIdentityRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.post()
+      .uri("/sync/contact-identity/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactIdentityRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.delete()
+      .uri("/sync/contact-identity/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
+  fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
+    webTestClient.get()
+      .uri("/sync/contact-identity/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.post()
+      .uri("/sync/contact-identity")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactIdentityRequest(savedContactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.put()
+      .uri("/sync/contact-identity/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactIdentityRequest(savedContactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.delete()
+      .uri("/sync/contact-identity/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should get an existing contact identity`() {
+    // From base data
+    val contactIdentityId = 2L
+    val contactIdentity = webTestClient.get()
+      .uri("/sync/contact-identity/{contactIdentityId}", contactIdentityId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactIdentity::class.java)
+      .returnResult().responseBody!!
+
+    with(contactIdentity) {
+      assertThat(identityType).isEqualTo("PASS")
     }
+  }
 
-    @Test
-    fun `Sync endpoints should return unauthorized if no token provided`() {
-      webTestClient.get()
-        .uri("/sync/contact-identity/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+  @Test
+  fun `should create a new contact identity`() {
+    val contactIdentity = webTestClient.post()
+      .uri("/sync/contact-identity")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactIdentityRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactIdentity::class.java)
+      .returnResult().responseBody!!
 
-      webTestClient.put()
-        .uri("/sync/contact-identity")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactIdentityRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.post()
-        .uri("/sync/contact-identity/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactIdentityRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.delete()
-        .uri("/sync/contact-identity/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+    // The created identity is returned
+    with(contactIdentity) {
+      assertThat(contactIdentityId).isGreaterThan(3)
+      assertThat(contactId).isEqualTo(savedContactId)
+      assertThat(identityType).isEqualTo("PASS")
+      assertThat(issuingAuthority).isEqualTo("UKBORDER")
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
     }
-
-    @ParameterizedTest
-    @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
-    fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
-      webTestClient.get()
-        .uri("/sync/contact-identity/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.post()
-        .uri("/sync/contact-identity")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactIdentityRequest(savedContactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.put()
-        .uri("/sync/contact-identity/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactIdentityRequest(savedContactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.delete()
-        .uri("/sync/contact-identity/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should get an existing contact identity`() {
-      // From base data
-      val contactIdentityId = 2L
-      val contactIdentity = webTestClient.get()
-        .uri("/sync/contact-identity/{contactIdentityId}", contactIdentityId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactIdentity::class.java)
-        .returnResult().responseBody!!
-
-      with(contactIdentity) {
-        assertThat(identityType).isEqualTo("PASS")
-      }
-    }
-
-    @Test
-    fun `should create a new contact identity`() {
-      val contactIdentity = webTestClient.post()
-        .uri("/sync/contact-identity")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactIdentityRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactIdentity::class.java)
-        .returnResult().responseBody!!
-
-      // The created identity is returned
-      with(contactIdentity) {
-        assertThat(contactIdentityId).isGreaterThan(3)
-        assertThat(contactId).isEqualTo(savedContactId)
-        assertThat(identityType).isEqualTo("PASS")
-        assertThat(issuingAuthority).isEqualTo("UKBORDER")
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_IDENTITY_CREATED,
-        additionalInfo = ContactIdentityInfo(contactIdentity.contactIdentityId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = contactIdentity.contactId),
-      )
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-      value = [
-        "UKBORDER;UKBORDER",
-        "null;UKBORDER",
-      ],
-      delimiter = ';',
-    )
-    fun `should create and then update a contact identity`(givenIssuingAuthority: String, expectedIssuingAuthority: String) {
-      val actualGivenIssuingAuthority = if (givenIssuingAuthority == "null") null else givenIssuingAuthority
-
-      val contactIdentity = webTestClient.post()
-        .uri("/sync/contact-identity")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactIdentityRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactIdentity::class.java)
-        .returnResult().responseBody!!
-
-      with(contactIdentity) {
-        assertThat(identityType).isEqualTo("PASS")
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      val updatedIdentity = webTestClient.put()
-        .uri("/sync/contact-identity/{contactIdentityId}", contactIdentity.contactIdentityId)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(updateContactIdentityRequest(savedContactId, actualGivenIssuingAuthority))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactIdentity::class.java)
-        .returnResult().responseBody!!
-
-      // Check the updated copy
-      with(updatedIdentity) {
-        assertThat(contactIdentityId).isGreaterThan(4)
-        assertThat(contactId).isEqualTo(savedContactId)
-        assertThat(identityType).isEqualTo("PASS")
-        assertThat(issuingAuthority).isEqualTo(expectedIssuingAuthority)
-        assertThat(updatedBy).isEqualTo("UPDATE")
-        assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isNotNull()
-      }
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_IDENTITY_UPDATED,
-        additionalInfo = ContactIdentityInfo(updatedIdentity.contactIdentityId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = updatedIdentity.contactId),
-      )
-    }
-
-    @Test
-    fun `should delete an existing contact identity`() {
-      val contactIdentityId = 3L
-
-      webTestClient.delete()
-        .uri("/sync/contact-identity/{contactIdentityId}", contactIdentityId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-
-      webTestClient.get()
-        .uri("/sync/contact-identity/{contactIdentityId}", contactIdentityId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isNotFound
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_IDENTITY_DELETED,
-        additionalInfo = ContactIdentityInfo(3, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = 3),
-      )
-    }
-
-    private fun updateContactIdentityRequest(contactId: Long, issuingAuthority: String? = "UKBORDER") = SyncUpdateContactIdentityRequest(
-      contactId = contactId,
-      identityType = "PASS",
-      identityValue = "PP87878787878",
-      issuingAuthority = issuingAuthority,
-      updatedBy = "UPDATE",
-      updatedTime = LocalDateTime.now(),
-    )
-
-    private fun createContactIdentityRequest(contactId: Long, issuingAuthority: String? = "UKBORDER") = SyncCreateContactIdentityRequest(
-      contactId = contactId,
-      identityType = "PASS",
-      identityValue = "PP87878787878",
-      issuingAuthority = issuingAuthority,
-      createdBy = "CREATE",
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_IDENTITY_CREATED,
+      additionalInfo = ContactIdentityInfo(contactIdentity.contactIdentityId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = contactIdentity.contactId),
     )
   }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "UKBORDER;UKBORDER",
+      "null;UKBORDER",
+    ],
+    delimiter = ';',
+  )
+  fun `should create and then update a contact identity`(givenIssuingAuthority: String, expectedIssuingAuthority: String) {
+    val actualGivenIssuingAuthority = if (givenIssuingAuthority == "null") null else givenIssuingAuthority
+
+    val contactIdentity = webTestClient.post()
+      .uri("/sync/contact-identity")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactIdentityRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactIdentity::class.java)
+      .returnResult().responseBody!!
+
+    with(contactIdentity) {
+      assertThat(identityType).isEqualTo("PASS")
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+    }
+
+    val updatedIdentity = webTestClient.put()
+      .uri("/sync/contact-identity/{contactIdentityId}", contactIdentity.contactIdentityId)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(updateContactIdentityRequest(savedContactId, actualGivenIssuingAuthority))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactIdentity::class.java)
+      .returnResult().responseBody!!
+
+    // Check the updated copy
+    with(updatedIdentity) {
+      assertThat(contactIdentityId).isGreaterThan(4)
+      assertThat(contactId).isEqualTo(savedContactId)
+      assertThat(identityType).isEqualTo("PASS")
+      assertThat(issuingAuthority).isEqualTo(expectedIssuingAuthority)
+      assertThat(updatedBy).isEqualTo("UPDATE")
+      assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isNotNull()
+    }
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_IDENTITY_UPDATED,
+      additionalInfo = ContactIdentityInfo(updatedIdentity.contactIdentityId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = updatedIdentity.contactId),
+    )
+  }
+
+  @Test
+  fun `should delete an existing contact identity`() {
+    val contactIdentityId = 3L
+
+    webTestClient.delete()
+      .uri("/sync/contact-identity/{contactIdentityId}", contactIdentityId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    webTestClient.get()
+      .uri("/sync/contact-identity/{contactIdentityId}", contactIdentityId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_IDENTITY_DELETED,
+      additionalInfo = ContactIdentityInfo(3, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = 3),
+    )
+  }
+
+  private fun updateContactIdentityRequest(contactId: Long, issuingAuthority: String? = "UKBORDER") = SyncUpdateContactIdentityRequest(
+    contactId = contactId,
+    identityType = "PASS",
+    identityValue = "PP87878787878",
+    issuingAuthority = issuingAuthority,
+    updatedBy = "UPDATE",
+    updatedTime = LocalDateTime.now(),
+  )
+
+  private fun createContactIdentityRequest(contactId: Long, issuingAuthority: String? = "UKBORDER") = SyncCreateContactIdentityRequest(
+    contactId = contactId,
+    identityType = "PASS",
+    identityValue = "PP87878787878",
+    issuingAuthority = issuingAuthority,
+    createdBy = "CREATE",
+  )
 
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.sync
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
@@ -14,311 +13,309 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
-  @Nested
-  inner class ContactSyncTests {
+  @BeforeEach
+  fun resetEvents() {
+    stubEvents.reset()
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER)
+  }
 
-    @BeforeEach
-    fun resetEvents() {
-      stubEvents.reset()
+  @Test
+  fun `Sync endpoints should return unauthorized if no token provided`() {
+    webTestClient.get()
+      .uri("/sync/contact/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.post()
+      .uri("/sync/contact")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createSyncContactRequest(5000L))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.put()
+      .uri("/sync/contact/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactRequest())
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.delete()
+      .uri("/sync/contact/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Sync endpoints should return forbidden without an authorised role on the token`() {
+    webTestClient.get()
+      .uri("/sync/contact/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.post()
+      .uri("/sync/contact")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createSyncContactRequest(5000L))
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.put()
+      .uri("/sync/contact/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactRequest())
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.delete()
+      .uri("/sync/contact/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should get an existing contact`() {
+    // From base data
+    val contactId = 15L
+    val contact = webTestClient.get()
+      .uri("/sync/contact/{contactId}", contactId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContact::class.java)
+      .returnResult().responseBody!!
+
+    with(contact) {
+      assertThat(id).isEqualTo(15)
+      assertThat(title).isEqualTo("MRS")
+      assertThat(firstName).isEqualTo("Carl")
+      assertThat(lastName).isEqualTo("Fifteen")
+      assertThat(middleName).isEqualTo("Middle")
+      assertThat(dateOfBirth).isEqualTo(LocalDate.of(2000, 11, 26))
+      assertThat(isStaff).isFalse
+      assertThat(deceasedFlag).isFalse
+      assertThat(deceasedDate).isEqualTo("2024-01-26")
+      assertThat(gender).isEqualTo("F")
+      assertThat(domesticStatus).isEqualTo("S")
+      assertThat(languageCode).isEqualTo("ENG")
+      assertThat(interpreterRequired).isFalse
+      assertThat(createdBy).isEqualTo("TIM")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      assertThat(updatedBy).isNull()
+      assertThat(updatedTime).isNull()
+    }
+  }
+
+  @Test
+  fun `should create a new contact`() {
+    val contact = testAPIClient.syncCreateAnContact(createSyncContactRequest(5000L))
+
+    // The created is returned
+    with(contact) {
+      assertThat(id).isEqualTo(5000L)
+      assertThat(title).isEqualTo("MR")
+      assertThat(firstName).isEqualTo("John")
+      assertThat(lastName).isEqualTo("Doe")
+      assertThat(middleName).isEqualTo("William")
+      assertThat(dateOfBirth).isEqualTo(LocalDate.of(1980, 1, 1))
+      assertThat(isStaff).isFalse
+      assertThat(deceasedFlag).isFalse
+      assertThat(deceasedDate).isNull()
+      assertThat(gender).isEqualTo("M")
+      assertThat(domesticStatus).isEqualTo("S")
+      assertThat(languageCode).isEqualTo("EN")
+      assertThat(interpreterRequired).isFalse
+      assertThat(createdBy).isEqualTo("JD000001")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
     }
 
-    @Test
-    fun `Sync endpoints should return unauthorized if no token provided`() {
-      webTestClient.get()
-        .uri("/sync/contact/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.post()
-        .uri("/sync/contact")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createSyncContactRequest(5000L))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.put()
-        .uri("/sync/contact/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactRequest())
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.delete()
-        .uri("/sync/contact/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `Sync endpoints should return forbidden without an authorised role on the token`() {
-      webTestClient.get()
-        .uri("/sync/contact/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.post()
-        .uri("/sync/contact")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createSyncContactRequest(5000L))
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.put()
-        .uri("/sync/contact/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactRequest())
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.delete()
-        .uri("/sync/contact/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should get an existing contact`() {
-      // From base data
-      val contactId = 15L
-      val contact = webTestClient.get()
-        .uri("/sync/contact/{contactId}", contactId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContact::class.java)
-        .returnResult().responseBody!!
-
-      with(contact) {
-        assertThat(id).isEqualTo(15)
-        assertThat(title).isEqualTo("MRS")
-        assertThat(firstName).isEqualTo("Carl")
-        assertThat(lastName).isEqualTo("Fifteen")
-        assertThat(middleName).isEqualTo("Middle")
-        assertThat(dateOfBirth).isEqualTo(LocalDate.of(2000, 11, 26))
-        assertThat(isStaff).isFalse
-        assertThat(deceasedFlag).isFalse
-        assertThat(deceasedDate).isEqualTo("2024-01-26")
-        assertThat(gender).isEqualTo("F")
-        assertThat(domesticStatus).isEqualTo("S")
-        assertThat(languageCode).isEqualTo("ENG")
-        assertThat(interpreterRequired).isFalse
-        assertThat(createdBy).isEqualTo("TIM")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-        assertThat(updatedBy).isNull()
-        assertThat(updatedTime).isNull()
-      }
-    }
-
-    @Test
-    fun `should create a new contact`() {
-      val contact = testAPIClient.syncCreateAnContact(createSyncContactRequest(5000L))
-
-      // The created is returned
-      with(contact) {
-        assertThat(id).isEqualTo(5000L)
-        assertThat(title).isEqualTo("MR")
-        assertThat(firstName).isEqualTo("John")
-        assertThat(lastName).isEqualTo("Doe")
-        assertThat(middleName).isEqualTo("William")
-        assertThat(dateOfBirth).isEqualTo(LocalDate.of(1980, 1, 1))
-        assertThat(isStaff).isFalse
-        assertThat(deceasedFlag).isFalse
-        assertThat(deceasedDate).isNull()
-        assertThat(gender).isEqualTo("M")
-        assertThat(domesticStatus).isEqualTo("S")
-        assertThat(languageCode).isEqualTo("EN")
-        assertThat(interpreterRequired).isFalse
-        assertThat(createdBy).isEqualTo("JD000001")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_CREATED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
-        personReference = PersonReference(dpsContactId = contact.id),
-      )
-    }
-
-    @Test
-    fun `should create and then update a contact`() {
-      val contact = testAPIClient.syncCreateAnContact(createSyncContactRequest(5001L))
-
-      with(contact) {
-        assertThat(id).isEqualTo(5001L)
-        assertThat(title).isEqualTo("MR")
-        assertThat(firstName).isEqualTo("John")
-        assertThat(lastName).isEqualTo("Doe")
-        assertThat(middleName).isEqualTo("William")
-        assertThat(createdBy).isEqualTo("JD000001")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_CREATED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
-        personReference = PersonReference(dpsContactId = contact.id),
-      )
-
-      val updatedContact = webTestClient.put()
-        .uri("/sync/contact/{contactId}", contact.id)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(updateContactRequest())
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContact::class.java)
-        .returnResult().responseBody!!
-
-      // Check the updated copy
-      with(updatedContact) {
-        assertThat(id).isEqualTo(5001L)
-        assertThat(title).isEqualTo("MR")
-        assertThat(firstName).isEqualTo("John")
-        assertThat(lastName).isEqualTo("Doe")
-        assertThat(middleName).isEqualTo("William")
-        assertThat(dateOfBirth).isEqualTo(LocalDate.of(1980, 1, 1))
-        assertThat(createdBy).isEqualTo("JD000001")
-        assertThat(isStaff).isFalse
-        assertThat(deceasedFlag).isFalse
-        assertThat(deceasedDate).isNull()
-        assertThat(gender).isEqualTo("M")
-        assertThat(domesticStatus).isEqualTo("S")
-        assertThat(languageCode).isEqualTo("EN")
-        assertThat(interpreterRequired).isTrue()
-        assertThat(updatedBy).isEqualTo("UPDATE")
-        assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
-        personReference = PersonReference(dpsContactId = contact.id),
-      )
-    }
-
-    @Test
-    fun `should delete an existing contact`() {
-      val contact = testAPIClient.syncCreateAnContact(createSyncContactRequest(5002L))
-
-      webTestClient.delete()
-        .uri("/sync/contact/{contactId}", contact.id)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-
-      webTestClient.get()
-        .uri("/sync/contact/{contactId}", contact.id)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isNotFound
-
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_CREATED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
-        personReference = PersonReference(dpsContactId = contact.id),
-      )
-
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_DELETED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
-        personReference = PersonReference(dpsContactId = contact.id),
-      )
-    }
-
-    @Test
-    fun `should support pageable contact IDs for reconciliation`() {
-      testAPIClient.syncCreateAnContact(createSyncContactRequest(5005L))
-      testAPIClient.syncCreateAnContact(createSyncContactRequest(5006L))
-      testAPIClient.syncCreateAnContact(createSyncContactRequest(5007L))
-
-      val firstPage = testAPIClient.syncReconcileContacts(0, 2)
-      with(firstPage) {
-        assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
-        assertThat(content).hasSize(2)
-        assertThat(content).extracting("contactId").hasSize(2)
-      }
-
-      val secondPage = testAPIClient.syncReconcileContacts(1, 2)
-      with(secondPage) {
-        assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
-        assertThat(content.size).isGreaterThanOrEqualTo(1)
-      }
-
-      val bigPage = testAPIClient.syncReconcileContacts(0, 100)
-      with(bigPage) {
-        assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
-        assertThat(content.size).isGreaterThanOrEqualTo(3)
-        assertThat(content).extracting("contactId").containsAll(listOf(5005L, 5006L, 5007L))
-      }
-    }
-
-    private fun updateContactRequest() = SyncUpdateContactRequest(
-      title = "MR",
-      firstName = "John",
-      lastName = "Doe",
-      middleName = "William",
-      dateOfBirth = LocalDate.of(1980, 1, 1),
-      isStaff = false,
-      deceasedFlag = false,
-      deceasedDate = null,
-      gender = "M",
-      domesticStatus = "S",
-      languageCode = "EN",
-      interpreterRequired = true,
-      updatedBy = "UPDATE",
-      updatedTime = LocalDateTime.now(),
-    )
-
-    private fun createSyncContactRequest(personId: Long = 0L) = SyncCreateContactRequest(
-      personId = personId,
-      firstName = "John",
-      title = "MR",
-      lastName = "Doe",
-      middleName = "William",
-      dateOfBirth = LocalDate.of(1980, 1, 1),
-      createdBy = "JD000001",
-      isStaff = false,
-      deceasedFlag = false,
-      deceasedDate = null,
-      gender = "M",
-      domesticStatus = "S",
-      languageCode = "EN",
-      interpreterRequired = false,
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_CREATED,
+      additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
+      personReference = PersonReference(dpsContactId = contact.id),
     )
   }
+
+  @Test
+  fun `should create and then update a contact`() {
+    val contact = testAPIClient.syncCreateAnContact(createSyncContactRequest(5001L))
+
+    with(contact) {
+      assertThat(id).isEqualTo(5001L)
+      assertThat(title).isEqualTo("MR")
+      assertThat(firstName).isEqualTo("John")
+      assertThat(lastName).isEqualTo("Doe")
+      assertThat(middleName).isEqualTo("William")
+      assertThat(createdBy).isEqualTo("JD000001")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+    }
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_CREATED,
+      additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
+      personReference = PersonReference(dpsContactId = contact.id),
+    )
+
+    val updatedContact = webTestClient.put()
+      .uri("/sync/contact/{contactId}", contact.id)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(updateContactRequest())
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContact::class.java)
+      .returnResult().responseBody!!
+
+    // Check the updated copy
+    with(updatedContact) {
+      assertThat(id).isEqualTo(5001L)
+      assertThat(title).isEqualTo("MR")
+      assertThat(firstName).isEqualTo("John")
+      assertThat(lastName).isEqualTo("Doe")
+      assertThat(middleName).isEqualTo("William")
+      assertThat(dateOfBirth).isEqualTo(LocalDate.of(1980, 1, 1))
+      assertThat(createdBy).isEqualTo("JD000001")
+      assertThat(isStaff).isFalse
+      assertThat(deceasedFlag).isFalse
+      assertThat(deceasedDate).isNull()
+      assertThat(gender).isEqualTo("M")
+      assertThat(domesticStatus).isEqualTo("S")
+      assertThat(languageCode).isEqualTo("EN")
+      assertThat(interpreterRequired).isTrue()
+      assertThat(updatedBy).isEqualTo("UPDATE")
+      assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
+    }
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_UPDATED,
+      additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
+      personReference = PersonReference(dpsContactId = contact.id),
+    )
+  }
+
+  @Test
+  fun `should delete an existing contact`() {
+    val contact = testAPIClient.syncCreateAnContact(createSyncContactRequest(5002L))
+
+    webTestClient.delete()
+      .uri("/sync/contact/{contactId}", contact.id)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    webTestClient.get()
+      .uri("/sync/contact/{contactId}", contact.id)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_CREATED,
+      additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
+      personReference = PersonReference(dpsContactId = contact.id),
+    )
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_DELETED,
+      additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
+      personReference = PersonReference(dpsContactId = contact.id),
+    )
+  }
+
+  @Test
+  fun `should support pageable contact IDs for reconciliation`() {
+    testAPIClient.syncCreateAnContact(createSyncContactRequest(5005L))
+    testAPIClient.syncCreateAnContact(createSyncContactRequest(5006L))
+    testAPIClient.syncCreateAnContact(createSyncContactRequest(5007L))
+
+    val firstPage = testAPIClient.syncReconcileContacts(0, 2)
+    with(firstPage) {
+      assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
+      assertThat(content).hasSize(2)
+      assertThat(content).extracting("contactId").hasSize(2)
+    }
+
+    val secondPage = testAPIClient.syncReconcileContacts(1, 2)
+    with(secondPage) {
+      assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
+      assertThat(content.size).isGreaterThanOrEqualTo(1)
+    }
+
+    val bigPage = testAPIClient.syncReconcileContacts(0, 100)
+    with(bigPage) {
+      assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
+      assertThat(content.size).isGreaterThanOrEqualTo(3)
+      assertThat(content).extracting("contactId").containsAll(listOf(5005L, 5006L, 5007L))
+    }
+  }
+
+  private fun updateContactRequest() = SyncUpdateContactRequest(
+    title = "MR",
+    firstName = "John",
+    lastName = "Doe",
+    middleName = "William",
+    dateOfBirth = LocalDate.of(1980, 1, 1),
+    isStaff = false,
+    deceasedFlag = false,
+    deceasedDate = null,
+    gender = "M",
+    domesticStatus = "S",
+    languageCode = "EN",
+    interpreterRequired = true,
+    updatedBy = "UPDATE",
+    updatedTime = LocalDateTime.now(),
+  )
+
+  private fun createSyncContactRequest(personId: Long = 0L) = SyncCreateContactRequest(
+    personId = personId,
+    firstName = "John",
+    title = "MR",
+    lastName = "Doe",
+    middleName = "William",
+    dateOfBirth = LocalDate.of(1980, 1, 1),
+    createdBy = "JD000001",
+    isStaff = false,
+    deceasedFlag = false,
+    deceasedDate = null,
+    gender = "M",
+    domesticStatus = "S",
+    languageCode = "EN",
+    interpreterRequired = false,
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIntegrationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.PostgresIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdateContactRequest
@@ -161,7 +162,7 @@ class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_CREATED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS),
+        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
         personReference = PersonReference(dpsContactId = contact.id),
       )
     }
@@ -182,7 +183,7 @@ class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_CREATED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS),
+        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
         personReference = PersonReference(dpsContactId = contact.id),
       )
 
@@ -221,7 +222,7 @@ class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS),
+        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
         personReference = PersonReference(dpsContactId = contact.id),
       )
     }
@@ -248,13 +249,13 @@ class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_CREATED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS),
+        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
         personReference = PersonReference(dpsContactId = contact.id),
       )
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_DELETED,
-        additionalInfo = ContactInfo(contact.id, Source.NOMIS),
+        additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
         personReference = PersonReference(dpsContactId = contact.id),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactPhoneIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.sync
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -16,244 +15,244 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactPhone
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDateTime
 
 class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
 
-  @Nested
-  inner class SyncContactPhoneSyncTests {
-    private var savedContactId = 0L
+  private var savedContactId = 0L
 
-    @BeforeEach
-    fun initialiseData() {
-      savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+  @BeforeEach
+  fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
+    savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER)
+  }
+
+  @Test
+  fun `Sync endpoints should return unauthorized if no token provided`() {
+    webTestClient.get()
+      .uri("/sync/contact-phone/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.put()
+      .uri("/sync/contact-phone")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactPhoneRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.post()
+      .uri("/sync/contact-phone/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactPhoneRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.delete()
+      .uri("/sync/contact-phone/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
+  fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
+    webTestClient.get()
+      .uri("/sync/contact-phone/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.post()
+      .uri("/sync/contact-phone")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactPhoneRequest(savedContactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.put()
+      .uri("/sync/contact-phone/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactPhoneRequest(savedContactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.delete()
+      .uri("/sync/contact-phone/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should get an existing contact phone`() {
+    // From base data
+    val contactPhoneId = 3L
+    val contactPhone = webTestClient.get()
+      .uri("/sync/contact-phone/{contactPhoneId}", contactPhoneId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactPhone::class.java)
+      .returnResult().responseBody!!
+
+    with(contactPhone) {
+      assertThat(phoneType).isEqualTo("MOB")
+      assertThat(phoneNumber).isEqualTo("07878 222222")
     }
+  }
 
-    @Test
-    fun `Sync endpoints should return unauthorized if no token provided`() {
-      webTestClient.get()
-        .uri("/sync/contact-phone/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+  @Test
+  fun `should create a new contact phone`() {
+    val contactPhone = webTestClient.post()
+      .uri("/sync/contact-phone")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactPhoneRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactPhone::class.java)
+      .returnResult().responseBody!!
 
-      webTestClient.put()
-        .uri("/sync/contact-phone")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactPhoneRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.post()
-        .uri("/sync/contact-phone/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactPhoneRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.delete()
-        .uri("/sync/contact-phone/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+    // The created phone is returned
+    with(contactPhone) {
+      assertThat(contactPhoneId).isGreaterThan(10L)
+      assertThat(contactId).isEqualTo(savedContactId)
+      assertThat(phoneType).isEqualTo("Mobile")
+      assertThat(phoneNumber).isEqualTo("555-1234")
+      assertThat(extNumber).isEqualTo("101")
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
     }
-
-    @ParameterizedTest
-    @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
-    fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
-      webTestClient.get()
-        .uri("/sync/contact-phone/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.post()
-        .uri("/sync/contact-phone")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactPhoneRequest(savedContactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.put()
-        .uri("/sync/contact-phone/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactPhoneRequest(savedContactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.delete()
-        .uri("/sync/contact-phone/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should get an existing contact phone`() {
-      // From base data
-      val contactPhoneId = 3L
-      val contactPhone = webTestClient.get()
-        .uri("/sync/contact-phone/{contactPhoneId}", contactPhoneId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactPhone::class.java)
-        .returnResult().responseBody!!
-
-      with(contactPhone) {
-        assertThat(phoneType).isEqualTo("MOB")
-        assertThat(phoneNumber).isEqualTo("07878 222222")
-      }
-    }
-
-    @Test
-    fun `should create a new contact phone`() {
-      val contactPhone = webTestClient.post()
-        .uri("/sync/contact-phone")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactPhoneRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactPhone::class.java)
-        .returnResult().responseBody!!
-
-      // The created phone is returned
-      with(contactPhone) {
-        assertThat(contactPhoneId).isGreaterThan(10L)
-        assertThat(contactId).isEqualTo(savedContactId)
-        assertThat(phoneType).isEqualTo("Mobile")
-        assertThat(phoneNumber).isEqualTo("555-1234")
-        assertThat(extNumber).isEqualTo("101")
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_PHONE_CREATED,
-        additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = contactPhone.contactId),
-      )
-    }
-
-    @Test
-    fun `should create and then update a contact phone`() {
-      val contactPhone = webTestClient.post()
-        .uri("/sync/contact-phone")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactPhoneRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactPhone::class.java)
-        .returnResult().responseBody!!
-
-      with(contactPhone) {
-        assertThat(phoneType).isEqualTo("Mobile")
-        assertThat(phoneNumber).isEqualTo("555-1234")
-        assertThat(extNumber).isEqualTo("101")
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      val updatedPhone = webTestClient.put()
-        .uri("/sync/contact-phone/{contactPhoneId}", contactPhone.contactPhoneId)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(updateContactPhoneRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactPhone::class.java)
-        .returnResult().responseBody!!
-
-      // Check the updated copy
-      with(updatedPhone) {
-        assertThat(contactPhoneId).isGreaterThan(10)
-        assertThat(contactId).isEqualTo(savedContactId)
-        assertThat(phoneType).isEqualTo("Mobile")
-        assertThat(phoneNumber).isEqualTo("555-1234")
-        assertThat(updatedBy).isEqualTo("UPDATE")
-        assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isNotNull()
-      }
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_PHONE_UPDATED,
-        additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = contactPhone.contactId),
-      )
-    }
-
-    @Test
-    fun `should delete an existing contact phone`() {
-      val contactPhoneId = 11L
-
-      webTestClient.delete()
-        .uri("/sync/contact-phone/{contactPhoneId}", contactPhoneId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-
-      webTestClient.get()
-        .uri("/sync/contact-phone/{contactPhoneId}", contactPhoneId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isNotFound
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_PHONE_DELETED,
-        additionalInfo = ContactPhoneInfo(contactPhoneId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = 10),
-      )
-    }
-
-    private fun updateContactPhoneRequest(contactId: Long) = SyncUpdateContactPhoneRequest(
-      contactId = contactId,
-      phoneType = "Mobile",
-      phoneNumber = "555-1234",
-      extNumber = "101",
-      updatedBy = "UPDATE",
-      updatedTime = LocalDateTime.now(),
-    )
-
-    private fun createContactPhoneRequest(contactId: Long) = SyncCreateContactPhoneRequest(
-      contactId = contactId,
-      phoneType = "Mobile",
-      phoneNumber = "555-1234",
-      extNumber = "101",
-      createdBy = "CREATE",
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_PHONE_CREATED,
+      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = contactPhone.contactId),
     )
   }
+
+  @Test
+  fun `should create and then update a contact phone`() {
+    val contactPhone = webTestClient.post()
+      .uri("/sync/contact-phone")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactPhoneRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactPhone::class.java)
+      .returnResult().responseBody!!
+
+    with(contactPhone) {
+      assertThat(phoneType).isEqualTo("Mobile")
+      assertThat(phoneNumber).isEqualTo("555-1234")
+      assertThat(extNumber).isEqualTo("101")
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+    }
+
+    val updatedPhone = webTestClient.put()
+      .uri("/sync/contact-phone/{contactPhoneId}", contactPhone.contactPhoneId)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(updateContactPhoneRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactPhone::class.java)
+      .returnResult().responseBody!!
+
+    // Check the updated copy
+    with(updatedPhone) {
+      assertThat(contactPhoneId).isGreaterThan(10)
+      assertThat(contactId).isEqualTo(savedContactId)
+      assertThat(phoneType).isEqualTo("Mobile")
+      assertThat(phoneNumber).isEqualTo("555-1234")
+      assertThat(updatedBy).isEqualTo("UPDATE")
+      assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isNotNull()
+    }
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_PHONE_UPDATED,
+      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = contactPhone.contactId),
+    )
+  }
+
+  @Test
+  fun `should delete an existing contact phone`() {
+    val contactPhoneId = 11L
+
+    webTestClient.delete()
+      .uri("/sync/contact-phone/{contactPhoneId}", contactPhoneId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    webTestClient.get()
+      .uri("/sync/contact-phone/{contactPhoneId}", contactPhoneId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_PHONE_DELETED,
+      additionalInfo = ContactPhoneInfo(contactPhoneId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = 10),
+    )
+  }
+
+  private fun updateContactPhoneRequest(contactId: Long) = SyncUpdateContactPhoneRequest(
+    contactId = contactId,
+    phoneType = "Mobile",
+    phoneNumber = "555-1234",
+    extNumber = "101",
+    updatedBy = "UPDATE",
+    updatedTime = LocalDateTime.now(),
+  )
+
+  private fun createContactPhoneRequest(contactId: Long) = SyncCreateContactPhoneRequest(
+    contactId = contactId,
+    phoneType = "Mobile",
+    phoneNumber = "555-1234",
+    extNumber = "101",
+    createdBy = "CREATE",
+  )
 
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactPhoneIntegrationTest.kt
@@ -258,6 +258,5 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",
     firstName = "first",
-    createdBy = "created",
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactRestrictionIntegrationTest.kt
@@ -265,6 +265,5 @@ class SyncContactRestrictionIntegrationTest : PostgresIntegrationTestBase() {
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",
     firstName = "first",
-    createdBy = "created",
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactRestrictionIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.sync
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -16,251 +15,251 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactRestr
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 class SyncContactRestrictionIntegrationTest : PostgresIntegrationTestBase() {
 
-  @Nested
-  inner class ContactRestrictionSyncTests {
-    private var savedContactId = 0L
+  private var savedContactId = 0L
 
-    @BeforeEach
-    fun initialiseData() {
-      savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+  @BeforeEach
+  fun initialiseData() {
+    setCurrentUser(StubUser.READ_WRITE_USER)
+    savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER)
+  }
+
+  @Test
+  fun `Sync endpoints should return unauthorized if no token provided`() {
+    webTestClient.get()
+      .uri("/sync/contact-restriction/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.put()
+      .uri("/sync/contact-restriction")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactRestrictionRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.post()
+      .uri("/sync/contact-restriction/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactRestrictionRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.delete()
+      .uri("/sync/contact-restriction/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
+  fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
+    webTestClient.get()
+      .uri("/sync/contact-restriction/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.post()
+      .uri("/sync/contact-restriction")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createContactRestrictionRequest(savedContactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.put()
+      .uri("/sync/contact-restriction/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateContactRestrictionRequest(savedContactId))
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.delete()
+      .uri("/sync/contact-restriction/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(role)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should get an existing contact restriction`() {
+    // From base data
+    val contactRestrictionId = 2L
+    val contactRestriction = webTestClient.get()
+      .uri("/sync/contact-restriction/{contactRestrictionId}", contactRestrictionId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactRestriction::class.java)
+      .returnResult().responseBody!!
+
+    with(contactRestriction) {
+      assertThat(restrictionType).isEqualTo("BAN")
+      assertThat(startDate).isEqualTo(LocalDate.of(2000, 11, 21))
+      assertThat(expiryDate).isEqualTo(LocalDate.of(2005, 11, 21))
+      assertThat(comments).isEqualTo("N/A")
     }
+  }
 
-    @Test
-    fun `Sync endpoints should return unauthorized if no token provided`() {
-      webTestClient.get()
-        .uri("/sync/contact-restriction/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+  @Test
+  fun `should create a new contact restriction`() {
+    val contactRestriction = webTestClient.post()
+      .uri("/sync/contact-restriction")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactRestrictionRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactRestriction::class.java)
+      .returnResult().responseBody!!
 
-      webTestClient.put()
-        .uri("/sync/contact-restriction")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactRestrictionRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.post()
-        .uri("/sync/contact-restriction/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactRestrictionRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-
-      webTestClient.delete()
-        .uri("/sync/contact-restriction/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+    // The created restriction is returned
+    with(contactRestriction) {
+      assertThat(contactRestrictionId).isGreaterThan(0)
+      assertThat(contactId).isEqualTo(savedContactId)
+      assertThat(restrictionType).isEqualTo("NEW")
+      assertThat(startDate).isEqualTo(LocalDate.of(1982, 6, 15))
+      assertThat(expiryDate).isEqualTo(LocalDate.of(2025, 6, 15))
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
     }
-
-    @ParameterizedTest
-    @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
-    fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
-      webTestClient.get()
-        .uri("/sync/contact-restriction/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.post()
-        .uri("/sync/contact-restriction")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createContactRestrictionRequest(savedContactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.put()
-        .uri("/sync/contact-restriction/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateContactRestrictionRequest(savedContactId))
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-
-      webTestClient.delete()
-        .uri("/sync/contact-restriction/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf(role)))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should get an existing contact restriction`() {
-      // From base data
-      val contactRestrictionId = 2L
-      val contactRestriction = webTestClient.get()
-        .uri("/sync/contact-restriction/{contactRestrictionId}", contactRestrictionId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactRestriction::class.java)
-        .returnResult().responseBody!!
-
-      with(contactRestriction) {
-        assertThat(restrictionType).isEqualTo("BAN")
-        assertThat(startDate).isEqualTo(LocalDate.of(2000, 11, 21))
-        assertThat(expiryDate).isEqualTo(LocalDate.of(2005, 11, 21))
-        assertThat(comments).isEqualTo("N/A")
-      }
-    }
-
-    @Test
-    fun `should create a new contact restriction`() {
-      val contactRestriction = webTestClient.post()
-        .uri("/sync/contact-restriction")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactRestrictionRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactRestriction::class.java)
-        .returnResult().responseBody!!
-
-      // The created restriction is returned
-      with(contactRestriction) {
-        assertThat(contactRestrictionId).isGreaterThan(0)
-        assertThat(contactId).isEqualTo(savedContactId)
-        assertThat(restrictionType).isEqualTo("NEW")
-        assertThat(startDate).isEqualTo(LocalDate.of(1982, 6, 15))
-        assertThat(expiryDate).isEqualTo(LocalDate.of(2025, 6, 15))
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_RESTRICTION_CREATED,
-        additionalInfo = ContactRestrictionInfo(contactRestriction.contactRestrictionId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = contactRestriction.contactId),
-      )
-    }
-
-    @Test
-    fun `should create and then update a contact restriction`() {
-      val contactRestriction = webTestClient.post()
-        .uri("/sync/contact-restriction")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createContactRestrictionRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactRestriction::class.java)
-        .returnResult().responseBody!!
-
-      with(contactRestriction) {
-        assertThat(restrictionType).isEqualTo("NEW")
-        assertThat(startDate).isEqualTo(LocalDate.of(1982, 6, 15))
-        assertThat(expiryDate).isEqualTo(LocalDate.of(2025, 6, 15))
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      val updatedRestriction = webTestClient.put()
-        .uri("/sync/contact-restriction/{contactRestrictionId}", contactRestriction.contactRestrictionId)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(updateContactRestrictionRequest(savedContactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncContactRestriction::class.java)
-        .returnResult().responseBody!!
-
-      // Check the updated copy
-      with(updatedRestriction) {
-        assertThat(contactRestrictionId).isGreaterThan(0)
-        assertThat(contactId).isEqualTo(savedContactId)
-        assertThat(restrictionType).isEqualTo("RESTRICTION")
-        assertThat(startDate).isEqualTo(LocalDate.of(1982, 6, 15))
-        assertThat(expiryDate).isEqualTo(LocalDate.of(1988, 6, 15))
-        assertThat(comments).isEqualTo("N/A")
-        assertThat(updatedBy).isEqualTo("UPDATE")
-        assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
-        assertThat(createdBy).isEqualTo("CREATE")
-        assertThat(createdTime).isNotNull()
-      }
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_RESTRICTION_UPDATED,
-        additionalInfo = ContactRestrictionInfo(updatedRestriction.contactRestrictionId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = updatedRestriction.contactId),
-      )
-    }
-
-    @Test
-    fun `should delete an existing contact restriction`() {
-      val contactRestrictionId = 3L
-
-      webTestClient.delete()
-        .uri("/sync/contact-restriction/{contactRestrictionId}", contactRestrictionId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-
-      webTestClient.get()
-        .uri("/sync/contact-restriction/{contactRestrictionId}", contactRestrictionId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isNotFound
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.CONTACT_RESTRICTION_DELETED,
-        additionalInfo = ContactRestrictionInfo(contactRestrictionId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = 3),
-      )
-    }
-
-    private fun updateContactRestrictionRequest(contactId: Long) = SyncUpdateContactRestrictionRequest(
-      contactId = contactId,
-      restrictionType = "RESTRICTION",
-      startDate = LocalDate.of(1982, 6, 15),
-      expiryDate = LocalDate.of(1988, 6, 15),
-      comments = "N/A",
-      updatedBy = "UPDATE",
-      updatedTime = LocalDateTime.now(),
-    )
-
-    private fun createContactRestrictionRequest(contactId: Long) = SyncCreateContactRestrictionRequest(
-      contactId = contactId,
-      restrictionType = "NEW",
-      startDate = LocalDate.of(1982, 6, 15),
-      expiryDate = LocalDate.of(2025, 6, 15),
-      comments = "N/A",
-      createdBy = "CREATE",
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_RESTRICTION_CREATED,
+      additionalInfo = ContactRestrictionInfo(contactRestriction.contactRestrictionId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = contactRestriction.contactId),
     )
   }
+
+  @Test
+  fun `should create and then update a contact restriction`() {
+    val contactRestriction = webTestClient.post()
+      .uri("/sync/contact-restriction")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createContactRestrictionRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactRestriction::class.java)
+      .returnResult().responseBody!!
+
+    with(contactRestriction) {
+      assertThat(restrictionType).isEqualTo("NEW")
+      assertThat(startDate).isEqualTo(LocalDate.of(1982, 6, 15))
+      assertThat(expiryDate).isEqualTo(LocalDate.of(2025, 6, 15))
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+    }
+
+    val updatedRestriction = webTestClient.put()
+      .uri("/sync/contact-restriction/{contactRestrictionId}", contactRestriction.contactRestrictionId)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(updateContactRestrictionRequest(savedContactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncContactRestriction::class.java)
+      .returnResult().responseBody!!
+
+    // Check the updated copy
+    with(updatedRestriction) {
+      assertThat(contactRestrictionId).isGreaterThan(0)
+      assertThat(contactId).isEqualTo(savedContactId)
+      assertThat(restrictionType).isEqualTo("RESTRICTION")
+      assertThat(startDate).isEqualTo(LocalDate.of(1982, 6, 15))
+      assertThat(expiryDate).isEqualTo(LocalDate.of(1988, 6, 15))
+      assertThat(comments).isEqualTo("N/A")
+      assertThat(updatedBy).isEqualTo("UPDATE")
+      assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      assertThat(createdBy).isEqualTo("CREATE")
+      assertThat(createdTime).isNotNull()
+    }
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_RESTRICTION_UPDATED,
+      additionalInfo = ContactRestrictionInfo(updatedRestriction.contactRestrictionId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = updatedRestriction.contactId),
+    )
+  }
+
+  @Test
+  fun `should delete an existing contact restriction`() {
+    val contactRestrictionId = 3L
+
+    webTestClient.delete()
+      .uri("/sync/contact-restriction/{contactRestrictionId}", contactRestrictionId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    webTestClient.get()
+      .uri("/sync/contact-restriction/{contactRestrictionId}", contactRestrictionId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_RESTRICTION_DELETED,
+      additionalInfo = ContactRestrictionInfo(contactRestrictionId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = 3),
+    )
+  }
+
+  private fun updateContactRestrictionRequest(contactId: Long) = SyncUpdateContactRestrictionRequest(
+    contactId = contactId,
+    restrictionType = "RESTRICTION",
+    startDate = LocalDate.of(1982, 6, 15),
+    expiryDate = LocalDate.of(1988, 6, 15),
+    comments = "N/A",
+    updatedBy = "UPDATE",
+    updatedTime = LocalDateTime.now(),
+  )
+
+  private fun createContactRestrictionRequest(contactId: Long) = SyncCreateContactRestrictionRequest(
+    contactId = contactId,
+    restrictionType = "NEW",
+    startDate = LocalDate.of(1982, 6, 15),
+    expiryDate = LocalDate.of(2025, 6, 15),
+    comments = "N/A",
+    createdBy = "CREATE",
+  )
 
   private fun aMinimalCreateContactRequest() = CreateContactRequest(
     lastName = "last",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncEmploymentIntegrationTest.kt
@@ -274,7 +274,6 @@ class SyncEmploymentIntegrationTest : PostgresIntegrationTestBase() {
       firstName = "first",
       middleNames = "middle",
       dateOfBirth = LocalDate.of(1982, 6, 15),
-      createdBy = "created",
     )
 
     val response = testAPIClient.createAContact(request)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncEmploymentIntegrationTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.sync
 import org.apache.commons.lang3.RandomUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.PostgresIntegrationTestBase
@@ -15,214 +14,212 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.EmploymentIn
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 class SyncEmploymentIntegrationTest : PostgresIntegrationTestBase() {
 
-  @Nested
-  inner class EmploymentSyncTests {
+  @BeforeEach
+  fun resetEvents() {
+    stubEvents.reset()
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER)
+  }
 
-    @BeforeEach
-    fun resetEvents() {
-      stubEvents.reset()
+  @Test
+  fun `Sync endpoints should return unauthorized if no token provided`() {
+    webTestClient.get()
+      .uri("/sync/employment/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.post()
+      .uri("/sync/employment")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createSyncEmploymentRequest())
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.put()
+      .uri("/sync/employment/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateEmploymentRequest(employmentSyncResponse()))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+
+    webTestClient.delete()
+      .uri("/sync/employment/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Sync endpoints should return forbidden without an authorised role on the token`() {
+    webTestClient.get()
+      .uri("/sync/employment/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.post()
+      .uri("/sync/employment")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createSyncEmploymentRequest())
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.put()
+      .uri("/sync/employment/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(updateEmploymentRequest(employmentSyncResponse()))
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+
+    webTestClient.delete()
+      .uri("/sync/employment/1")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should get an existing employment`() {
+    val savedEmployment = createEmployment()
+    val employment = webTestClient.get()
+      .uri("/sync/employment/{employmentId}", savedEmployment.employmentId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncEmployment::class.java)
+      .returnResult().responseBody!!
+
+    with(employment) {
+      assertThat(employmentId).isEqualTo(savedEmployment.employmentId)
+      assertThat(organisationId).isEqualTo(savedEmployment.organisationId)
+      assertThat(contactId).isEqualTo(savedEmployment.contactId)
+      assertThat(active).isTrue()
+      assertThat(createdBy).isEqualTo(savedEmployment.createdBy)
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+    }
+  }
+
+  @Test
+  fun `should create a new employment`() {
+    val organisationId = createOrganisation()
+    val contactId = createContact()
+
+    val employment = webTestClient.post()
+      .uri("/sync/employment")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(createSyncEmploymentRequest(organisationId = organisationId, contactId = contactId))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncEmployment::class.java)
+      .returnResult().responseBody!!
+
+    // The created is returned
+    with(employment) {
+      assertThat(employmentId).isNotNull()
+      assertThat(employment.organisationId).isEqualTo(organisationId)
+      assertThat(employment.contactId).isEqualTo(contactId)
+      assertThat(active).isTrue()
+      assertThat(createdBy).isEqualTo("CREATOR")
+      assertThat(updatedBy).isEqualTo(null)
+      assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
     }
 
-    @Test
-    fun `Sync endpoints should return unauthorized if no token provided`() {
-      webTestClient.get()
-        .uri("/sync/employment/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.EMPLOYMENT_CREATED,
+      additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = employment.contactId),
+    )
+  }
 
-      webTestClient.post()
-        .uri("/sync/employment")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createSyncEmploymentRequest())
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+  @Test
+  fun `should create and then update a employment`() {
+    val employment = createEmployment()
 
-      webTestClient.put()
-        .uri("/sync/employment/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateEmploymentRequest(employmentSyncResponse()))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+    val updateEmploymentRequest = updateEmploymentRequest(employment)
+    val updatedEmployment = webTestClient.put()
+      .uri("/sync/employment/{employmentId}", employment.employmentId)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .bodyValue(updateEmploymentRequest)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SyncEmployment::class.java)
+      .returnResult().responseBody!!
 
-      webTestClient.delete()
-        .uri("/sync/employment/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
+    // Check the updated copy
+    with(updatedEmployment) {
+      assertThat(employmentId).isEqualTo(employment.employmentId)
+      assertThat(organisationId).isEqualTo(updateEmploymentRequest.organisationId)
+      assertThat(contactId).isEqualTo(updateEmploymentRequest.contactId)
+      assertThat(active).isFalse()
+      assertThat(updatedBy).isEqualTo(updateEmploymentRequest.updatedBy)
+      assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
     }
 
-    @Test
-    fun `Sync endpoints should return forbidden without an authorised role on the token`() {
-      webTestClient.get()
-        .uri("/sync/employment/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.EMPLOYMENT_UPDATED,
+      additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = updatedEmployment.contactId),
+    )
+  }
 
-      webTestClient.post()
-        .uri("/sync/employment")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(createSyncEmploymentRequest())
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
+  @Test
+  fun `should delete an existing employment`() {
+    val employment = createEmployment()
 
-      webTestClient.put()
-        .uri("/sync/employment/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(updateEmploymentRequest(employmentSyncResponse()))
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
+    webTestClient.delete()
+      .uri("/sync/employment/{employmentId}", employment.employmentId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isOk
 
-      webTestClient.delete()
-        .uri("/sync/employment/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
+    webTestClient.get()
+      .uri("/sync/employment/{employmentId}", employment.employmentId)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .exchange()
+      .expectStatus()
+      .isNotFound
 
-    @Test
-    fun `should get an existing employment`() {
-      val savedEmployment = createEmployment()
-      val employment = webTestClient.get()
-        .uri("/sync/employment/{employmentId}", savedEmployment.employmentId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncEmployment::class.java)
-        .returnResult().responseBody!!
-
-      with(employment) {
-        assertThat(employmentId).isEqualTo(savedEmployment.employmentId)
-        assertThat(organisationId).isEqualTo(savedEmployment.organisationId)
-        assertThat(contactId).isEqualTo(savedEmployment.contactId)
-        assertThat(active).isTrue()
-        assertThat(createdBy).isEqualTo(savedEmployment.createdBy)
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-    }
-
-    @Test
-    fun `should create a new employment`() {
-      val organisationId = createOrganisation()
-      val contactId = createContact()
-
-      val employment = webTestClient.post()
-        .uri("/sync/employment")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(createSyncEmploymentRequest(organisationId = organisationId, contactId = contactId))
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncEmployment::class.java)
-        .returnResult().responseBody!!
-
-      // The created is returned
-      with(employment) {
-        assertThat(employmentId).isNotNull()
-        assertThat(employment.organisationId).isEqualTo(organisationId)
-        assertThat(employment.contactId).isEqualTo(contactId)
-        assertThat(active).isTrue()
-        assertThat(createdBy).isEqualTo("CREATOR")
-        assertThat(updatedBy).isEqualTo(null)
-        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.EMPLOYMENT_CREATED,
-        additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = employment.contactId),
-      )
-    }
-
-    @Test
-    fun `should create and then update a employment`() {
-      val employment = createEmployment()
-
-      val updateEmploymentRequest = updateEmploymentRequest(employment)
-      val updatedEmployment = webTestClient.put()
-        .uri("/sync/employment/{employmentId}", employment.employmentId)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .bodyValue(updateEmploymentRequest)
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectHeader().contentType(MediaType.APPLICATION_JSON)
-        .expectBody(SyncEmployment::class.java)
-        .returnResult().responseBody!!
-
-      // Check the updated copy
-      with(updatedEmployment) {
-        assertThat(employmentId).isEqualTo(employment.employmentId)
-        assertThat(organisationId).isEqualTo(updateEmploymentRequest.organisationId)
-        assertThat(contactId).isEqualTo(updateEmploymentRequest.contactId)
-        assertThat(active).isFalse()
-        assertThat(updatedBy).isEqualTo(updateEmploymentRequest.updatedBy)
-        assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
-      }
-
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.EMPLOYMENT_UPDATED,
-        additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = updatedEmployment.contactId),
-      )
-    }
-
-    @Test
-    fun `should delete an existing employment`() {
-      val employment = createEmployment()
-
-      webTestClient.delete()
-        .uri("/sync/employment/{employmentId}", employment.employmentId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isOk
-
-      webTestClient.get()
-        .uri("/sync/employment/{employmentId}", employment.employmentId)
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
-        .exchange()
-        .expectStatus()
-        .isNotFound
-
-      stubEvents.assertHasEvent(
-        event = OutboundEvent.EMPLOYMENT_DELETED,
-        additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS),
-        personReference = PersonReference(dpsContactId = employment.contactId),
-      )
-    }
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.EMPLOYMENT_DELETED,
+      additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS),
+      personReference = PersonReference(dpsContactId = employment.contactId),
+    )
   }
 
   private fun updateEmploymentRequest(employment: SyncEmployment) = SyncUpdateEmploymentRequest(
@@ -276,7 +273,7 @@ class SyncEmploymentIntegrationTest : PostgresIntegrationTestBase() {
       dateOfBirth = LocalDate.of(1982, 6, 15),
     )
 
-    val response = testAPIClient.createAContact(request)
+    val response = doWithTemporaryWritePermission { testAPIClient.createAContact(request) }
 
     assertThat(response).isNotNull
     with(response) { assertThat(id).isNotNull() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactIntegrationTest.kt
@@ -166,7 +166,7 @@ class SyncPrisonerContactIntegrationTest : PostgresIntegrationTestBase() {
       }
       stubEvents.assertHasEvent(
         event = OutboundEvent.PRISONER_CONTACT_CREATED,
-        additionalInfo = PrisonerContactInfo(prisonerContact.id, Source.NOMIS),
+        additionalInfo = PrisonerContactInfo(prisonerContact.id, Source.NOMIS, "SYS"),
         personReference = PersonReference(dpsContactId = prisonerContact.contactId, nomsNumber = prisonerContact.prisonerNumber),
       )
     }
@@ -239,7 +239,7 @@ class SyncPrisonerContactIntegrationTest : PostgresIntegrationTestBase() {
       }
       stubEvents.assertHasEvent(
         event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-        additionalInfo = PrisonerContactInfo(updatedPrisonerContact.id, Source.NOMIS),
+        additionalInfo = PrisonerContactInfo(updatedPrisonerContact.id, Source.NOMIS, "SYS"),
         personReference = PersonReference(dpsContactId = updatedPrisonerContact.contactId, nomsNumber = updatedPrisonerContact.prisonerNumber),
       )
     }
@@ -276,7 +276,7 @@ class SyncPrisonerContactIntegrationTest : PostgresIntegrationTestBase() {
         .isNotFound
       stubEvents.assertHasEvent(
         event = OutboundEvent.PRISONER_CONTACT_DELETED,
-        additionalInfo = PrisonerContactInfo(prisonerContact.id, Source.NOMIS),
+        additionalInfo = PrisonerContactInfo(prisonerContact.id, Source.NOMIS, "SYS"),
         personReference = PersonReference(dpsContactId = prisonerContact.contactId, nomsNumber = prisonerContact.prisonerNumber),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/wiremock/ManageUsersApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/wiremock/ManageUsersApiMockServer.kt
@@ -5,11 +5,11 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 
 class ManageUsersApiMockServer : MockServer(8093) {
 
-  fun stubGetUser(user: User) {
+  fun stubGetUser(user: UserDetails) {
     stubFor(
       WireMock.get("/users/${user.username}")
         .willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactControllerTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.whenever
 import org.openapitools.jackson.nullable.JsonNullable
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.PrisonerContactRestrictionsFacade
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createPrisonerContactRelationshipDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createPrisonerContactRestrictionDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
@@ -80,28 +81,28 @@ class PrisonerContactControllerTest {
   inner class PatchContactRelationship {
     private val prisonerContactId = 2L
     private val request = patchContactRelationshipRequest()
+    private val user = aUser("updated")
 
     @Test
     fun `should update a contact relationship successfully`() {
-      doNothing().whenever(contactFacade).patchRelationship(prisonerContactId, request)
+      doNothing().whenever(contactFacade).patchRelationship(prisonerContactId, request, user)
 
-      controller.patchContactRelationship(prisonerContactId, request)
+      controller.patchContactRelationship(prisonerContactId, request, user)
 
-      Mockito.verify(contactFacade).patchRelationship(prisonerContactId, request)
+      Mockito.verify(contactFacade).patchRelationship(prisonerContactId, request, user)
     }
 
     @Test
     fun `should propagate exceptions patching a contact relationship`() {
-      whenever(contactFacade.patchRelationship(prisonerContactId, request)).thenThrow(RuntimeException("Bang!"))
+      whenever(contactFacade.patchRelationship(prisonerContactId, request, user)).thenThrow(RuntimeException("Bang!"))
 
       assertThrows<RuntimeException>("Bang!") {
-        controller.patchContactRelationship(prisonerContactId, request)
+        controller.patchContactRelationship(prisonerContactId, request, user)
       }
     }
 
     private fun patchContactRelationshipRequest() = PatchRelationshipRequest(
       relationshipToPrisonerCode = JsonNullable.of("ENG"),
-      updatedBy = "system",
     )
   }
 
@@ -117,25 +118,26 @@ class PrisonerContactControllerTest {
       isApprovedVisitor = false,
       comments = "Foo",
     )
-    private val request = AddContactRelationshipRequest(contactId, relationship, "USER")
+    private val user = aUser("created")
+    private val request = AddContactRelationshipRequest(contactId, relationship)
 
     @Test
     fun `should create a contact relationship successfully`() {
       val created = createPrisonerContactRelationshipDetails()
-      whenever(contactFacade.addContactRelationship(request)).thenReturn(created)
+      whenever(contactFacade.addContactRelationship(request, user)).thenReturn(created)
 
-      val result = controller.addContactRelationship(request)
+      val result = controller.addContactRelationship(request, user)
 
       assertThat(result).isEqualTo(created)
-      Mockito.verify(contactFacade).addContactRelationship(request)
+      Mockito.verify(contactFacade).addContactRelationship(request, user)
     }
 
     @Test
     fun `should propagate exceptions getting a contact`() {
-      whenever(contactFacade.addContactRelationship(request)).thenThrow(RuntimeException("Bang!"))
+      whenever(contactFacade.addContactRelationship(request, user)).thenThrow(RuntimeException("Bang!"))
 
       assertThrows<RuntimeException>("Bang!") {
-        controller.addContactRelationship(request)
+        controller.addContactRelationship(request, user)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/RestrictionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/RestrictionsServiceTest.kt
@@ -11,7 +11,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactRestrictionEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntity
@@ -96,8 +96,8 @@ class RestrictionsServiceTest {
     fun `get global restrictions successfully`() {
       val now = now()
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(manageUsersService.getUserByUsername("created")).thenReturn(User("created", "Created User"))
-      whenever(manageUsersService.getUserByUsername("updated")).thenReturn(User("updated", "Updated User"))
+      whenever(manageUsersService.getUserByUsername("created")).thenReturn(UserDetails("created", "Created User"))
+      whenever(manageUsersService.getUserByUsername("updated")).thenReturn(UserDetails("updated", "Updated User"))
       whenever(contactRestrictionDetailsRepository.findAllByContactId(contactId)).thenReturn(
         listOf(
           createContactRestrictionDetailsEntity(
@@ -192,7 +192,7 @@ class RestrictionsServiceTest {
     fun `only lookup once if same username is required multiple times`() {
       val now = now()
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(manageUsersService.getUserByUsername("created")).thenReturn(User("created", "Created User"))
+      whenever(manageUsersService.getUserByUsername("created")).thenReturn(UserDetails("created", "Created User"))
       whenever(contactRestrictionDetailsRepository.findAllByContactId(contactId)).thenReturn(
         listOf(
           createContactRestrictionDetailsEntity(
@@ -255,19 +255,19 @@ class RestrictionsServiceTest {
       whenever(prisonerContactRepository.findById(prisonerContactId)).thenReturn(Optional.of(aPrisonerContact))
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(manageUsersService.getUserByUsername("created_global")).thenReturn(
-        User(
+        UserDetails(
           "created_global",
           "Created User Global",
         ),
       )
       whenever(manageUsersService.getUserByUsername("updated_global")).thenReturn(
-        User(
+        UserDetails(
           "updated_global",
           "Updated User Global",
         ),
       )
-      whenever(manageUsersService.getUserByUsername("created_pc")).thenReturn(User("created_pc", "Created PC"))
-      whenever(manageUsersService.getUserByUsername("updated_pc")).thenReturn(User("updated_pc", "Updated PC"))
+      whenever(manageUsersService.getUserByUsername("created_pc")).thenReturn(UserDetails("created_pc", "Created PC"))
+      whenever(manageUsersService.getUserByUsername("updated_pc")).thenReturn(UserDetails("updated_pc", "Updated PC"))
       whenever(contactRestrictionDetailsRepository.findAllByContactId(contactId)).thenReturn(
         listOf(
           createContactRestrictionDetailsEntity(
@@ -358,7 +358,7 @@ class RestrictionsServiceTest {
       val now = now()
       whenever(prisonerContactRepository.findById(prisonerContactId)).thenReturn(Optional.of(aPrisonerContact))
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(manageUsersService.getUserByUsername("created_pc")).thenReturn(User("created_pc", "Created PC"))
+      whenever(manageUsersService.getUserByUsername("created_pc")).thenReturn(UserDetails("created_pc", "Created PC"))
       whenever(contactRestrictionDetailsRepository.findAllByContactId(contactId)).thenReturn(emptyList())
       whenever(prisonerContactRestrictionDetailsRepository.findAllByPrisonerContactId(prisonerContactId)).thenReturn(
         listOf(
@@ -474,7 +474,7 @@ class RestrictionsServiceTest {
     @Test
     fun `create global restriction`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(manageUsersService.getUserByUsername("created")).thenReturn(User("created", "Created User"))
+      whenever(manageUsersService.getUserByUsername("created")).thenReturn(UserDetails("created", "Created User"))
       whenever(
         referenceCodeService.validateReferenceCode(
           ReferenceCodeGroup.RESTRICTION,
@@ -615,7 +615,7 @@ class RestrictionsServiceTest {
     fun `updated global restriction`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(contactRestrictionRepository.findById(contactRestrictionId)).thenReturn(Optional.of(existingEntity))
-      whenever(manageUsersService.getUserByUsername("updated")).thenReturn(User("updated", "Updated User"))
+      whenever(manageUsersService.getUserByUsername("updated")).thenReturn(UserDetails("updated", "Updated User"))
       whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.RESTRICTION, "CCTV", allowInactive = true)).thenReturn(
         ReferenceCode(
           referenceCodeId = 0,
@@ -703,7 +703,7 @@ class RestrictionsServiceTest {
 
     @Test
     fun `create prisoner contact restriction`() {
-      whenever(manageUsersService.getUserByUsername("created")).thenReturn(User("created", "Created User"))
+      whenever(manageUsersService.getUserByUsername("created")).thenReturn(UserDetails("created", "Created User"))
       whenever(prisonerContactRepository.findById(prisonerContactId)).thenReturn(Optional.of(aPrisonerContact))
       whenever(
         referenceCodeService.validateReferenceCode(
@@ -830,7 +830,7 @@ class RestrictionsServiceTest {
 
     @Test
     fun `updated prisoner contact restriction`() {
-      whenever(manageUsersService.getUserByUsername("updated")).thenReturn(User("updated", "Updated User"))
+      whenever(manageUsersService.getUserByUsername("updated")).thenReturn(UserDetails("updated", "Updated User"))
       whenever(prisonerContactRepository.findById(prisonerContactId)).thenReturn(Optional.of(aPrisonerContact))
       whenever(prisonerContactRestrictionRepository.findById(prisonerContactRestrictionId)).thenReturn(
         Optional.of(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
@@ -27,10 +28,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_CREATED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_CREATED, 1L, 1L, user = aUser("foo"))
     verify(
       expectedEventType = "contacts-api.contact.created",
-      expectedAdditionalInformation = ContactInfo(contactId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = ContactInfo(contactId = 1L, source = Source.DPS, "foo"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact has been created",
     )
@@ -39,10 +40,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact updated event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_UPDATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_UPDATED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_UPDATED, 1L, 1L, user = aUser("foo"))
     verify(
       expectedEventType = "contacts-api.contact.updated",
-      expectedAdditionalInformation = ContactInfo(contactId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = ContactInfo(contactId = 1L, source = Source.DPS, "foo"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact has been updated",
     )
@@ -51,10 +52,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_DELETED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_DELETED, 1L, 1L, user = aUser("foo"))
     verify(
       expectedEventType = "contacts-api.contact.deleted",
-      expectedAdditionalInformation = ContactInfo(contactId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = ContactInfo(contactId = 1L, source = Source.DPS, "foo"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact has been deleted",
     )
@@ -243,10 +244,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_CREATED, 1L, 1L, "A1234AA")
+    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_CREATED, 1L, 1L, "A1234AA", user = aUser("foo"))
     verify(
       expectedEventType = "contacts-api.prisoner-contact.created",
-      expectedAdditionalInformation = PrisonerContactInfo(prisonerContactId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = PrisonerContactInfo(prisonerContactId = 1L, source = Source.DPS, username = "foo"),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact has been created",
     )
@@ -255,10 +256,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact updated event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_UPDATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_UPDATED, 1L, 1L, "A1234AA")
+    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_UPDATED, 1L, 1L, "A1234AA", user = aUser("foo"))
     verify(
       expectedEventType = "contacts-api.prisoner-contact.updated",
-      expectedAdditionalInformation = PrisonerContactInfo(prisonerContactId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = PrisonerContactInfo(prisonerContactId = 1L, source = Source.DPS, username = "foo"),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact has been updated",
     )
@@ -267,10 +268,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_DELETED, 1L, 1L, "A1234AA")
+    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_DELETED, 1L, 1L, "A1234AA", user = aUser("foo"))
     verify(
       expectedEventType = "contacts-api.prisoner-contact.deleted",
-      expectedAdditionalInformation = PrisonerContactInfo(prisonerContactId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = PrisonerContactInfo(prisonerContactId = 1L, source = Source.DPS, username = "foo"),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact has been deleted",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/StubUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/StubUser.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.util
+
+data class StubUser(val username: String, val displayName: String, val roles: List<String>, val caseload: String? = null, val isSystemUser: Boolean = false) {
+  companion object {
+    val USER_WITH_NO_ROLES = StubUser("unauthorised", "Unauthorised", emptyList())
+    val SYNC_AND_MIGRATE_USER = StubUser("sys", "System", listOf("PERSONAL_RELATIONSHIPS_MIGRATION"), caseload = null, isSystemUser = true)
+    val READ_ONLY_USER = StubUser("read_only_user", "Read Only", listOf("ROLE_CONTACTS__R"), caseload = "BXI")
+    val READ_WRITE_USER = StubUser("read_write_user", "Read Write", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
+    val CREATING_USER = StubUser("created", "Created", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
+    val UPDATING_USER = StubUser("updated", "Updated", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
+  }
+}


### PR DESCRIPTION
Use the user token to get a username instead of using the createdBy or updatedBy field.
Only applied to create and update contacts and relationships currently.
Changed to set a user in integration tests but many old style tests still remain.