### PR TITLE
PRC-651: Use username from token for employments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/employment/CreateEmploymentRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/employment/CreateEmploymentRequest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.Size
 
 @Schema(description = "Request to create a new employment with an employer and whether it is active or inactive")
 data class CreateEmploymentRequest(
@@ -9,7 +8,4 @@ data class CreateEmploymentRequest(
   val organisationId: Long,
   @Schema(description = "Whether this is a current employment or not", nullable = false, required = true)
   val isActive: Boolean,
-  @Schema(description = "The id of the user who created the entry", example = "JD000001")
-  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
-  val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/employment/PatchEmploymentsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/employment/PatchEmploymentsRequest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.Size
 
 @Schema(description = "Request allowing several changes to employments in a single request.")
 data class PatchEmploymentsRequest(
@@ -13,8 +12,4 @@ data class PatchEmploymentsRequest(
 
   @Schema(description = "List of ids for employments to delete", required = true)
   val deleteEmployments: List<Long>,
-
-  @Schema(description = "The id of the user requesting the changes. Will become created by for new employments and updated by for updated employments", required = true)
-  @field:Size(max = 100, message = "requestedBy must be <= 100 characters")
-  val requestedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/employment/UpdateEmploymentRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/employment/UpdateEmploymentRequest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.Size
 
 @Schema(description = "Request to update an existing employment's employer or active flag.")
 data class UpdateEmploymentRequest(
@@ -9,7 +8,4 @@ data class UpdateEmploymentRequest(
   val organisationId: Long,
   @Schema(description = "Whether this is a current employment or not", nullable = false, required = true)
   val isActive: Boolean,
-  @Schema(description = "The id of the user who updated the entry", example = "JD000001")
-  @field:Size(max = 100, message = "updatedBy must be <= 100 characters")
-  val updatedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmploymentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmploymentController.kt
@@ -19,10 +19,12 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.EmploymentFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.CreateEmploymentRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.PatchEmploymentsRequest
@@ -80,7 +82,8 @@ class ContactEmploymentController(
       example = "123456",
     ) contactId: Long,
     @Valid @RequestBody request: PatchEmploymentsRequest,
-  ): List<EmploymentDetails> = employmentFacade.patchEmployments(contactId, request)
+    @RequestAttribute user: User,
+  ): List<EmploymentDetails> = employmentFacade.patchEmployments(contactId, request, user)
 
   @PostMapping
   @Operation(
@@ -121,8 +124,9 @@ class ContactEmploymentController(
       example = "123456",
     ) contactId: Long,
     @Valid @RequestBody request: CreateEmploymentRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<EmploymentDetails> {
-    val createdEmployment = employmentFacade.createEmployment(contactId, request)
+    val createdEmployment = employmentFacade.createEmployment(contactId, request, user)
     return ResponseEntity
       .created(URI.create("/contact/$contactId/employment/${createdEmployment.employmentId}"))
       .body(createdEmployment)
@@ -172,7 +176,8 @@ class ContactEmploymentController(
       example = "123456",
     ) employmentId: Long,
     @Valid @RequestBody request: UpdateEmploymentRequest,
-  ) = employmentFacade.updateEmployment(contactId, employmentId, request)
+    @RequestAttribute user: User,
+  ) = employmentFacade.updateEmployment(contactId, employmentId, request, user)
 
   @DeleteMapping("/{employmentId}")
   @Operation(
@@ -205,8 +210,9 @@ class ContactEmploymentController(
       description = "The id of the employment",
       example = "123456",
     ) employmentId: Long,
+    @RequestAttribute user: User,
   ) {
-    employmentFacade.deleteEmployment(contactId, employmentId)
+    employmentFacade.deleteEmployment(contactId, employmentId, user)
   }
 
   @GetMapping("/{employmentId}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/EmploymentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/EmploymentService.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.organisationsapi.model.OrganisationSummary
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.EmploymentEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.internal.PatchEmploymentResult
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.PatchEmploymentsRequest
@@ -21,7 +22,7 @@ class EmploymentService(
   private val organisationService: OrganisationService,
 ) {
 
-  fun patchEmployments(contactId: Long, request: PatchEmploymentsRequest): PatchEmploymentResult {
+  fun patchEmployments(contactId: Long, request: PatchEmploymentsRequest, user: User): PatchEmploymentResult {
     validateContactExists(contactId)
     val createdIds = mutableListOf<Long>()
     val updatedIds = mutableListOf<Long>()
@@ -34,7 +35,7 @@ class EmploymentService(
           organisationId = newEmployment.organisationId,
           contactId = contactId,
           active = newEmployment.isActive,
-          createdBy = request.requestedBy,
+          createdBy = user.username,
           createdTime = LocalDateTime.now(),
           updatedBy = null,
           updatedTime = null,
@@ -49,7 +50,7 @@ class EmploymentService(
         existingEmployment.copy(
           organisationId = updatedEmployment.organisationId,
           active = updatedEmployment.isActive,
-          updatedBy = request.requestedBy,
+          updatedBy = user.username,
           updatedTime = LocalDateTime.now(),
         ),
       )
@@ -99,7 +100,7 @@ class EmploymentService(
     return createEmploymentDetails(created, organisation)
   }
 
-  fun updateEmployment(contactId: Long, employmentId: Long, request: UpdateEmploymentRequest): EmploymentDetails {
+  fun updateEmployment(contactId: Long, employmentId: Long, request: UpdateEmploymentRequest, user: User): EmploymentDetails {
     validateContactExists(contactId)
     val organisation = validateOrganisationExists(request.organisationId)
     val originalEntity = validateEmploymentExists(employmentId)
@@ -107,7 +108,7 @@ class EmploymentService(
       originalEntity.copy(
         organisationId = request.organisationId,
         active = request.isActive,
-        updatedBy = request.updatedBy,
+        updatedBy = user.username,
         updatedTime = LocalDateTime.now(),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -322,7 +322,7 @@ data class ContactIdentityInfo(val contactIdentityId: Long, override val source:
 data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class EmploymentInfo(val employmentId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class EmploymentInfo(val employmentId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class PrisonerDomesticStatus(val domesticStatusId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class PrisonerNumberOfChildren(val prisonerNumberOfChildrenId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -133,7 +133,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            EmploymentInfo(identifier, source),
+            EmploymentInfo(identifier, source, user.username),
             contactId?.let { PersonReference(it) },
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -567,13 +567,13 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_CREATED,
-      additionalInfo = EmploymentInfo(firstCreated.employmentId, Source.DPS),
+      additionalInfo = EmploymentInfo(firstCreated.employmentId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_CREATED,
-      additionalInfo = EmploymentInfo(secondCreated.employmentId, Source.DPS),
+      additionalInfo = EmploymentInfo(secondCreated.employmentId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateEmploymentIntegrationTest.kt
@@ -25,7 +25,7 @@ class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
-    setCurrentUser(StubUser.READ_WRITE_USER)
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "employment",
@@ -44,12 +44,10 @@ class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
   @ParameterizedTest
   @CsvSource(
     value = [
-      "createdBy must not be null;{\"organisationId\": 99, \"isActive\": true, \"createdBy\": null}",
-      "createdBy must not be null;{\"organisationId\": 99, \"isActive\": true}",
-      "organisationId must not be null;{\"organisationId\": null, \"isActive\": true, \"createdBy\": \"USER\"}",
-      "organisationId must not be null;{\"isActive\": true, \"createdBy\": \"USER\"}",
-      "isActive must not be null;{\"organisationId\": 99, \"isActive\": null, \"createdBy\": \"USER\"}",
-      "isActive must not be null;{\"organisationId\": 99, \"createdBy\": \"USER\"}",
+      "organisationId must not be null;{\"organisationId\": null, \"isActive\": true}",
+      "organisationId must not be null;{\"isActive\": true}",
+      "isActive must not be null;{\"organisationId\": 99, \"isActive\": null}",
+      "isActive must not be null;{\"organisationId\": 99}",
     ],
     delimiter = ';',
   )
@@ -58,7 +56,7 @@ class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/$savedContactId/employment")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(json)
       .exchange()
       .expectStatus()
@@ -78,7 +76,7 @@ class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/-321/employment")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -100,7 +98,7 @@ class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_CREATED,
-      additionalInfo = EmploymentInfo(created.employmentId, Source.DPS),
+      additionalInfo = EmploymentInfo(created.employmentId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -109,7 +107,6 @@ class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
     private fun aMinimalRequest() = CreateEmploymentRequest(
       organisationId = 999,
       isActive = true,
-      createdBy = "created",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteEmploymentIntegrationTest.kt
@@ -28,7 +28,7 @@ class DeleteEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
     stubOrganisationSummary(999)
     stubOrganisationSummary(666)
 
-    setCurrentUser(StubUser.READ_WRITE_USER)
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "employment",
@@ -40,9 +40,9 @@ class DeleteEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateEmploymentRequest(
         organisationId = 999,
         isActive = true,
-        createdBy = "created",
       ),
     ).employmentId
+    setCurrentUser(StubUser.DELETING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.delete()
@@ -54,7 +54,7 @@ class DeleteEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
     val errors = webTestClient.delete()
       .uri("/contact/-321/employment/$savedEmploymentId")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound
@@ -71,7 +71,7 @@ class DeleteEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
     val errors = webTestClient.delete()
       .uri("/contact/$savedContactId/employment/-321")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound
@@ -91,7 +91,7 @@ class DeleteEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_DELETED,
-      additionalInfo = EmploymentInfo(savedEmploymentId, Source.DPS),
+      additionalInfo = EmploymentInfo(savedEmploymentId, Source.DPS, "deleted"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetEmploymentIntegrationTest.kt
@@ -35,7 +35,6 @@ class GetEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
         CreateEmploymentRequest(
           organisationId = 999,
           isActive = true,
-          createdBy = "created",
         ),
       ).employmentId
     }
@@ -50,7 +49,7 @@ class GetEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
     val errors = webTestClient.get()
       .uri("/contact/-321/employment/$savedEmploymentId")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound
@@ -66,7 +65,7 @@ class GetEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
     val errors = webTestClient.get()
       .uri("/contact/$savedContactId/employment/-321")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateEmploymentIntegrationTest.kt
@@ -41,7 +41,6 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       CreateEmploymentRequest(
         organisationId = 999,
         isActive = true,
-        createdBy = "created",
       ),
     ).employmentId
     setCurrentUser(StubUser.UPDATING_USER)
@@ -56,12 +55,10 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
   @ParameterizedTest
   @CsvSource(
     value = [
-      "updatedBy must not be null;{\"organisationId\": 99, \"isActive\": true, \"updatedBy\": null}",
-      "updatedBy must not be null;{\"organisationId\": 99, \"isActive\": true}",
-      "organisationId must not be null;{\"organisationId\": null, \"isActive\": true, \"updatedBy\": \"USER\"}",
-      "organisationId must not be null;{\"isActive\": true, \"updatedBy\": \"USER\"}",
-      "isActive must not be null;{\"organisationId\": 99, \"isActive\": null, \"updatedBy\": \"USER\"}",
-      "isActive must not be null;{\"organisationId\": 99, \"updatedBy\": \"USER\"}",
+      "organisationId must not be null;{\"organisationId\": null, \"isActive\": true}",
+      "organisationId must not be null;{\"isActive\": true}",
+      "isActive must not be null;{\"organisationId\": 99, \"isActive\": null}",
+      "isActive must not be null;{\"organisationId\": 99}",
     ],
     delimiter = ';',
   )
@@ -70,7 +67,7 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/$savedContactId/employment/$savedEmploymentId")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(json)
       .exchange()
       .expectStatus()
@@ -90,7 +87,7 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/-321/employment/$savedEmploymentId")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -111,7 +108,7 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
       .uri("/contact/$savedContactId/employment/-321")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(request)
       .exchange()
       .expectStatus()
@@ -134,7 +131,7 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_UPDATED,
-      additionalInfo = EmploymentInfo(updated.employmentId, Source.DPS),
+      additionalInfo = EmploymentInfo(updated.employmentId, Source.DPS, "updated"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -143,7 +140,6 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
     private fun aMinimalRequest() = UpdateEmploymentRequest(
       organisationId = 666,
       isActive = false,
-      updatedBy = "updated",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/EmploymentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/EmploymentServiceTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.EmploymentEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createEmploymentEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createOrganisationSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.employment.Employment
@@ -42,6 +43,7 @@ class EmploymentServiceTest {
   private val employmentRepository: EmploymentRepository = mock()
   private val organisationService: OrganisationService = mock()
   private val service = EmploymentService(contactRepository, employmentRepository, organisationService)
+  private val user = aUser()
 
   @Test
   fun `Patch employments should create a new employment`() {
@@ -64,8 +66,8 @@ class EmploymentServiceTest {
         createEmployments = listOf(Employment(2, true)),
         updateEmployments = emptyList(),
         deleteEmployments = emptyList(),
-        requestedBy = "USER1",
       ),
+      user,
     )
 
     assertThat(employments.employmentsAfterUpdate).hasSize(2)
@@ -130,8 +132,8 @@ class EmploymentServiceTest {
         createEmployments = emptyList(),
         updateEmployments = listOf(PatchEmploymentsUpdateEmployment(1, 2, false)),
         deleteEmployments = emptyList(),
-        requestedBy = "USER1",
       ),
+      user,
     )
 
     assertThat(employments.employmentsAfterUpdate).hasSize(1)
@@ -171,8 +173,8 @@ class EmploymentServiceTest {
           createEmployments = emptyList(),
           updateEmployments = listOf(PatchEmploymentsUpdateEmployment(1, 2, false)),
           deleteEmployments = emptyList(),
-          requestedBy = "USER1",
         ),
+        user,
       )
     }
     assertThat(exception.message).isEqualTo("Employment with id 1 not found")
@@ -190,8 +192,8 @@ class EmploymentServiceTest {
           createEmployments = emptyList(),
           updateEmployments = listOf(PatchEmploymentsUpdateEmployment(1, 2, false)),
           deleteEmployments = emptyList(),
-          requestedBy = "USER1",
         ),
+        user,
       )
     }
     assertThat(exception.message).isEqualTo("Contact (99) not found")
@@ -223,8 +225,8 @@ class EmploymentServiceTest {
         createEmployments = emptyList(),
         updateEmployments = emptyList(),
         deleteEmployments = listOf(1),
-        requestedBy = "USER1",
       ),
+      user,
     )
 
     assertThat(employments.employmentsAfterUpdate).isEmpty()
@@ -249,8 +251,8 @@ class EmploymentServiceTest {
           createEmployments = emptyList(),
           updateEmployments = emptyList(),
           deleteEmployments = listOf(99),
-          requestedBy = "USER1",
         ),
+        user,
       )
     }
     assertThat(exception.message).isEqualTo("Employment with id 99 not found")
@@ -385,8 +387,8 @@ class EmploymentServiceTest {
       UpdateEmploymentRequest(
         organisationId = 2,
         isActive = false,
-        updatedBy = "UPDATED",
       ),
+      user,
     )
 
     assertThat(updated.employmentId).isEqualTo(999)
@@ -403,7 +405,7 @@ class EmploymentServiceTest {
           active = false,
           createdBy = "USER",
           createdTime = now(),
-          updatedBy = "UPDATED",
+          updatedBy = "USER1",
           updatedTime = now(),
         ),
       )
@@ -426,8 +428,8 @@ class EmploymentServiceTest {
         UpdateEmploymentRequest(
           organisationId = 1,
           isActive = true,
-          updatedBy = "USER1",
         ),
+        user,
       )
     }
     assertThat(exception).isEqualTo(expectedException)
@@ -449,8 +451,8 @@ class EmploymentServiceTest {
         UpdateEmploymentRequest(
           organisationId = 1,
           isActive = true,
-          updatedBy = "USER1",
         ),
+        user,
       )
     }
     assertThat(exception.message).isEqualTo("Employment (1) not found")
@@ -472,8 +474,8 @@ class EmploymentServiceTest {
         UpdateEmploymentRequest(
           organisationId = 1,
           isActive = true,
-          updatedBy = "USER1",
         ),
+        user,
       )
     }
     assertThat(exception.message).isEqualTo("Contact (99) not found")


### PR DESCRIPTION
Use username from the token rather than created/updated by.  Also add username to events.