### PR TITLE
PRC-651: Convert number of children to use user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerNumberOfChildrenFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerNumberOfChildrenFacade.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerNumberOfChildrenRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerNumberOfChildrenResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.PrisonerNumberOfChildrenService
@@ -18,13 +19,15 @@ class PrisonerNumberOfChildrenFacade(
   fun createOrUpdateNumberOfChildren(
     prisonerNumber: String,
     request: CreateOrUpdatePrisonerNumberOfChildrenRequest,
-  ): PrisonerNumberOfChildrenResponse = prisonerNumberOfChildrenService.createOrUpdateNumberOfChildren(prisonerNumber, request)
+    user: User,
+  ): PrisonerNumberOfChildrenResponse = prisonerNumberOfChildrenService.createOrUpdateNumberOfChildren(prisonerNumber, request, user)
     .also {
       outboundEventsService.send(
         outboundEvent = OutboundEvent.PRISONER_NUMBER_OF_CHILDREN_CREATED,
         identifier = it.id,
         noms = prisonerNumber,
         source = Source.DPS,
+        user = user,
       )
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateOrUpdatePrisonerNumberOfChildrenRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateOrUpdatePrisonerNumberOfChildrenRequest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.Size
 
 @Schema(description = "Request to update prisoner number of children")
 data class CreateOrUpdatePrisonerNumberOfChildrenRequest(
@@ -13,7 +12,4 @@ data class CreateOrUpdatePrisonerNumberOfChildrenRequest(
   @field:Max(99)
   val numberOfChildren: Int?,
 
-  @Schema(description = "User who requesting to create or update", example = "admin")
-  @field:Size(max = 100, message = "requestedBy must be <= 100 characters")
-  val requestedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerNumberOfChildrenController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerNumberOfChildrenController.kt
@@ -12,9 +12,11 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.PrisonerNumberOfChildrenFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerNumberOfChildrenRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerNumberOfChildrenResponse
@@ -95,5 +97,6 @@ class PrisonerNumberOfChildrenController(
   fun createOrUpdateNumberOfChildren(
     @PathVariable prisonerNumber: String,
     @Valid @RequestBody request: CreateOrUpdatePrisonerNumberOfChildrenRequest,
-  ): PrisonerNumberOfChildrenResponse = prisonerNumberOfChildrenFacade.createOrUpdateNumberOfChildren(prisonerNumber, request)
+    @RequestAttribute user: User,
+  ): PrisonerNumberOfChildrenResponse = prisonerNumberOfChildrenFacade.createOrUpdateNumberOfChildren(prisonerNumber, request, user)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerNumberOfChildrenService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerNumberOfChildrenService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerNumberOfChildren
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerNumberOfChildrenRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerNumberOfChildrenResponse
@@ -30,6 +31,7 @@ class PrisonerNumberOfChildrenService(
   fun createOrUpdateNumberOfChildren(
     prisonerNumber: String,
     request: CreateOrUpdatePrisonerNumberOfChildrenRequest,
+    user: User,
   ): PrisonerNumberOfChildrenResponse {
     prisonerService.getPrisoner(prisonerNumber)
       ?: throw EntityNotFoundException("Prisoner number $prisonerNumber - not found")
@@ -46,7 +48,7 @@ class PrisonerNumberOfChildrenService(
     val newNumberOfChildren = PrisonerNumberOfChildren(
       prisonerNumber = prisonerNumber,
       numberOfChildren = request.numberOfChildren?.toString(),
-      createdBy = request.requestedBy,
+      createdBy = user.username,
       createdTime = LocalDateTime.now(),
       active = true,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -324,7 +324,7 @@ data class PrisonerContactInfo(val prisonerContactId: Long, override val source:
 data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class EmploymentInfo(val employmentId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class PrisonerDomesticStatus(val domesticStatusId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
-data class PrisonerNumberOfChildren(val prisonerNumberOfChildrenId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class PrisonerNumberOfChildren(val prisonerNumberOfChildrenId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 
 /**
  * The event source.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -153,7 +153,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            PrisonerNumberOfChildren(identifier, source),
+            PrisonerNumberOfChildren(identifier, source, user.username),
             PersonReference(noms),
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerNumberOfChildrenIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerNumberOfChildrenIntegrationTest.kt
@@ -1,15 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.prisoner
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerNumberOfChildrenRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerNumberOfChildrenResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
 
 class GetPrisonerNumberOfChildrenIntegrationTest : SecureAPIIntegrationTestBase() {
 
@@ -18,6 +18,11 @@ class GetPrisonerNumberOfChildrenIntegrationTest : SecureAPIIntegrationTestBase(
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
 
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
+
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.get()
     .uri("/prisoner/A1234BC/number-of-children")
 
@@ -25,26 +30,25 @@ class GetPrisonerNumberOfChildrenIntegrationTest : SecureAPIIntegrationTestBase(
   fun `should return 404 when prisoner number of children does not exist`() {
     webTestClient.get()
       .uri("/prisoner/A1234EE/number-of-children")
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
-  fun `should return number of children when user has roles`(role: String) {
+  @Test
+  fun `should return number of children`() {
     initialiseData()
     val expectedResponse = PrisonerNumberOfChildrenResponse(
       id = 1L,
       numberOfChildren = "1",
       active = true,
-      createdBy = "test-user",
+      createdBy = "read_write_user",
     )
 
     val response = webTestClient.get()
       .uri("/prisoner/A1234BC/number-of-children")
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus().isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -69,20 +73,20 @@ class GetPrisonerNumberOfChildrenIntegrationTest : SecureAPIIntegrationTestBase(
     )
     val request = CreateOrUpdatePrisonerNumberOfChildrenRequest(
       numberOfChildren = 1,
-      requestedBy = "test-user",
     )
 
-    val response = webTestClient.put()
-      .uri("/prisoner/$prisonerNumber/number-of-children")
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS__RW")))
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(request)
-      .exchange()
-      .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(PrisonerNumberOfChildrenResponse::class.java)
-      .returnResult().responseBody
-
+    val response = doWithTemporaryWritePermission {
+      webTestClient.put()
+        .uri("/prisoner/$prisonerNumber/number-of-children")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus().isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(PrisonerNumberOfChildrenResponse::class.java)
+        .returnResult().responseBody
+    }
     assertThat(response).isNotNull
     numberOfChildrenId = response!!.id
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerNumberOfChildrenControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerNumberOfChildrenControllerTest.kt
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.PrisonerNumberOfChildrenFacade
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerNumberOfChildrenRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerNumberOfChildrenResponse
 @ExtendWith(MockitoExtension::class)
@@ -61,13 +62,14 @@ class PrisonerNumberOfChildrenControllerTest {
   @Nested
   inner class CreateOrUpdateNumberOfChildren {
 
+    private val user = aUser("test-user")
+
     @Test
     fun `should create or update number of children successfully`() {
       // Given
       val prisonerNumber = "A1234BC"
       val request = CreateOrUpdatePrisonerNumberOfChildrenRequest(
         numberOfChildren = 1,
-        requestedBy = "test-user",
       )
       val expectedResponse = PrisonerNumberOfChildrenResponse(
         id = 1L,
@@ -75,15 +77,15 @@ class PrisonerNumberOfChildrenControllerTest {
         active = true,
       )
       whenever(
-        prisonerNumberOfChildrenFacade.createOrUpdateNumberOfChildren(prisonerNumber, request),
+        prisonerNumberOfChildrenFacade.createOrUpdateNumberOfChildren(prisonerNumber, request, user),
       ).thenReturn(expectedResponse)
 
       // When
-      val result = controller.createOrUpdateNumberOfChildren(prisonerNumber, request)
+      val result = controller.createOrUpdateNumberOfChildren(prisonerNumber, request, user)
 
       // Then
       assertThat(result).isEqualTo(expectedResponse)
-      verify(prisonerNumberOfChildrenFacade).createOrUpdateNumberOfChildren(prisonerNumber, request)
+      verify(prisonerNumberOfChildrenFacade).createOrUpdateNumberOfChildren(prisonerNumber, request, user)
     }
 
     @Test
@@ -92,17 +94,16 @@ class PrisonerNumberOfChildrenControllerTest {
       val prisonerNumber = "A1234BC"
       val request = CreateOrUpdatePrisonerNumberOfChildrenRequest(
         numberOfChildren = 1,
-        requestedBy = "test-user",
       )
       whenever(
-        prisonerNumberOfChildrenFacade.createOrUpdateNumberOfChildren(prisonerNumber, request),
+        prisonerNumberOfChildrenFacade.createOrUpdateNumberOfChildren(prisonerNumber, request, user),
       ).thenThrow(EntityNotFoundException("Prisoner not found"))
 
       // When/Then
       assertThrows<EntityNotFoundException> {
-        controller.createOrUpdateNumberOfChildren(prisonerNumber, request)
+        controller.createOrUpdateNumberOfChildren(prisonerNumber, request, user)
       }
-      verify(prisonerNumberOfChildrenFacade).createOrUpdateNumberOfChildren(prisonerNumber, request)
+      verify(prisonerNumberOfChildrenFacade).createOrUpdateNumberOfChildren(prisonerNumber, request, user)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerNumberOfChildrenServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerNumberOfChildrenServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerNumberOfChildren
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.prisoner
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerNumberOfChildrenRequest
@@ -34,6 +35,7 @@ class PrisonerNumberOfChildrenServiceTest {
   private lateinit var prisonerNumberOfChildrenService: PrisonerNumberOfChildrenService
 
   private val prisonerNumber = "A1234BC"
+  private val user = aUser("test-user")
 
   @Nested
   inner class GetNumberOfChildrenByPrisonerNumber {
@@ -85,7 +87,6 @@ class PrisonerNumberOfChildrenServiceTest {
       // Given
       val request = CreateOrUpdatePrisonerNumberOfChildrenRequest(
         numberOfChildren = 1,
-        requestedBy = "USER1",
       )
 
       whenever(prisonerNumberOfChildrenRepository.findByPrisonerNumberAndActiveTrue(prisonerNumber))
@@ -107,6 +108,7 @@ class PrisonerNumberOfChildrenServiceTest {
       val result = prisonerNumberOfChildrenService.createOrUpdateNumberOfChildren(
         prisonerNumber,
         request,
+        user,
       )
 
       // Then
@@ -123,7 +125,6 @@ class PrisonerNumberOfChildrenServiceTest {
       // Given
       val request = CreateOrUpdatePrisonerNumberOfChildrenRequest(
         numberOfChildren = null,
-        requestedBy = "USER1",
       )
       whenever(prisonerService.getPrisoner(any())).thenReturn(prisoner("A1234BC", prisonId = "MDI"))
       whenever(prisonerNumberOfChildrenRepository.findByPrisonerNumberAndActiveTrue(prisonerNumber))
@@ -145,6 +146,7 @@ class PrisonerNumberOfChildrenServiceTest {
       val result = prisonerNumberOfChildrenService.createOrUpdateNumberOfChildren(
         prisonerNumber,
         request,
+        user,
       )
 
       // Then
@@ -170,7 +172,6 @@ class PrisonerNumberOfChildrenServiceTest {
 
       val request = CreateOrUpdatePrisonerNumberOfChildrenRequest(
         numberOfChildren = 1,
-        requestedBy = "USER1",
       )
       whenever(prisonerNumberOfChildrenRepository.findByPrisonerNumberAndActiveTrue(prisonerNumber))
         .thenReturn(existingNumberOfChildrenCount)
@@ -184,6 +185,7 @@ class PrisonerNumberOfChildrenServiceTest {
       val result = prisonerNumberOfChildrenService.createOrUpdateNumberOfChildren(
         prisonerNumber,
         request,
+        user,
       )
 
       verify(prisonerNumberOfChildrenRepository, times(1)).save(
@@ -212,7 +214,6 @@ class PrisonerNumberOfChildrenServiceTest {
       // Given
       val request = CreateOrUpdatePrisonerNumberOfChildrenRequest(
         numberOfChildren = 1,
-        requestedBy = "test-user",
       )
       whenever(prisonerService.getPrisoner(any())).thenReturn(null)
 
@@ -221,6 +222,7 @@ class PrisonerNumberOfChildrenServiceTest {
         prisonerNumberOfChildrenService.createOrUpdateNumberOfChildren(
           prisonerNumber,
           request,
+          user,
         )
       }.message isEqualTo "Prisoner number $prisonerNumber - not found"
     }


### PR DESCRIPTION
Use the user from the token instead of created/updated by fields. Specify the user on events related to number of children