### PR TITLE
PRC-651: Convert identities to use user

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ DB_NAME=personal-relationships-db
 DB_USER=personal-relationships
 DB_PASS=contacts
 DB_SSL_MODE=prefer
+DPR_USER=dpr_user
+DPR_PASSWORD=dpr_password
 ```
 
 Start up the docker dependencies using the docker-compose file in the `hmpps-personal-relationships-api` service.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacade.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.identity.CreateIdentityRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.identity.CreateMultipleIdentitiesRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.identity.UpdateIdentityRequest
@@ -16,40 +17,42 @@ class ContactIdentityFacade(
   private val outboundEventsService: OutboundEventsService,
 ) {
 
-  fun create(contactId: Long, request: CreateIdentityRequest): ContactIdentityDetails = contactIdentityService.create(contactId, request).also {
+  fun create(contactId: Long, request: CreateIdentityRequest, user: User): ContactIdentityDetails = contactIdentityService.create(contactId, request, user).also {
     outboundEventsService.send(
       outboundEvent = OutboundEvent.CONTACT_IDENTITY_CREATED,
       identifier = it.contactIdentityId,
       contactId = contactId,
+      user = user,
     )
   }
 
-  fun createMultiple(contactId: Long, request: CreateMultipleIdentitiesRequest): List<ContactIdentityDetails> = contactIdentityService.createMultiple(contactId, request).also { created ->
-    created.forEach {
-      outboundEventsService.send(
-        outboundEvent = OutboundEvent.CONTACT_IDENTITY_CREATED,
-        identifier = it.contactIdentityId,
-        contactId = contactId,
-      )
-    }
+  fun createMultiple(contactId: Long, request: CreateMultipleIdentitiesRequest, user: User): List<ContactIdentityDetails> = contactIdentityService.createMultiple(contactId, request, user).onEach {
+    outboundEventsService.send(
+      outboundEvent = OutboundEvent.CONTACT_IDENTITY_CREATED,
+      identifier = it.contactIdentityId,
+      contactId = contactId,
+      user = user,
+    )
   }
 
-  fun update(contactId: Long, contactIdentityId: Long, request: UpdateIdentityRequest): ContactIdentityDetails = contactIdentityService.update(contactId, contactIdentityId, request).also {
+  fun update(contactId: Long, contactIdentityId: Long, request: UpdateIdentityRequest, user: User): ContactIdentityDetails = contactIdentityService.update(contactId, contactIdentityId, request, user).also {
     outboundEventsService.send(
       outboundEvent = OutboundEvent.CONTACT_IDENTITY_UPDATED,
       identifier = contactIdentityId,
       contactId = contactId,
+      user = user,
     )
   }
 
   fun get(contactId: Long, contactIdentityId: Long): ContactIdentityDetails = contactIdentityService.get(contactId, contactIdentityId) ?: throw EntityNotFoundException("Contact identity with id ($contactIdentityId) not found for contact ($contactId)")
 
-  fun delete(contactId: Long, contactIdentityId: Long) {
+  fun delete(contactId: Long, contactIdentityId: Long, user: User) {
     contactIdentityService.delete(contactId, contactIdentityId).also {
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_IDENTITY_DELETED,
         identifier = contactIdentityId,
         contactId = contactId,
+        user = user,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/identity/CreateIdentityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/identity/CreateIdentityRequest.kt
@@ -17,7 +17,4 @@ data class CreateIdentityRequest(
   @field:Size(max = 40, message = "issuingAuthority must be <= 40 characters")
   val issuingAuthority: String? = null,
 
-  @Schema(description = "User who created the entry", example = "admin")
-  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
-  val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/identity/CreateMultipleIdentitiesRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/identity/CreateMultipleIdentitiesRequest.kt
@@ -10,8 +10,4 @@ data class CreateMultipleIdentitiesRequest(
   @field:Valid
   @field:Size(min = 1, message = "identities must have at least 1 item")
   val identities: List<IdentityDocument>,
-
-  @Schema(description = "User who created the entry", example = "admin")
-  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
-  val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/identity/UpdateIdentityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/identity/UpdateIdentityRequest.kt
@@ -16,8 +16,4 @@ data class UpdateIdentityRequest(
   @Schema(description = "The authority who issued the identity", example = "DVLA", nullable = true)
   @field:Size(max = 40, message = "issuingAuthority must be <= 40 characters")
   val issuingAuthority: String? = null,
-
-  @Schema(description = "User who updated the entry", example = "admin")
-  @field:Size(max = 100, message = "updatedBy must be <= 100 characters")
-  val updatedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactIdentityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactIdentityController.kt
@@ -18,9 +18,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactIdentityFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.identity.CreateIdentityRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.identity.CreateMultipleIdentitiesRequest
@@ -72,8 +74,9 @@ class ContactIdentityController(private val contactIdentityFacade: ContactIdenti
       example = "123456",
     ) contactId: Long,
     @Valid @RequestBody request: CreateIdentityRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    val created = contactIdentityFacade.create(contactId, request)
+    val created = contactIdentityFacade.create(contactId, request, user)
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(created)
@@ -116,8 +119,9 @@ class ContactIdentityController(private val contactIdentityFacade: ContactIdenti
       example = "123456",
     ) contactId: Long,
     @Valid @RequestBody request: CreateMultipleIdentitiesRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    val created = contactIdentityFacade.createMultiple(contactId, request)
+    val created = contactIdentityFacade.createMultiple(contactId, request, user)
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(created)
@@ -165,7 +169,8 @@ class ContactIdentityController(private val contactIdentityFacade: ContactIdenti
       example = "987654",
     ) contactIdentityId: Long,
     @Valid @RequestBody request: UpdateIdentityRequest,
-  ): ResponseEntity<Any> = ResponseEntity.ok(contactIdentityFacade.update(contactId, contactIdentityId, request))
+    @RequestAttribute user: User,
+  ): ResponseEntity<Any> = ResponseEntity.ok(contactIdentityFacade.update(contactId, contactIdentityId, request, user))
 
   @GetMapping("/identity/{contactIdentityId}")
   @Operation(
@@ -241,8 +246,9 @@ class ContactIdentityController(private val contactIdentityFacade: ContactIdenti
       description = "The id of the contact identity",
       example = "987654",
     ) contactIdentityId: Long,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    contactIdentityFacade.delete(contactId, contactIdentityId)
+    contactIdentityFacade.delete(contactId, contactIdentityId, user)
     return ResponseEntity.noContent().build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactIdentityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactIdentityService.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
 import jakarta.validation.ValidationException
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactIdentityEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.ReferenceCodeGroup
@@ -27,19 +28,19 @@ class ContactIdentityService(
 ) {
 
   @Transactional
-  fun create(contactId: Long, request: CreateIdentityRequest): ContactIdentityDetails {
+  fun create(contactId: Long, request: CreateIdentityRequest, user: User): ContactIdentityDetails {
     validateContactExists(contactId)
     return createAContactIdentity(
       contactId,
       request.identityType,
       request.identityValue,
       request.issuingAuthority,
-      request.createdBy,
+      user.username,
     )
   }
 
   @Transactional
-  fun createMultiple(contactId: Long, request: CreateMultipleIdentitiesRequest): List<ContactIdentityDetails> {
+  fun createMultiple(contactId: Long, request: CreateMultipleIdentitiesRequest, user: User): List<ContactIdentityDetails> {
     validateContactExists(contactId)
     return request.identities.map {
       createAContactIdentity(
@@ -47,7 +48,7 @@ class ContactIdentityService(
         it.identityType,
         it.identityValue,
         it.issuingAuthority,
-        request.createdBy,
+        user.username,
       )
     }
   }
@@ -80,7 +81,7 @@ class ContactIdentityService(
   }
 
   @Transactional
-  fun update(contactId: Long, contactIdentityId: Long, request: UpdateIdentityRequest): ContactIdentityDetails {
+  fun update(contactId: Long, contactIdentityId: Long, request: UpdateIdentityRequest, user: User): ContactIdentityDetails {
     validateContactExists(contactId)
     val existing = validateExistingIdentity(contactIdentityId)
     val type = referenceCodeService.validateReferenceCode(ReferenceCodeGroup.ID_TYPE, request.identityType, allowInactive = true)
@@ -90,7 +91,7 @@ class ContactIdentityService(
       identityType = request.identityType,
       identityValue = request.identityValue,
       issuingAuthority = request.issuingAuthority,
-      updatedBy = request.updatedBy,
+      updatedBy = user.username,
       updatedTime = LocalDateTime.now(),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -78,7 +78,7 @@ class ContactService(
     val newRelationship = request.relationship?.toEntity(createdContact.id(), user.username)
       ?.let { prisonerContactRepository.saveAndFlush(it) }
 
-    createIdentityInformation(createdContact, request)
+    createIdentityInformation(createdContact, request, user)
     createAddresses(createdContact.id(), user.username, request.addresses)
     createPhoneNumbers(request, createdContact, user)
     createEmailAddresses(request, createdContact, user)
@@ -445,14 +445,13 @@ class ContactService(
   fun createIdentityInformation(
     createdContact: ContactEntity,
     request: CreateContactRequest,
+    user: User,
   ) {
     if (request.identities.isNotEmpty()) {
       contactIdentityService.createMultiple(
         createdContact.id(),
-        CreateMultipleIdentitiesRequest(
-          identities = request.identities,
-          createdBy = createdContact.createdBy,
-        ),
+        CreateMultipleIdentitiesRequest(identities = request.identities),
+        user,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -318,7 +318,7 @@ data class ContactAddressInfo(val contactAddressId: Long, override val source: S
 data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
-data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -89,7 +89,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactIdentityInfo(identifier, source),
+            ContactIdentityInfo(identifier, source, user.username),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
@@ -48,14 +48,6 @@ abstract class IntegrationTestBase {
     stubEvents.reset()
   }
 
-  internal fun setAuthorisation(
-    username: String? = "AUTH_ADM",
-    roles: List<String> = listOf(),
-    scopes: List<String> = listOf("read"),
-  ): (HttpHeaders) -> Unit = testAPIClient.setAuthorisation(username = username, scopes = scopes, roles = roles)
-
-  internal fun setAuthorisationUsingCurrentUser(): (HttpHeaders) -> Unit = testAPIClient.setAuthorisationUsingCurrentUser()
-
   protected fun stubPingWithResponse(status: Int) {
     hmppsAuth.stubHealthPing(status)
     prisonerSearchApiServer.stubHealthPing(status)
@@ -91,6 +83,25 @@ abstract class IntegrationTestBase {
     organisationsApiMockServer.stubOrganisationSummaryNotFound(id)
   }
 
+  @Deprecated(
+    "Use setCurrentUser and setAuthorisationUsingCurrentUser instead",
+    ReplaceWith("testAPIClient.setAuthorisationUsingCurrentUser"),
+  )
+  internal fun setAuthorisation(
+    username: String? = "AUTH_ADM",
+    roles: List<String> = listOf(),
+    scopes: List<String> = listOf("read"),
+  ): (HttpHeaders) -> Unit = testAPIClient.setAuthorisation(username = username, scopes = scopes, roles = roles)
+
+  /**
+   * Use #setCurrentUser with a `StubUser` to set the current user. Default for all tests is no user.
+   */
+  internal fun setAuthorisationUsingCurrentUser(): (HttpHeaders) -> Unit = testAPIClient.setAuthorisationUsingCurrentUser()
+
+  /**
+   * Setting to null will mean there is no user and authentication will fail.
+   * To simulate a non-user system token use a StubUser with isSystemUser set to trye.
+   */
   fun setCurrentUser(user: StubUser?) {
     testAPIClient.currentUser = user
     if (user != null && !user.isSystemUser) {
@@ -98,6 +109,9 @@ abstract class IntegrationTestBase {
     }
   }
 
+  /**
+   * Perform the specified action as StubUser.READ_WRITE_USER before switching back to the previous user.
+   */
   fun <T> doWithTemporaryWritePermission(action: () -> T): T {
     val previousUser = testAPIClient.currentUser
     setCurrentUser(StubUser.READ_WRITE_USER)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/NotFoundTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/NotFoundTest.kt
@@ -1,13 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration
 
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 
 class NotFoundTest : PostgresIntegrationTestBase() {
 
   @Test
   fun `Resources that aren't found should return 404 - test of the exception handler`() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
     webTestClient.get().uri("/some-url-not-found")
-      .headers(setAuthorisation())
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus().isNotFound
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -238,7 +238,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
     contactReturnedOnCreate.identities.forEach { identity ->
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_IDENTITY_CREATED,
-        additionalInfo = ContactIdentityInfo(identity.contactIdentityId, Source.DPS),
+        additionalInfo = ContactIdentityInfo(identity.contactIdentityId, Source.DPS, "created"),
         personReference = PersonReference(dpsContactId = contactReturnedOnCreate.id),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
@@ -43,7 +43,6 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
         identityType = "DL",
         identityValue = "DL123456789",
         issuingAuthority = "DVLA",
-        createdBy = "created",
       ),
 
     ).contactIdentityId
@@ -59,12 +58,10 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
   @ParameterizedTest
   @CsvSource(
     value = [
-      "identityType must not be null;{\"identityType\": null, \"identityValue\": \"0123456789\", \"updatedBy\": \"created\"}",
-      "identityType must not be null;{\"identityValue\": \"0123456789\", \"updatedBy\": \"created\"}",
-      "identityValue must not be null;{\"identityType\": \"DL\", \"identityValue\": null, \"updatedBy\": \"created\"}",
-      "identityValue must not be null;{\"identityType\": \"DL\", \"updatedBy\": \"created\"}",
-      "updatedBy must not be null;{\"identityType\": \"DL\", \"identityValue\": \"0123456789\", \"updatedBy\": null}",
-      "updatedBy must not be null;{\"identityType\": \"DL\", \"identityValue\": \"0123456789\"}",
+      "identityType must not be null;{\"identityType\": null, \"identityValue\": \"0123456789\"}",
+      "identityType must not be null;{\"identityValue\": \"0123456789\"}",
+      "identityValue must not be null;{\"identityType\": \"DL\", \"identityValue\": null}",
+      "identityValue must not be null;{\"identityType\": \"DL\"}",
     ],
     delimiter = ';',
   )
@@ -73,7 +70,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/$savedContactId/identity/$savedContactIdentityId")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(json)
       .exchange()
       .expectStatus()
@@ -83,7 +80,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure: $expectedMessage")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED, ContactIdentityInfo(savedContactIdentityId))
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED)
   }
 
   @ParameterizedTest
@@ -93,7 +90,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/$savedContactId/identity/$savedContactIdentityId")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -103,7 +100,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure(s): $expectedMessage")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED, ContactIdentityInfo(savedContactIdentityId))
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED)
   }
 
   @Test
@@ -114,7 +111,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/$savedContactId/identity/$savedContactIdentityId")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -131,14 +128,13 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
     val request = UpdateIdentityRequest(
       identityType = "MACRO",
       identityValue = "DL123456789",
-      updatedBy = "updated",
     )
 
     val errors = webTestClient.put()
       .uri("/contact/$savedContactId/identity/$savedContactIdentityId")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -148,7 +144,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported identity type (MACRO)")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED, ContactIdentityInfo(savedContactIdentityId))
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED)
   }
 
   @Test
@@ -159,7 +155,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/-321/identity/$savedContactIdentityId")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -169,7 +165,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Entity not found : Contact (-321) not found")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED, ContactIdentityInfo(savedContactIdentityId))
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED)
   }
 
   @Test
@@ -180,7 +176,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/$savedContactId/identity/-99")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -190,7 +186,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Entity not found : Contact identity (-99) not found")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED, ContactIdentityInfo(-99))
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED)
   }
 
   @Test
@@ -199,7 +195,6 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       identityType = "PASS",
       identityValue = "P978654312",
       issuingAuthority = null,
-      updatedBy = "updated",
     )
     val updated = testAPIClient.updateAContactIdentity(
       savedContactId,
@@ -219,7 +214,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_UPDATED,
-      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS),
+      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -231,7 +226,6 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       identityType = "PASS",
       identityValue = "P978654312",
       issuingAuthority = "Passport office",
-      updatedBy = "updated",
     )
 
     val updated = testAPIClient.updateAContactIdentity(
@@ -253,7 +247,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_UPDATED,
-      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS),
+      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -267,16 +261,11 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
         "issuingAuthority must be <= 40 characters",
         aMinimalRequest().copy(issuingAuthority = "".padStart(41, 'X')),
       ),
-      Arguments.of(
-        "updatedBy must be <= 100 characters",
-        aMinimalRequest().copy(updatedBy = "".padStart(101, 'X')),
-      ),
     )
 
     private fun aMinimalRequest() = UpdateIdentityRequest(
       identityType = "DL",
       identityValue = "DL123456789",
-      updatedBy = "updated",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIdentityIntegrationTest.kt
@@ -68,10 +68,11 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
   @ParameterizedTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
   fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER.copy(roles = listOf(role)))
     webTestClient.get()
       .uri("/sync/contact-identity/1")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -81,7 +82,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(createContactIdentityRequest(savedContactId))
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -91,7 +92,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(updateContactIdentityRequest(savedContactId))
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -99,7 +100,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
     webTestClient.delete()
       .uri("/sync/contact-identity/1")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -112,7 +113,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
     val contactIdentity = webTestClient.get()
       .uri("/sync/contact-identity/{contactIdentityId}", contactIdentityId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isOk
@@ -131,7 +132,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-identity")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(createContactIdentityRequest(savedContactId))
       .exchange()
       .expectStatus()
@@ -151,7 +152,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_CREATED,
-      additionalInfo = ContactIdentityInfo(contactIdentity.contactIdentityId, Source.NOMIS),
+      additionalInfo = ContactIdentityInfo(contactIdentity.contactIdentityId, Source.NOMIS, "SYS"),
       personReference = PersonReference(dpsContactId = contactIdentity.contactId),
     )
   }
@@ -171,7 +172,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-identity")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(createContactIdentityRequest(savedContactId))
       .exchange()
       .expectStatus()
@@ -190,7 +191,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-identity/{contactIdentityId}", contactIdentity.contactIdentityId)
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(updateContactIdentityRequest(savedContactId, actualGivenIssuingAuthority))
       .exchange()
       .expectStatus()
@@ -212,7 +213,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_UPDATED,
-      additionalInfo = ContactIdentityInfo(updatedIdentity.contactIdentityId, Source.NOMIS),
+      additionalInfo = ContactIdentityInfo(updatedIdentity.contactIdentityId, Source.NOMIS, "SYS"),
       personReference = PersonReference(dpsContactId = updatedIdentity.contactId),
     )
   }
@@ -224,7 +225,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
     webTestClient.delete()
       .uri("/sync/contact-identity/{contactIdentityId}", contactIdentityId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isOk
@@ -232,13 +233,13 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
     webTestClient.get()
       .uri("/sync/contact-identity/{contactIdentityId}", contactIdentityId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_DELETED,
-      additionalInfo = ContactIdentityInfo(3, Source.NOMIS),
+      additionalInfo = ContactIdentityInfo(3, Source.NOMIS, "SYS"),
       personReference = PersonReference(dpsContactId = 3),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactIdentityControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactIdentityControllerTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactIdentityFacade
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactIdentityDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.identity.CreateIdentityRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.identity.UpdateIdentityRequest
@@ -20,6 +21,7 @@ class ContactIdentityControllerTest {
 
   private val facade: ContactIdentityFacade = mock()
   private val controller = ContactIdentityController(facade)
+  private val user = aUser()
 
   @Nested
   inner class CreateContactIdentity {
@@ -29,15 +31,14 @@ class ContactIdentityControllerTest {
       val request = CreateIdentityRequest(
         identityType = "DL",
         identityValue = "DL123456789",
-        createdBy = "created",
       )
-      whenever(facade.create(1, request)).thenReturn(createdIdentity)
+      whenever(facade.create(1, request, user)).thenReturn(createdIdentity)
 
-      val response = controller.createIdentityNumber(1, request)
+      val response = controller.createIdentityNumber(1, request, user)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
       assertThat(response.body).isEqualTo(createdIdentity)
-      verify(facade).create(1, request)
+      verify(facade).create(1, request, user)
     }
 
     @Test
@@ -45,17 +46,16 @@ class ContactIdentityControllerTest {
       val request = CreateIdentityRequest(
         identityType = "DL",
         identityValue = "DL123456789",
-        createdBy = "created",
       )
       val expected = EntityNotFoundException("Couldn't find contact")
-      whenever(facade.create(1, request)).thenThrow(expected)
+      whenever(facade.create(1, request, user)).thenThrow(expected)
 
       val exception = assertThrows<EntityNotFoundException> {
-        controller.createIdentityNumber(1, request)
+        controller.createIdentityNumber(1, request, user)
       }
 
       assertThat(exception).isEqualTo(expected)
-      verify(facade).create(1, request)
+      verify(facade).create(1, request, user)
     }
   }
 
@@ -68,15 +68,14 @@ class ContactIdentityControllerTest {
         "MOB",
         "+07777777777",
         null,
-        "JAMES",
       )
-      whenever(facade.update(1, 2, request)).thenReturn(updatedIdentity)
+      whenever(facade.update(1, 2, request, user)).thenReturn(updatedIdentity)
 
-      val response = controller.updateIdentityNumber(1, 2, request)
+      val response = controller.updateIdentityNumber(1, 2, request, user)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
       assertThat(response.body).isEqualTo(updatedIdentity)
-      verify(facade).update(1, 2, request)
+      verify(facade).update(1, 2, request, user)
     }
 
     @Test
@@ -85,17 +84,16 @@ class ContactIdentityControllerTest {
         "MOB",
         "+07777777777",
         null,
-        "JAMES",
       )
       val expected = EntityNotFoundException("Couldn't find contact")
-      whenever(facade.update(1, 2, request)).thenThrow(expected)
+      whenever(facade.update(1, 2, request, user)).thenThrow(expected)
 
       val exception = assertThrows<EntityNotFoundException> {
-        controller.updateIdentityNumber(1, 2, request)
+        controller.updateIdentityNumber(1, 2, request, user)
       }
 
       assertThat(exception).isEqualTo(expected)
-      verify(facade).update(1, 2, request)
+      verify(facade).update(1, 2, request, user)
     }
   }
 
@@ -139,25 +137,25 @@ class ContactIdentityControllerTest {
   inner class DeleteContactIdentity {
     @Test
     fun `should return 204 if deleted successfully`() {
-      whenever(facade.delete(1, 2)).then { }
+      whenever(facade.delete(1, 2, user)).then { }
 
-      val response = controller.deleteIdentityNumber(1, 2)
+      val response = controller.deleteIdentityNumber(1, 2, user)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
-      verify(facade).delete(1, 2)
+      verify(facade).delete(1, 2, user)
     }
 
     @Test
     fun `should propagate exceptions if delete fails`() {
       val expected = EntityNotFoundException("Couldn't find contact")
-      whenever(facade.delete(1, 2)).thenThrow(expected)
+      whenever(facade.delete(1, 2, user)).thenThrow(expected)
 
       val exception = assertThrows<EntityNotFoundException> {
-        controller.deleteIdentityNumber(1, 2)
+        controller.deleteIdentityNumber(1, 2, user)
       }
 
       assertThat(exception).isEqualTo(expected)
-      verify(facade).delete(1, 2)
+      verify(facade).delete(1, 2, user)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -132,7 +132,7 @@ class ContactServiceTest {
       )
       whenever(contactRepository.saveAndFlush(any())).thenAnswer { i -> (i.arguments[0] as ContactEntity).copy(contactId = 123) }
       whenever(contactAddressDetailsRepository.findByContactId(any())).thenReturn(listOf(aContactAddressDetailsEntity))
-      whenever(contactIdentityService.createMultiple(any(), any())).thenReturn(listOf(createContactIdentityDetails()))
+      whenever(contactIdentityService.createMultiple(any(), any(), any())).thenReturn(listOf(createContactIdentityDetails()))
       val identityEntity1 =
         createContactIdentityDetailsEntity(id = 1, identityType = "PNC", identityValue = "1923/1Z34567A")
       whenever(contactIdentityDetailsRepository.findByContactId(123L)).thenReturn(listOf(identityEntity1))
@@ -151,7 +151,7 @@ class ContactServiceTest {
 
       val result = service.createContact(request, user)
 
-      verify(contactIdentityService).createMultiple(123, CreateMultipleIdentitiesRequest(identities, "created"))
+      verify(contactIdentityService).createMultiple(123, CreateMultipleIdentitiesRequest(identities), user)
       val contactCaptor = argumentCaptor<ContactEntity>()
       verify(contactRepository).saveAndFlush(contactCaptor.capture())
       with(contactCaptor.firstValue) {
@@ -241,7 +241,7 @@ class ContactServiceTest {
       )
       whenever(contactRepository.saveAndFlush(any())).thenAnswer { i -> (i.arguments[0] as ContactEntity).copy(contactId = 123L) }
       whenever(contactAddressDetailsRepository.findByContactId(123L)).thenReturn(listOf(aContactAddressDetailsEntity))
-      whenever(contactIdentityService.createMultiple(any(), any())).thenReturn(
+      whenever(contactIdentityService.createMultiple(any(), any(), any())).thenReturn(
         listOf(
           createContactIdentityDetails(),
           createContactIdentityDetails(2L),
@@ -260,7 +260,7 @@ class ContactServiceTest {
 
       val result = service.createContact(request, user)
 
-      verify(contactIdentityService).createMultiple(123L, CreateMultipleIdentitiesRequest(identities, "created"))
+      verify(contactIdentityService).createMultiple(123L, CreateMultipleIdentitiesRequest(identities), user)
       val contactCaptor = argumentCaptor<ContactEntity>()
       verify(contactRepository).saveAndFlush(contactCaptor.capture())
       assertThat(contactCaptor.firstValue).isNotNull()
@@ -290,7 +290,7 @@ class ContactServiceTest {
 
       val result = service.createContact(request, user)
 
-      verify(contactIdentityService, never()).createMultiple(any(), any())
+      verify(contactIdentityService, never()).createMultiple(any(), any(), any())
 
       val contactCaptor = argumentCaptor<ContactEntity>()
       verify(contactRepository).saveAndFlush(contactCaptor.capture())
@@ -472,7 +472,7 @@ class ContactServiceTest {
       )
       whenever(contactRepository.saveAndFlush(any())).thenAnswer { i -> (i.arguments[0] as ContactEntity).copy(contactId = 123) }
       whenever(contactAddressDetailsRepository.findByContactId(any())).thenReturn(listOf(aContactAddressDetailsEntity))
-      whenever(contactIdentityService.createMultiple(any(), any())).thenThrow(RuntimeException("Bang!"))
+      whenever(contactIdentityService.createMultiple(any(), any(), any())).thenThrow(RuntimeException("Bang!"))
 
       assertThrows<RuntimeException>("Bang!") {
         service.createContact(request, user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
@@ -172,10 +172,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact identity created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_IDENTITY_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_CREATED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_CREATED, 1L, 1L, user = aUser("id_user"))
     verify(
       expectedEventType = "contacts-api.contact-identity.created",
-      expectedAdditionalInformation = ContactIdentityInfo(contactIdentityId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = ContactIdentityInfo(contactIdentityId = 1L, source = Source.DPS, username = "id_user"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact proof of identity has been created",
     )
@@ -184,10 +184,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact identity updated event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_IDENTITY_UPDATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_UPDATED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_UPDATED, 1L, 1L, user = aUser("id_user"))
     verify(
       expectedEventType = "contacts-api.contact-identity.updated",
-      expectedAdditionalInformation = ContactIdentityInfo(contactIdentityId = 1, source = Source.DPS),
+      expectedAdditionalInformation = ContactIdentityInfo(contactIdentityId = 1, source = Source.DPS, username = "id_user"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact proof of identity has been updated",
     )
@@ -196,10 +196,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact identity deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_IDENTITY_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_DELETED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_DELETED, 1L, 1L, user = aUser("id_user"))
     verify(
       expectedEventType = "contacts-api.contact-identity.deleted",
-      expectedAdditionalInformation = ContactIdentityInfo(contactIdentityId = 1, source = Source.DPS),
+      expectedAdditionalInformation = ContactIdentityInfo(contactIdentityId = 1, source = Source.DPS, username = "id_user"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact proof of identity has been deleted",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/StubUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/StubUser.kt
@@ -1,6 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.util
 
-data class StubUser(val username: String, val displayName: String, val roles: List<String>, val caseload: String? = null, val isSystemUser: Boolean = false) {
+data class StubUser(
+  val username: String,
+  val displayName: String,
+  val roles: List<String>,
+  val caseload: String? = null,
+  // isSystemUser indicates a user that does not have a user_name claim, i.e. syscon
+  val isSystemUser: Boolean = false,
+) {
   companion object {
     val USER_WITH_NO_ROLES = StubUser("unauthorised", "Unauthorised", emptyList())
     val SYNC_AND_MIGRATE_USER = StubUser("sys", "System", listOf("PERSONAL_RELATIONSHIPS_MIGRATION"), caseload = null, isSystemUser = true)
@@ -8,5 +15,6 @@ data class StubUser(val username: String, val displayName: String, val roles: Li
     val READ_WRITE_USER = StubUser("read_write_user", "Read Write", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
     val CREATING_USER = StubUser("created", "Created", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
     val UPDATING_USER = StubUser("updated", "Updated", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
+    val DELETING_USER = StubUser("deleted", "Deleted", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
   }
 }


### PR DESCRIPTION
Use the user from the token instead of created/updated by fields. Specify the user on events related to identity docs. Some minor tidy up and docs as requested in previous PR.