### PR TITLE
PRC-651: Use username from token for addresses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactAddressDetailsMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactAddressDetailsMappers.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping
 
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressDetailsEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.address.CreateContactAddressRequest
@@ -40,7 +41,7 @@ fun ContactAddressDetailsEntity.toModel(phoneNumbers: List<ContactAddressPhoneDe
   updatedTime = this.updatedTime,
 )
 
-fun CreateContactAddressRequest.toEntity(contactId: Long): ContactAddressEntity = ContactAddressEntity(
+fun CreateContactAddressRequest.toEntity(contactId: Long, user: User): ContactAddressEntity = ContactAddressEntity(
   contactAddressId = 0L,
   contactId = contactId,
   addressType = this.addressType,
@@ -59,7 +60,7 @@ fun CreateContactAddressRequest.toEntity(contactId: Long): ContactAddressEntity 
   endDate = this.endDate,
   noFixedAddress = this.noFixedAddress ?: false,
   comments = this.comments,
-  createdBy = this.createdBy,
+  createdBy = user.username,
   createdTime = LocalDateTime.now(),
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/CreateContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/CreateContactAddressRequest.kt
@@ -79,8 +79,4 @@ data class CreateContactAddressRequest(
   @Schema(description = "Any additional information or comments about the address", example = "Some additional information", nullable = true)
   @field:Size(max = 240, message = "comments must be <= 240 characters")
   val comments: String? = null,
-
-  @Schema(description = "The id of the user who created the contact", example = "JD000001")
-  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
-  val createdBy: String,
 ) : AddressLines<String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/PatchContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/PatchContactAddressRequest.kt
@@ -76,8 +76,4 @@ data class PatchContactAddressRequest(
   @Schema(description = "Any additional information or comments about the address", example = "Some additional information", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @field:Size(max = 240, message = "comments must be <= 240 characters")
   val comments: JsonNullable<String?> = JsonNullable.undefined(),
-
-  @Schema(description = "The id of the user who updated the address", example = "JD000001", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
-  @field:Size(max = 100, message = "updatedBy must be <= 100 characters")
-  val updatedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/UpdateContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/UpdateContactAddressRequest.kt
@@ -72,8 +72,4 @@ data class UpdateContactAddressRequest(
   @Schema(description = "Any additional information or comments about the address", example = "Some additional information", nullable = true)
   @field:Size(max = 240, message = "comments must be <= 240 characters")
   val comments: String? = null,
-
-  @Schema(description = "The id of the user who updated the address", example = "JD000001")
-  @field:Size(max = 100, message = "updatedBy must be <= 100 characters")
-  val updatedBy: String,
 ) : AddressLines<String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressController.kt
@@ -18,9 +18,11 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactAddressFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.address.CreateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.address.PatchContactAddressRequest
@@ -68,8 +70,9 @@ class ContactAddressController(private val contactAddressFacade: ContactAddressF
     contactId: Long,
     @Valid @RequestBody
     request: CreateContactAddressRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    val created = contactAddressFacade.create(contactId, request)
+    val created = contactAddressFacade.create(contactId, request, user)
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(created)
@@ -111,7 +114,8 @@ class ContactAddressController(private val contactAddressFacade: ContactAddressF
     contactAddressId: Long,
     @Valid @RequestBody
     request: UpdateContactAddressRequest,
-  ) = contactAddressFacade.update(contactId, contactAddressId, request)
+    @RequestAttribute user: User,
+  ) = contactAddressFacade.update(contactId, contactAddressId, request, user)
 
   @PatchMapping("/{contactAddressId}", consumes = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(summary = "Patch a contact address individual fields as a patch", description = "Patches an existing contact address by its ID")
@@ -149,7 +153,8 @@ class ContactAddressController(private val contactAddressFacade: ContactAddressF
     contactAddressId: Long,
     @Valid @RequestBody
     request: PatchContactAddressRequest,
-  ) = contactAddressFacade.patch(contactId, contactAddressId, request)
+    @RequestAttribute user: User,
+  ) = contactAddressFacade.patch(contactId, contactAddressId, request, user)
 
   @GetMapping("/{contactAddressId}")
   @Operation(summary = "Get a contact address", description = "Get a contact address by its ID")
@@ -211,8 +216,9 @@ class ContactAddressController(private val contactAddressFacade: ContactAddressF
     @PathVariable("contactAddressId")
     @Parameter(name = "contactAddressId", description = "The contact address ID", example = "456")
     contactAddressId: Long,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    contactAddressFacade.delete(contactId, contactAddressId)
+    contactAddressFacade.delete(contactId, contactAddressId, user)
     return ResponseEntity.noContent().build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -79,7 +79,7 @@ class ContactService(
       ?.let { prisonerContactRepository.saveAndFlush(it) }
 
     createIdentityInformation(createdContact, request, user)
-    createAddresses(createdContact.id(), user.username, request.addresses)
+    createAddresses(createdContact.id(), user.username, request.addresses, user)
     createPhoneNumbers(request, createdContact, user)
     createEmailAddresses(request, createdContact, user)
     createEmployments(request, createdContact, user)
@@ -130,7 +130,7 @@ class ContactService(
   fun getContact(id: Long): ContactDetails? = contactRepository.findById(id).getOrNull()
     ?.let { enrichContact(it) }
 
-  private fun createAddresses(contactId: Long, createdBy: String, addresses: List<Address>) {
+  private fun createAddresses(contactId: Long, createdBy: String, addresses: List<Address>, user: User) {
     addresses.forEach { address ->
       contactAddressService.create(
         contactId,
@@ -152,8 +152,8 @@ class ContactService(
           noFixedAddress = address.noFixedAddress,
           phoneNumbers = address.phoneNumbers,
           comments = address.comments,
-          createdBy = createdBy,
         ),
+        user,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -314,7 +314,7 @@ data class OutboundHMPPSDomainEvent(
  */
 
 data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -45,7 +45,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactAddressInfo(identifier, source),
+            ContactAddressInfo(identifier, source, user.username),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacadeTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.contactAddressResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.patchContactAddressRequest
@@ -28,6 +29,7 @@ class ContactAddressFacadeTest {
 
   private val contactId = 1L
   private val contactAddressId = 2L
+  private val user = aUser()
 
   @Test
   fun `should send event if create success`() {
@@ -36,18 +38,19 @@ class ContactAddressFacadeTest {
     val addressSpecificPhoneId2 = 2L
     val response = contactAddressResponse(contactAddressId, contactId, phoneNumberIds = listOf(addressSpecificPhoneId1, addressSpecificPhoneId2))
 
-    whenever(addressService.create(any(), any())).thenReturn(CreateAddressResponse(response, emptySet()))
+    whenever(addressService.create(any(), any(), any())).thenReturn(CreateAddressResponse(response, emptySet()))
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
-    val result = facade.create(contactId, request)
+    val result = facade.create(contactId, request, user)
 
     assertThat(result).isEqualTo(response)
-    verify(addressService).create(contactId, request)
+    verify(addressService).create(contactId, request, user)
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_CREATED,
       identifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
 
     verify(eventsService).send(
@@ -56,6 +59,7 @@ class ContactAddressFacadeTest {
       secondIdentifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
@@ -63,6 +67,7 @@ class ContactAddressFacadeTest {
       secondIdentifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
   }
 
@@ -71,16 +76,16 @@ class ContactAddressFacadeTest {
     val expectedException = RuntimeException("Bang!")
     val request = createContactAddressRequest()
 
-    whenever(addressService.create(any(), any())).thenThrow(expectedException)
+    whenever(addressService.create(any(), any(), any())).thenThrow(expectedException)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
-      facade.create(contactId, request)
+      facade.create(contactId, request, user)
     }
 
     assertThat(exception.message).isEqualTo(expectedException.message)
 
-    verify(addressService).create(contactId, request)
+    verify(addressService).create(contactId, request, user)
     verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
@@ -89,22 +94,24 @@ class ContactAddressFacadeTest {
     val response = contactAddressResponse(contactAddressId, contactId)
     val request = updateContactAddressRequest()
 
-    whenever(addressService.update(any(), any(), any())).thenReturn(UpdateAddressResponse(response, emptySet()))
+    whenever(addressService.update(any(), any(), any(), any())).thenReturn(UpdateAddressResponse(response, emptySet()))
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.update(
       contactId = contactId,
       contactAddressId = contactAddressId,
       request = request,
+      user = user,
     )
 
     assertThat(result).isEqualTo(response)
-    verify(addressService).update(contactId, contactAddressId, request)
+    verify(addressService).update(contactId, contactAddressId, request, user)
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_UPDATED,
       identifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
   }
 
@@ -113,15 +120,15 @@ class ContactAddressFacadeTest {
     val expectedException = RuntimeException("Bang!")
     val request = updateContactAddressRequest()
 
-    whenever(addressService.update(any(), any(), any())).thenThrow(expectedException)
+    whenever(addressService.update(any(), any(), any(), any())).thenThrow(expectedException)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
-      facade.update(contactId, contactAddressId, request)
+      facade.update(contactId, contactAddressId, request, user)
     }
 
     assertThat(exception).isEqualTo(exception)
-    verify(addressService).update(contactId, contactAddressId, request)
+    verify(addressService).update(contactId, contactAddressId, request, user)
     verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
@@ -130,22 +137,24 @@ class ContactAddressFacadeTest {
     val response = contactAddressResponse(contactAddressId, contactId)
     val request = patchContactAddressRequest()
 
-    whenever(addressService.patch(any(), any(), any())).thenReturn(UpdateAddressResponse(response, emptySet()))
+    whenever(addressService.patch(any(), any(), any(), any())).thenReturn(UpdateAddressResponse(response, emptySet()))
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.patch(
       contactId = contactId,
       contactAddressId = contactAddressId,
       request = request,
+      user = user,
     )
 
     assertThat(result).isEqualTo(response)
-    verify(addressService).patch(contactId, contactAddressId, request)
+    verify(addressService).patch(contactId, contactAddressId, request, user)
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_UPDATED,
       identifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
   }
 
@@ -154,15 +163,15 @@ class ContactAddressFacadeTest {
     val expectedException = RuntimeException("Bang!")
     val request = patchContactAddressRequest()
 
-    whenever(addressService.patch(any(), any(), any())).thenThrow(expectedException)
+    whenever(addressService.patch(any(), any(), any(), any())).thenThrow(expectedException)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
-      facade.patch(contactId, contactAddressId, request)
+      facade.patch(contactId, contactAddressId, request, user)
     }
 
     assertThat(exception).isEqualTo(exception)
-    verify(addressService).patch(contactId, contactAddressId, request)
+    verify(addressService).patch(contactId, contactAddressId, request, user)
     verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
@@ -198,10 +207,10 @@ class ContactAddressFacadeTest {
     whenever(addressService.delete(any(), any())).thenReturn(response)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
-    facade.delete(contactId, contactAddressId)
+    facade.delete(contactId, contactAddressId, user)
 
     verify(addressService).delete(contactId, contactAddressId)
-    verify(eventsService).send(OutboundEvent.CONTACT_ADDRESS_DELETED, contactAddressId, contactId)
+    verify(eventsService).send(OutboundEvent.CONTACT_ADDRESS_DELETED, contactAddressId, contactId, user = user)
   }
 
   @Test
@@ -211,7 +220,7 @@ class ContactAddressFacadeTest {
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
-      facade.delete(contactId, contactAddressId)
+      facade.delete(contactId, contactAddressId, user)
     }
 
     assertThat(exception.message).isEqualTo(expectedException.message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
@@ -489,7 +489,6 @@ fun createContactAddressRequest(
   area: String = "Bulls Nose",
   postcode: String = "EC1 2NJ",
   countryCode: String = "ENG",
-  createdBy: String = "CREATE_USER",
 ) = CreateContactAddressRequest(
   addressType = addressType,
   flat = flat,
@@ -498,7 +497,6 @@ fun createContactAddressRequest(
   area = area,
   postcode = postcode,
   countryCode = countryCode,
-  createdBy = createdBy,
 )
 
 fun updateContactAddressRequest(
@@ -510,7 +508,6 @@ fun updateContactAddressRequest(
   area: String = "Bulls Nose",
   postcode: String = "EC1 2NJ",
   countryCode: String = "ENG",
-  updatedBy: String = "AMEND_USER",
 ) = UpdateContactAddressRequest(
   primaryAddress = primaryAddress,
   addressType = addressType,
@@ -520,7 +517,6 @@ fun updateContactAddressRequest(
   area = area,
   postcode = postcode,
   countryCode = countryCode,
-  updatedBy = updatedBy,
 )
 
 fun patchContactAddressRequest() = PatchContactAddressRequest(
@@ -531,7 +527,6 @@ fun patchContactAddressRequest() = PatchContactAddressRequest(
   street = JsonNullable.of("Acacia Avenue"),
   area = JsonNullable.of("Bulls Nose"),
   postcode = JsonNullable.of("EC1 2NJ"),
-  updatedBy = "AMEND_USER",
 )
 
 fun contactAddressResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
@@ -30,7 +30,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
-    setCurrentUser(StubUser.READ_WRITE_USER)
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address",
@@ -48,14 +48,12 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
   @ParameterizedTest
   @CsvSource(
     value = [
-      "createdBy must not be null;{\"createdBy\": null, \"countryCode\": \"ENG\"}",
-      "createdBy must not be null;{\"countryCode\": \"ENG\"}",
-      "countryCode must not be null;{\"createdBy\": \"JD000001\", \"countryCode\": null}",
-      "countryCode must not be null;{\"createdBy\": \"JD000001\"}",
-      "Unsupported phone type (UNKNOWN);{ \"phoneNumbers\": [ { \"phoneNumber\": \"01234567890\", \"phoneType\": \"UNKNOWN\" } ], \"countryCode\": \"ENG\", \"createdBy\": \"JD000001\"}",
-      "phoneNumbers[0].phoneNumber must not be null;{ \"phoneNumbers\": [ { \"phoneType\": \"MOB\" } ], \"countryCode\": \"ENG\", \"createdBy\": \"JD000001\"}",
-      "phoneNumbers[0].phoneType must not be null;{ \"phoneNumbers\": [ { \"phoneNumber\": \"01234567890\" } ], \"countryCode\": \"ENG\", \"createdBy\": \"JD000001\"}",
-      "phoneNumbers must not be null;{ \"phoneNumbers\": null, \"countryCode\": \"ENG\", \"createdBy\": \"JD000001\"}",
+      "countryCode must not be null;{\"countryCode\": null}",
+      "countryCode must not be null;{}",
+      "Unsupported phone type (UNKNOWN);{ \"phoneNumbers\": [ { \"phoneNumber\": \"01234567890\", \"phoneType\": \"UNKNOWN\" } ], \"countryCode\": \"ENG\"}",
+      "phoneNumbers[0].phoneNumber must not be null;{ \"phoneNumbers\": [ { \"phoneType\": \"MOB\" } ], \"countryCode\": \"ENG\"}",
+      "phoneNumbers[0].phoneType must not be null;{ \"phoneNumbers\": [ { \"phoneNumber\": \"01234567890\" } ], \"countryCode\": \"ENG\"}",
+      "phoneNumbers must not be null;{ \"phoneNumbers\": null, \"countryCode\": \"ENG\"}",
     ],
     delimiter = ';',
   )
@@ -96,7 +94,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(savedContactId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactId, Source.DPS, "created"),
     )
   }
 
@@ -120,7 +118,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(savedContactId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactId, Source.DPS, "created"),
     )
   }
 
@@ -155,7 +153,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -168,7 +166,6 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       property = "27",
       street = "Hello Road",
       countryCode = "ENG",
-      createdBy = "created",
       phoneNumbers = listOf(
         PhoneNumber(phoneType = "MOB", phoneNumber = "07777123456", extNumber = null),
         PhoneNumber(phoneType = "BUS", phoneNumber = "07777123455", extNumber = null),
@@ -181,7 +178,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
 
@@ -217,10 +214,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(contact.addresses).isEmpty()
 
     // Verify no events were published
-    stubEvents.assertHasNoEvents(
-      event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(savedContactId, Source.DPS),
-    )
+    stubEvents.assertHasNoEvents(event = OutboundEvent.CONTACT_ADDRESS_CREATED)
   }
 
   @Test
@@ -234,7 +228,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -253,12 +247,12 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -277,7 +271,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasNoEvents(event = OutboundEvent.CONTACT_ADDRESS_UPDATED)
@@ -297,12 +291,12 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -321,7 +315,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasNoEvents(event = OutboundEvent.CONTACT_ADDRESS_UPDATED)
@@ -349,22 +343,22 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS, "created"),
     )
   }
 
@@ -387,12 +381,12 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -426,7 +420,6 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       Arguments.of("area must be <= 70 characters", aMinimalAddressRequest().copy(area = "".padStart(71, 'X'))),
       Arguments.of("postcode must be <= 12 characters", aMinimalAddressRequest().copy(postcode = "".padStart(13, 'X'))),
       Arguments.of("comments must be <= 240 characters", aMinimalAddressRequest().copy(comments = "".padStart(241, 'X'))),
-      Arguments.of("createdBy must be <= 100 characters", aMinimalAddressRequest().copy(createdBy = "".padStart(101, 'X'))),
       Arguments.of("phoneNumbers[0].phoneNumber must be <= 40 characters", aMinimalAddressRequest().copy(phoneNumbers = listOf(PhoneNumber(phoneType = "MOB", phoneNumber = "".padStart(41, 'X'), extNumber = null)))),
       Arguments.of("phoneNumbers[0].phoneType must be <= 12 characters", aMinimalAddressRequest().copy(phoneNumbers = listOf(PhoneNumber(phoneType = "".padStart(13, 'X'), phoneNumber = "07403322232", extNumber = null)))),
       Arguments.of("phoneNumbers[0].extNumber must be <= 7 characters", aMinimalAddressRequest().copy(phoneNumbers = listOf(PhoneNumber(phoneType = "MOB", phoneNumber = "07403322232", extNumber = "".padStart(8, 'X'))))),
@@ -439,7 +432,6 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
         assertThat(property).isEqualTo(request.property)
         assertThat(street).isEqualTo(request.street)
         assertThat(postcode).isEqualTo(request.postcode)
-        assertThat(createdBy).isEqualTo(request.createdBy)
         assertThat(createdTime).isNotNull()
       }
     }
@@ -450,7 +442,6 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       property = "27",
       street = "Hello Road",
       countryCode = "ENG",
-      createdBy = "created",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
@@ -46,7 +46,6 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
         property = "27",
         street = "Hello Road",
         countryCode = "ENG",
-        createdBy = "created",
       ),
     ).contactAddressId
     stubEvents.reset()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -63,7 +63,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(json)
       .exchange()
       .expectStatus()
@@ -85,7 +85,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -107,7 +107,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -135,7 +135,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(json)
       .exchange()
       .expectStatus()
@@ -165,7 +165,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -353,13 +353,13 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(minimalCreated.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(minimalCreated.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(everythingCreated.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(everythingCreated.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -401,7 +401,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(aMinimalCreateContactRequest().copy(addresses = listOf(addressWithInvalidPhone)))
       .exchange()
       .expectStatus()
@@ -472,7 +472,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(aMinimalCreateContactRequest().copy(phoneNumbers = listOf(invalidPhone)))
       .exchange()
       .expectStatus()
@@ -527,7 +527,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(aMinimalCreateContactRequest().copy(emailAddresses = listOf(invalid)))
       .exchange()
       .expectStatus()
@@ -589,7 +589,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(aMinimalCreateContactRequest().copy(employments = listOf(invalid)))
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
@@ -46,7 +46,6 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
         property = "27",
         street = "Hello Road",
         countryCode = "ENG",
-        createdBy = "created",
       ),
     ).contactAddressId
     stubEvents.reset()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
@@ -44,9 +44,9 @@ class DeleteContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
         area = "Hoggs Bottom",
         postcode = "HB10 2NB",
         countryCode = "ENG",
-        createdBy = "created",
       ),
     ).contactAddressId
+    setCurrentUser(StubUser.DELETING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.delete()
@@ -70,7 +70,7 @@ class DeleteContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_DELETED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "deleted"),
     )
   }
 
@@ -89,10 +89,7 @@ class DeleteContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     assertThat(errors.userMessage).isEqualTo("Entity not found : Contact address (-99) not found")
 
-    stubEvents.assertHasNoEvents(
-      event = OutboundEvent.CONTACT_ADDRESS_DELETED,
-      additionalInfo = ContactAddressInfo(-99, Source.DPS),
-    )
+    stubEvents.assertHasNoEvents(event = OutboundEvent.CONTACT_ADDRESS_DELETED)
   }
 
   @ParameterizedTest
@@ -117,7 +114,7 @@ class DeleteContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_DELETED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "deleted"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
@@ -43,7 +43,6 @@ class DeleteContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
         property = "27",
         street = "Hello Road",
         countryCode = "ENG",
-        createdBy = "created",
       ),
     ).contactAddressId
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactAddressPhoneIntegrationTest.kt
@@ -42,7 +42,6 @@ class GetContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
           property = "27",
           street = "Hello Road",
           countryCode = "ENG",
-          createdBy = "created",
         ),
 
       ).contactAddressId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
@@ -52,7 +52,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
         area = "Hoggs Bottom",
         postcode = "HB10 2NB",
         countryCode = "ENG",
-        createdBy = "created",
       ),
 
     ).contactAddressId
@@ -68,9 +67,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
   @ParameterizedTest
   @CsvSource(
     value = [
-      "Validation failure: updatedBy must not be null;{\"updatedBy\": null}",
-      "Validation failure: updatedBy must not be null;{}",
-      "Validation failure(s): countryCode must not be null;{\"countryCode\": null, \"updatedBy\": \"user\"}",
+      "Validation failure(s): countryCode must not be null;{\"countryCode\": null}",
     ],
     delimiter = ';',
   )
@@ -92,7 +89,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
     )
   }
 
@@ -116,7 +112,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
     )
   }
 
@@ -140,7 +135,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
     )
   }
 
@@ -165,7 +159,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
     )
   }
 
@@ -190,7 +183,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(-99, Source.DPS),
     )
   }
 
@@ -214,7 +206,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       endDate = JsonNullable.of(LocalDate.of(2001, 12, 25)),
       noFixedAddress = JsonNullable.of(false),
       comments = JsonNullable.of("No comments"),
-      updatedBy = "updated",
     )
 
     val updated = testAPIClient.patchAContactAddress(
@@ -249,7 +240,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -270,7 +261,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -293,12 +284,12 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -321,7 +312,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -344,12 +335,12 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -372,7 +363,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -406,22 +397,22 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS, "updated"),
     )
   }
 
@@ -451,12 +442,12 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -487,10 +478,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       Arguments.of(
         "comments must be <= 240 characters",
         aMinimalPatchAddressRequest().copy(comments = JsonNullable.of("".padStart(241, 'X'))),
-      ),
-      Arguments.of(
-        "updatedBy must be <= 100 characters",
-        aMinimalPatchAddressRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 
@@ -564,9 +551,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       ),
     )
 
-    private fun aMinimalPatchAddressRequest() = PatchContactAddressRequest(
-      updatedBy = "updated",
-    )
+    private fun aMinimalPatchAddressRequest() = PatchContactAddressRequest()
 
     private fun aMinimalCreateAddressRequest() = CreateContactAddressRequest(
       addressType = "HOME",
@@ -575,7 +560,6 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       property = "27",
       street = "Hello Road",
       countryCode = "ENG",
-      createdBy = "created",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
@@ -50,7 +50,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
         area = "Hoggs Bottom",
         postcode = "HB10 2NB",
         countryCode = "ENG",
-        createdBy = "created",
       ),
 
     ).contactAddressId
@@ -66,11 +65,9 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
   @ParameterizedTest
   @CsvSource(
     value = [
-      "updatedBy must not be null;{\"updatedBy\": null, \"primaryAddress\": true, \"countryCode\": \"ENG\"}",
-      "updatedBy must not be null;{\"primaryAddress\": true, \"countryCode\": \"ENG\"}",
-      "countryCode must not be null;{\"updatedBy\": \"foo\", \"primaryAddress\": true, \"countryCode\": null}",
-      "countryCode must not be null;{\"updatedBy\": \"foo\", \"primaryAddress\": true}",
-      "primaryAddress must not be null;{\"updatedBy\": \"foo\", \"countryCode\": \"ENG\"}",
+      "countryCode must not be null;{\"primaryAddress\": true, \"countryCode\": null}",
+      "countryCode must not be null;{\"primaryAddress\": true}",
+      "primaryAddress must not be null;{\"countryCode\": \"ENG\"}",
     ],
     delimiter = ';',
   )
@@ -92,7 +89,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
     )
   }
 
@@ -116,7 +112,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
     )
   }
 
@@ -140,7 +135,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
     )
   }
 
@@ -165,7 +159,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
     )
   }
 
@@ -190,7 +183,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(-99, Source.DPS),
     )
   }
 
@@ -205,7 +197,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       area = "Hoggs Bottom",
       postcode = "HB10 1DJ",
       countryCode = "ENG",
-      updatedBy = "updated",
     )
 
     val updated = testAPIClient.updateAContactAddress(
@@ -228,7 +219,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -239,7 +230,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       addressType = null,
       primaryAddress = false,
       countryCode = "ENG",
-      updatedBy = "updated",
     )
 
     val updated = testAPIClient.updateAContactAddress(
@@ -252,7 +242,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -276,12 +266,12 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -305,7 +295,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -329,12 +319,12 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -358,7 +348,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -390,22 +380,22 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS, "updated"),
     )
   }
 
@@ -434,12 +424,12 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -464,11 +454,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       Arguments.of(
         "comments must be <= 240 characters",
         aMinimalUpdateAddressRequest().copy(comments = "".padStart(241, 'X')),
-      ),
-
-      Arguments.of(
-        "updatedBy must be <= 100 characters",
-        aMinimalUpdateAddressRequest().copy(updatedBy = "".padStart(101, 'X')),
       ),
     )
 
@@ -499,7 +484,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       property = "27",
       street = "Hello Road",
       countryCode = "ENG",
-      updatedBy = "updated",
     )
 
     private fun aMinimalCreateAddressRequest() = CreateContactAddressRequest(
@@ -509,7 +493,6 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
       property = "27",
       street = "Hello Road",
       countryCode = "ENG",
-      createdBy = "created",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
@@ -47,7 +47,6 @@ class UpdateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
         property = "27",
         street = "Hello Road",
         countryCode = "ENG",
-        createdBy = "created",
       ),
 
     ).contactAddressId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactAddressIntegrationTest.kt
@@ -71,10 +71,11 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
   @ParameterizedTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
   fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER.copy(roles = listOf(role)))
     webTestClient.get()
       .uri("/sync/contact-address/1")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -84,7 +85,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(createContactAddressRequest(contactId))
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -94,7 +95,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(updateContactAddressRequest(contactId))
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -102,7 +103,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
     webTestClient.delete()
       .uri("/sync/contact-address/1")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -115,7 +116,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
     val contactAddress = webTestClient.get()
       .uri("/sync/contact-address/{contactAddressId}", contactAddressId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isOk
@@ -137,7 +138,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-address")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(createContactAddressRequest(contactId))
       .exchange()
       .expectStatus()
@@ -158,7 +159,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS),
+      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS, "SYS"),
       personReference = PersonReference(dpsContactId = contactId),
     )
   }
@@ -169,7 +170,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-address")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(createContactAddressRequest(contactId))
       .exchange()
       .expectStatus()
@@ -191,7 +192,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-address/{contactAddressId}", contactAddress.contactAddressId)
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(updateContactAddressRequest(contactId))
       .exchange()
       .expectStatus()
@@ -213,7 +214,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS),
+      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS, "SYS"),
       personReference = PersonReference(dpsContactId = contactId),
     )
   }
@@ -225,7 +226,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-address")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(createContactAddressRequest(contactId))
       .exchange()
       .expectStatus()
@@ -246,7 +247,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-address/{contactAddressId}", contactAddress.contactAddressId)
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(updateContactAddressRequest(contactId, verified = true))
       .exchange()
       .expectStatus()
@@ -274,7 +275,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
     webTestClient.delete()
       .uri("/sync/contact-address/5")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isOk
@@ -283,7 +284,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
     assertThat(beforeCount).isEqualTo((afterCount + 1))
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_DELETED,
-      additionalInfo = ContactAddressInfo(5, Source.NOMIS),
+      additionalInfo = ContactAddressInfo(5, Source.NOMIS, "SYS"),
       personReference = PersonReference(dpsContactId = 4),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -17,6 +17,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.never
+import org.mockito.kotlin.same
 import org.mockito.kotlin.whenever
 import org.openapitools.jackson.nullable.JsonNullable
 import org.springframework.data.domain.Page
@@ -136,7 +137,7 @@ class ContactServiceTest {
       val identityEntity1 =
         createContactIdentityDetailsEntity(id = 1, identityType = "PNC", identityValue = "1923/1Z34567A")
       whenever(contactIdentityDetailsRepository.findByContactId(123L)).thenReturn(listOf(identityEntity1))
-      whenever(contactAddressService.create(any(), any())).thenReturn(
+      whenever(contactAddressService.create(any(), any(), any())).thenReturn(
         CreateAddressResponse(
           contactAddressResponse(
             999,
@@ -190,7 +191,7 @@ class ContactServiceTest {
       assertThat(result.createdContact.identities[0].identityValue).isEqualTo("1923/1Z34567A")
 
       val contactAddressCaptor = argumentCaptor<CreateContactAddressRequest>()
-      verify(contactAddressService).create(eq(123L), contactAddressCaptor.capture())
+      verify(contactAddressService).create(eq(123L), contactAddressCaptor.capture(), same(user))
       val createAddressRequest = contactAddressCaptor.firstValue
       with(createAddressRequest) {
         assertThat(addressType).isEqualTo(addressWithPhoneNumber.addressType)
@@ -210,7 +211,6 @@ class ContactServiceTest {
         assertThat(noFixedAddress).isEqualTo(addressWithPhoneNumber.noFixedAddress)
         assertThat(phoneNumbers).isEqualTo(addressWithPhoneNumber.phoneNumbers)
         assertThat(comments).isEqualTo(addressWithPhoneNumber.comments)
-        assertThat(createdBy).isEqualTo(user.username)
       }
 
       verify(contactPhoneService).createMultiple(123L, user.username, listOf(phoneNumber))
@@ -488,7 +488,7 @@ class ContactServiceTest {
       )
       whenever(contactRepository.saveAndFlush(any())).thenAnswer { i -> (i.arguments[0] as ContactEntity).copy(contactId = 123) }
       whenever(contactAddressDetailsRepository.findByContactId(any())).thenReturn(listOf(aContactAddressDetailsEntity))
-      whenever(contactAddressService.create(any(), any())).thenThrow(RuntimeException("Bang!"))
+      whenever(contactAddressService.create(any(), any(), any())).thenThrow(RuntimeException("Bang!"))
 
       assertThrows<RuntimeException>("Bang!") {
         service.createContact(request, user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
@@ -64,10 +64,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact address created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_CREATED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_CREATED, 1L, 1L, user = aUser("address"))
     verify(
       expectedEventType = "contacts-api.contact-address.created",
-      expectedAdditionalInformation = ContactAddressInfo(contactAddressId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = ContactAddressInfo(contactAddressId = 1L, source = Source.DPS, username = "address"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address has been created",
     )
@@ -76,10 +76,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact address updated event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_UPDATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_UPDATED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_UPDATED, 1L, 1L, user = aUser("address"))
     verify(
       expectedEventType = "contacts-api.contact-address.updated",
-      expectedAdditionalInformation = ContactAddressInfo(contactAddressId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = ContactAddressInfo(contactAddressId = 1L, source = Source.DPS, username = "address"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address has been updated",
     )
@@ -88,10 +88,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact address deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_DELETED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_DELETED, 1L, 1L, user = aUser("address"))
     verify(
       expectedEventType = "contacts-api.contact-address.deleted",
-      expectedAdditionalInformation = ContactAddressInfo(contactAddressId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = ContactAddressInfo(contactAddressId = 1L, source = Source.DPS, username = "address"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address has been deleted",
     )


### PR DESCRIPTION
Use username from the token rather than created/updated by.  Also add username to events.