### PR TITLE
PRC-651: Use username from token for phones

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacade.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdateContactAddressPhoneRequest
@@ -15,42 +16,46 @@ class ContactAddressPhoneFacade(
   private val outboundEventsService: OutboundEventsService,
 ) {
 
-  fun create(contactId: Long, contactAddressId: Long, request: CreateContactAddressPhoneRequest): ContactAddressPhoneDetails = contactAddressPhoneService.create(contactId, contactAddressId, request).also {
+  fun create(contactId: Long, contactAddressId: Long, request: CreateContactAddressPhoneRequest, user: User): ContactAddressPhoneDetails = contactAddressPhoneService.create(contactId, contactAddressId, request, user).also {
     outboundEventsService.send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
       identifier = it.contactAddressPhoneId,
       secondIdentifier = it.contactAddressId,
       contactId = contactId,
+      user = user,
     )
   }
 
-  fun createMultiple(contactId: Long, contactAddressId: Long, request: CreateMultiplePhoneNumbersRequest): List<ContactAddressPhoneDetails> = contactAddressPhoneService.createMultiple(contactId, contactAddressId, request).also { created ->
+  fun createMultiple(contactId: Long, contactAddressId: Long, request: CreateMultiplePhoneNumbersRequest, user: User): List<ContactAddressPhoneDetails> = contactAddressPhoneService.createMultiple(contactId, contactAddressId, request, user).also { created ->
     created.map {
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
         identifier = it.contactAddressPhoneId,
         secondIdentifier = it.contactAddressId,
         contactId = contactId,
+        user = user,
       )
     }
   }
 
-  fun update(contactId: Long, contactAddressPhoneId: Long, request: UpdateContactAddressPhoneRequest): ContactAddressPhoneDetails = contactAddressPhoneService.update(contactId, contactAddressPhoneId, request).also {
+  fun update(contactId: Long, contactAddressPhoneId: Long, request: UpdateContactAddressPhoneRequest, user: User): ContactAddressPhoneDetails = contactAddressPhoneService.update(contactId, contactAddressPhoneId, request, user).also {
     outboundEventsService.send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED,
       identifier = it.contactAddressPhoneId,
       secondIdentifier = it.contactAddressId,
       contactId = contactId,
+      user = user,
     )
   }
 
-  fun delete(contactId: Long, contactAddressPhoneId: Long) {
+  fun delete(contactId: Long, contactAddressPhoneId: Long, user: User) {
     contactAddressPhoneService.delete(contactId, contactAddressPhoneId).also {
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED,
         identifier = it.contactAddressPhoneId,
         secondIdentifier = it.contactAddressId,
         contactId = contactId,
+        user = user,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/CreateContactAddressPhoneRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/CreateContactAddressPhoneRequest.kt
@@ -19,8 +19,4 @@ data class CreateContactAddressPhoneRequest(
   @Schema(description = "Extension number", example = "123")
   @field:Size(max = 7, message = "extNumber must be <= 7 characters")
   val extNumber: String? = null,
-
-  @Schema(description = "User who created the entry", example = "admin")
-  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
-  val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/CreateMultiplePhoneNumbersRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/CreateMultiplePhoneNumbersRequest.kt
@@ -10,8 +10,4 @@ data class CreateMultiplePhoneNumbersRequest(
   @field:Valid
   @field:Size(min = 1, message = "phoneNumbers must have at least 1 item")
   val phoneNumbers: List<PhoneNumber>,
-
-  @Schema(description = "User who created the entry", example = "admin")
-  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
-  val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/CreatePhoneRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/CreatePhoneRequest.kt
@@ -16,8 +16,4 @@ data class CreatePhoneRequest(
   @Schema(description = "Extension number", example = "123", nullable = true)
   @field:Size(max = 7, message = "extNumber must be <= 7 characters")
   val extNumber: String? = null,
-
-  @Schema(description = "User who created the entry", example = "admin")
-  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
-  val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/UpdateContactAddressPhoneRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/UpdateContactAddressPhoneRequest.kt
@@ -16,8 +16,4 @@ data class UpdateContactAddressPhoneRequest(
   @Schema(description = "Extension number", example = "123")
   @field:Size(max = 7, message = "extNumber must be <= 7 characters")
   val extNumber: String? = null,
-
-  @Schema(description = "The username of the person who made the update", example = "JD000001")
-  @field:Size(max = 100, message = "updatedBy must be <= 100 characters")
-  val updatedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/UpdatePhoneRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/phone/UpdatePhoneRequest.kt
@@ -16,8 +16,4 @@ data class UpdatePhoneRequest(
   @Schema(description = "Extension number", example = "123", nullable = true)
   @field:Size(max = 7, message = "extNumber must be <= 7 characters")
   val extNumber: String? = null,
-
-  @Schema(description = "User who updated the entry", example = "admin")
-  @field:Size(max = 100, message = "updatedBy must be <= 100 characters")
-  val updatedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressPhoneController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressPhoneController.kt
@@ -18,9 +18,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactAddressPhoneFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
@@ -76,8 +78,9 @@ class ContactAddressPhoneController(
     contactAddressId: Long,
     @Valid @RequestBody
     request: CreateContactAddressPhoneRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    val created = contactAddressPhoneFacade.create(contactId, contactAddressId, request)
+    val created = contactAddressPhoneFacade.create(contactId, contactAddressId, request, user)
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(created)
@@ -119,8 +122,9 @@ class ContactAddressPhoneController(
     contactAddressId: Long,
     @Valid @RequestBody
     request: CreateMultiplePhoneNumbersRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    val created = contactAddressPhoneFacade.createMultiple(contactId, contactAddressId, request)
+    val created = contactAddressPhoneFacade.createMultiple(contactId, contactAddressId, request, user)
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(created)
@@ -165,7 +169,8 @@ class ContactAddressPhoneController(
     contactAddressPhoneId: Long,
     @Valid @RequestBody
     request: UpdateContactAddressPhoneRequest,
-  ) = contactAddressPhoneFacade.update(contactId, contactAddressPhoneId, request)
+    @RequestAttribute user: User,
+  ) = contactAddressPhoneFacade.update(contactId, contactAddressPhoneId, request, user)
 
   @GetMapping("/phone/{contactAddressPhoneId}")
   @Operation(summary = "Get an address-specific phone number", description = "Get an address-specific phone number by its ID")
@@ -233,8 +238,9 @@ class ContactAddressPhoneController(
     @PathVariable("contactAddressPhoneId")
     @Parameter(name = "contactAddressPhoneId", description = "The address-specific phone ID", example = "979")
     contactAddressPhoneId: Long,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    contactAddressPhoneFacade.delete(contactId, contactAddressPhoneId)
+    contactAddressPhoneFacade.delete(contactId, contactAddressPhoneId, user)
     return ResponseEntity.noContent().build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneController.kt
@@ -19,9 +19,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactPhoneFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreateMultiplePhoneNumbersRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreatePhoneRequest
@@ -73,8 +75,9 @@ class ContactPhoneController(private val contactPhoneFacade: ContactPhoneFacade)
       example = "123456",
     ) contactId: Long,
     @Valid @RequestBody request: CreatePhoneRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    val createdPhone = contactPhoneFacade.create(contactId, request)
+    val createdPhone = contactPhoneFacade.create(contactId, request, user)
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(createdPhone)
@@ -117,8 +120,9 @@ class ContactPhoneController(private val contactPhoneFacade: ContactPhoneFacade)
       example = "123456",
     ) contactId: Long,
     @Valid @RequestBody request: CreateMultiplePhoneNumbersRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    val createdPhone = contactPhoneFacade.createMultiple(contactId, request)
+    val createdPhone = contactPhoneFacade.createMultiple(contactId, request, user)
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(createdPhone)
@@ -206,8 +210,9 @@ class ContactPhoneController(private val contactPhoneFacade: ContactPhoneFacade)
       example = "987654",
     ) contactPhoneId: Long,
     @Valid @RequestBody request: UpdatePhoneRequest,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    val updatedPhone = contactPhoneFacade.update(contactId, contactPhoneId, request)
+    val updatedPhone = contactPhoneFacade.update(contactId, contactPhoneId, request, user)
     return ResponseEntity.ok(updatedPhone)
   }
 
@@ -247,8 +252,9 @@ class ContactPhoneController(private val contactPhoneFacade: ContactPhoneFacade)
       description = "The id of the contact phone",
       example = "987654",
     ) contactPhoneId: Long,
+    @RequestAttribute user: User,
   ): ResponseEntity<Any> {
-    contactPhoneFacade.delete(contactId, contactPhoneId)
+    contactPhoneFacade.delete(contactId, contactPhoneId, user)
     return ResponseEntity.noContent().build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactAddressPhoneService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactAddressPhoneService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressPhoneEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
@@ -35,21 +36,23 @@ class ContactAddressPhoneService(
     contactId: Long,
     contactAddressId: Long,
     request: CreateContactAddressPhoneRequest,
+    user: User,
   ): ContactAddressPhoneDetails {
     validateContactExists(contactId)
     validateContactAddressExists(contactAddressId)
-    return createAnAddressSpecificPhoneNumber(contactId, contactAddressId, request.phoneType, request.phoneNumber, request.extNumber, request.createdBy)
+    return createAnAddressSpecificPhoneNumber(contactId, contactAddressId, request.phoneType, request.phoneNumber, request.extNumber, user.username)
   }
 
   fun createMultiple(
     contactId: Long,
     contactAddressId: Long,
     request: CreateMultiplePhoneNumbersRequest,
+    user: User,
   ): List<ContactAddressPhoneDetails> {
     validateContactExists(contactId)
     validateContactAddressExists(contactAddressId)
     return request.phoneNumbers.map {
-      createAnAddressSpecificPhoneNumber(contactId, contactAddressId, it.phoneType, it.phoneNumber, it.extNumber, request.createdBy)
+      createAnAddressSpecificPhoneNumber(contactId, contactAddressId, it.phoneType, it.phoneNumber, it.extNumber, user.username)
     }
   }
 
@@ -130,6 +133,7 @@ class ContactAddressPhoneService(
     contactId: Long,
     contactAddressPhoneId: Long,
     request: UpdateContactAddressPhoneRequest,
+    user: User,
   ): ContactAddressPhoneDetails {
     validateContactExists(contactId)
     val existing = validateContactAddressPhoneExists(contactAddressPhoneId)
@@ -142,14 +146,14 @@ class ContactAddressPhoneService(
       phoneType = request.phoneType,
       phoneNumber = request.phoneNumber,
       extNumber = request.extNumber,
-      updatedBy = request.updatedBy,
+      updatedBy = user.username,
       updatedTime = LocalDateTime.now(),
     )
 
     val updatedPhone = contactPhoneRepository.saveAndFlush(updatingPhone)
 
     val updatingContactAddressPhone = existing.copy(
-      updatedBy = request.updatedBy,
+      updatedBy = user.username,
       updatedTime = LocalDateTime.now(),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactPhoneEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.ReferenceCodeGroup
@@ -28,14 +29,14 @@ class ContactPhoneService(
 ) {
 
   @Transactional
-  fun create(contactId: Long, request: CreatePhoneRequest): ContactPhoneDetails {
+  fun create(contactId: Long, request: CreatePhoneRequest, user: User): ContactPhoneDetails {
     validateContactExists(contactId)
     return createANewPhoneNumber(
       contactId,
       request.phoneType,
       request.phoneNumber,
       request.extNumber,
-      request.createdBy,
+      user.username,
     )
   }
 
@@ -83,7 +84,7 @@ class ContactPhoneService(
   fun get(contactId: Long, contactPhoneId: Long): ContactPhoneDetails? = contactPhoneDetailsRepository.findByContactIdAndContactPhoneId(contactId, contactPhoneId)?.toModel()
 
   @Transactional
-  fun update(contactId: Long, contactPhoneId: Long, request: UpdatePhoneRequest): ContactPhoneDetails {
+  fun update(contactId: Long, contactPhoneId: Long, request: UpdatePhoneRequest, user: User): ContactPhoneDetails {
     validateContactExists(contactId)
     val existing = validateExistingPhone(contactPhoneId)
     val type =
@@ -94,7 +95,7 @@ class ContactPhoneService(
       phoneType = request.phoneType,
       phoneNumber = request.phoneNumber,
       extNumber = request.extNumber,
-      updatedBy = request.updatedBy,
+      updatedBy = user.username,
       updatedTime = LocalDateTime.now(),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -315,8 +315,8 @@ data class OutboundHMPPSDomainEvent(
 
 data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
-data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
+data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -56,7 +56,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactPhoneInfo(identifier, source),
+            ContactPhoneInfo(identifier, source, user.username),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }
@@ -67,7 +67,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactAddressPhoneInfo(identifier, secondIdentifier!!, source),
+            ContactAddressPhoneInfo(identifier, secondIdentifier!!, source, user.username),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacadeTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactAddressPhoneDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.updateContactAddressPhoneRequest
@@ -29,25 +30,27 @@ class ContactAddressPhoneFacadeTest {
   private val contactAddressId = 2L
   private val contactPhoneId = 3L
   private val contactAddressPhoneId = 4L
+  private val user = aUser()
 
   @Test
   fun `should send event if create success`() {
     val request = createContactAddressPhoneRequest(contactAddressId)
     val response = createContactAddressPhoneDetails(contactAddressPhoneId, contactAddressId, contactPhoneId, contactId)
 
-    whenever(addressPhoneService.create(any(), any(), any())).thenReturn(response)
+    whenever(addressPhoneService.create(any(), any(), any(), any())).thenReturn(response)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
-    val result = facade.create(contactId, contactAddressId, request)
+    val result = facade.create(contactId, contactAddressId, request, user)
 
     assertThat(result).isEqualTo(response)
-    verify(addressPhoneService).create(contactId, contactAddressId, request)
+    verify(addressPhoneService).create(contactId, contactAddressId, request, user)
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
       identifier = contactAddressPhoneId,
       secondIdentifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
   }
 
@@ -56,16 +59,16 @@ class ContactAddressPhoneFacadeTest {
     val expectedException = RuntimeException("Bang!")
     val request = createContactAddressPhoneRequest(contactAddressId)
 
-    whenever(addressPhoneService.create(any(), any(), any())).thenThrow(expectedException)
+    whenever(addressPhoneService.create(any(), any(), any(), any())).thenThrow(expectedException)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
-      facade.create(contactId, contactAddressId, request)
+      facade.create(contactId, contactAddressId, request, user)
     }
 
     assertThat(exception.message).isEqualTo(expectedException.message)
 
-    verify(addressPhoneService).create(contactId, contactAddressId, request)
+    verify(addressPhoneService).create(contactId, contactAddressId, request, user)
     verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
@@ -84,7 +87,6 @@ class ContactAddressPhoneFacadeTest {
           extNumber = null,
         ),
       ),
-      "USER1",
     )
 
     val response = listOf(
@@ -92,19 +94,20 @@ class ContactAddressPhoneFacadeTest {
       createContactAddressPhoneDetails(8888, contactAddressId, 5555, contactId),
     )
 
-    whenever(addressPhoneService.createMultiple(any(), any(), any())).thenReturn(response)
+    whenever(addressPhoneService.createMultiple(any(), any(), any(), any())).thenReturn(response)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
-    val result = facade.createMultiple(contactId, contactAddressId, request)
+    val result = facade.createMultiple(contactId, contactAddressId, request, user)
 
     assertThat(result).isEqualTo(response)
-    verify(addressPhoneService).createMultiple(contactId, contactAddressId, request)
+    verify(addressPhoneService).createMultiple(contactId, contactAddressId, request, user)
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
       identifier = 9999,
       secondIdentifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
@@ -112,6 +115,7 @@ class ContactAddressPhoneFacadeTest {
       secondIdentifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
   }
 
@@ -120,23 +124,25 @@ class ContactAddressPhoneFacadeTest {
     val response = createContactAddressPhoneDetails(contactAddressPhoneId, contactAddressId, contactPhoneId, contactId)
     val request = updateContactAddressPhoneRequest()
 
-    whenever(addressPhoneService.update(any(), any(), any())).thenReturn(response)
+    whenever(addressPhoneService.update(any(), any(), any(), any())).thenReturn(response)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.update(
       contactId = contactId,
       contactAddressPhoneId = contactAddressPhoneId,
       request = request,
+      user = user,
     )
 
     assertThat(result).isEqualTo(response)
-    verify(addressPhoneService).update(contactId, contactAddressPhoneId, request)
+    verify(addressPhoneService).update(contactId, contactAddressPhoneId, request, user)
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED,
       identifier = contactAddressPhoneId,
       secondIdentifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
   }
 
@@ -145,15 +151,15 @@ class ContactAddressPhoneFacadeTest {
     val expectedException = RuntimeException("Bang!")
     val request = updateContactAddressPhoneRequest()
 
-    whenever(addressPhoneService.update(any(), any(), any())).thenThrow(expectedException)
+    whenever(addressPhoneService.update(any(), any(), any(), any())).thenThrow(expectedException)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
-      facade.update(contactId, contactAddressPhoneId, request)
+      facade.update(contactId, contactAddressPhoneId, request, user)
     }
 
     assertThat(exception).isEqualTo(exception)
-    verify(addressPhoneService).update(contactId, contactAddressPhoneId, request)
+    verify(addressPhoneService).update(contactId, contactAddressPhoneId, request, user)
     verify(eventsService, never()).send(any(), any(), any(), any(), any(), any(), any())
   }
 
@@ -189,7 +195,7 @@ class ContactAddressPhoneFacadeTest {
     whenever(addressPhoneService.delete(any(), any())).thenReturn(response)
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
-    facade.delete(contactId, contactAddressPhoneId)
+    facade.delete(contactId, contactAddressPhoneId, user)
 
     verify(addressPhoneService).delete(contactId, contactAddressPhoneId)
     verify(eventsService).send(
@@ -198,6 +204,7 @@ class ContactAddressPhoneFacadeTest {
       secondIdentifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
+      user = user,
     )
   }
 
@@ -208,7 +215,7 @@ class ContactAddressPhoneFacadeTest {
     whenever(eventsService.send(any(), any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
-      facade.delete(contactId, contactAddressPhoneId)
+      facade.delete(contactId, contactAddressPhoneId, user)
     }
 
     assertThat(exception.message).isEqualTo(expectedException.message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
@@ -575,25 +575,21 @@ fun createContactAddressPhoneRequest(
   phoneType: String = "HOME",
   phoneNumber: String = "0876 878787",
   extNumber: String? = null,
-  createdBy: String = "CREATE_USER",
 ) = CreateContactAddressPhoneRequest(
   contactAddressId = contactAddressId,
   phoneType = phoneType,
   phoneNumber = phoneNumber,
   extNumber = extNumber,
-  createdBy = createdBy,
 )
 
 fun updateContactAddressPhoneRequest(
   phoneType: String = "HOME",
   phoneNumber: String = "0878 7666565",
   extNumber: String? = null,
-  updatedBy: String = "AMEND_USER",
 ) = UpdateContactAddressPhoneRequest(
   phoneType = phoneType,
   phoneNumber = phoneNumber,
   extNumber = extNumber,
-  updatedBy = updatedBy,
 )
 
 fun createContactAddressPhoneDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
@@ -185,7 +185,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
     created.phoneNumberIds.map {
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
-        additionalInfo = ContactAddressPhoneInfo(it, created.contactAddressId, Source.DPS),
+        additionalInfo = ContactAddressPhoneInfo(it, created.contactAddressId, Source.DPS, "created"),
         personReference = PersonReference(dpsContactId = created.contactId),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
@@ -30,7 +30,7 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
   @BeforeEach
   fun initialiseData() {
-    setCurrentUser(StubUser.READ_WRITE_USER)
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address-phone",
@@ -171,7 +171,7 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
-      additionalInfo = ContactAddressPhoneInfo(created.contactAddressPhoneId, created.contactAddressId, Source.DPS),
+      additionalInfo = ContactAddressPhoneInfo(created.contactAddressPhoneId, created.contactAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -188,7 +188,7 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
       assertThat(phoneType).isEqualTo(request.phoneType)
       assertThat(phoneNumber).isEqualTo(request.phoneNumber)
       assertThat(extNumber).isEqualTo(request.extNumber)
-      assertThat(createdBy).isEqualTo(request.createdBy)
+      assertThat(createdBy).isEqualTo("created")
       assertThat(createdTime).isNotNull()
     }
   }
@@ -202,10 +202,6 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
         "extNumber must be <= 7 characters",
         aMinimalRequest().copy(extNumber = "".padStart(8, 'X')),
       ),
-      Arguments.of(
-        "createdBy must be <= 100 characters",
-        aMinimalRequest().copy(createdBy = "".padStart(101, 'X')),
-      ),
     )
 
     private fun aMinimalRequest() = CreateContactAddressPhoneRequest(
@@ -213,7 +209,6 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
       phoneType = "HOME",
       phoneNumber = "123456789",
       extNumber = "111",
-      createdBy = "CREATED",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -369,6 +369,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
         everythingCreated.phoneNumbers[0].contactAddressPhoneId,
         everythingCreated.contactAddressId,
         Source.DPS,
+        "created",
       ),
       personReference = PersonReference(dpsContactId = contactId),
     )
@@ -451,13 +452,13 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(minimalCreated.contactPhoneId, Source.DPS),
+      additionalInfo = ContactPhoneInfo(minimalCreated.contactPhoneId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(everythingCreated.contactPhoneId, Source.DPS),
+      additionalInfo = ContactPhoneInfo(everythingCreated.contactPhoneId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
@@ -30,7 +30,7 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
 
   @BeforeEach
   fun initialiseData() {
-    setCurrentUser(StubUser.READ_WRITE_USER)
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "phone",
@@ -60,12 +60,10 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
   @ParameterizedTest
   @CsvSource(
     value = [
-      "phoneNumbers[0].phoneType must not be null;{\"phoneNumbers\": [{ \"phoneType\": null, \"phoneNumber\": \"0123456789\"}], \"createdBy\": \"created\"}",
-      "phoneNumbers[0].phoneType must not be null;{\"phoneNumbers\": [{\"phoneNumber\": \"0123456789\"}], \"createdBy\": \"created\"}",
-      "phoneNumbers[0].phoneNumber must not be null;{\"phoneNumbers\": [{\"phoneType\": \"MOB\", \"phoneNumber\": null}], \"createdBy\": \"created\"}",
-      "phoneNumbers[0].phoneNumber must not be null;{\"phoneNumbers\": [{\"phoneType\": \"MOB\"}], \"createdBy\": \"created\"}",
-      "createdBy must not be null;{\"phoneNumbers\": [{\"phoneType\": \"MOB\", \"phoneNumber\": \"0123456789\"}], \"createdBy\": null}",
-      "createdBy must not be null;{\"phoneNumbers\": [{\"phoneType\": \"MOB\", \"phoneNumber\": \"0123456789\"}]}",
+      "phoneNumbers[0].phoneType must not be null;{\"phoneNumbers\": [{ \"phoneType\": null, \"phoneNumber\": \"0123456789\"}]}",
+      "phoneNumbers[0].phoneType must not be null;{\"phoneNumbers\": [{\"phoneNumber\": \"0123456789\"}]}",
+      "phoneNumbers[0].phoneNumber must not be null;{\"phoneNumbers\": [{\"phoneType\": \"MOB\", \"phoneNumber\": null}]}",
+      "phoneNumbers[0].phoneNumber must not be null;{\"phoneNumbers\": [{\"phoneType\": \"MOB\"}]}",
     ],
     delimiter = ';',
   )
@@ -124,7 +122,6 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
           phoneNumber = phoneNumber,
         ),
       ),
-      createdBy = "created",
     )
 
     val errors = webTestClient.post()
@@ -155,7 +152,6 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
           phoneNumber = "+44777777777 (0123)",
         ),
       ),
-      createdBy = "created",
     )
 
     val errors = webTestClient.post()
@@ -238,7 +234,6 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
           extNumber = null,
         ),
       ),
-      createdBy = "created",
     )
 
     val created = testAPIClient.createMultipleContactAddressPhones(savedContactId, savedAddressId, request, role)
@@ -247,7 +242,7 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
     assertThat(mobile).isNotNull()
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
-      additionalInfo = ContactAddressPhoneInfo(mobile!!.contactAddressPhoneId, savedAddressId, Source.DPS),
+      additionalInfo = ContactAddressPhoneInfo(mobile!!.contactAddressPhoneId, savedAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
 
@@ -255,7 +250,7 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
     assertThat(home).isNotNull()
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
-      additionalInfo = ContactAddressPhoneInfo(home!!.contactAddressPhoneId, savedAddressId, Source.DPS),
+      additionalInfo = ContactAddressPhoneInfo(home!!.contactAddressPhoneId, savedAddressId, Source.DPS, "created"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -298,7 +293,6 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
         ),
       ),
       Arguments.of("phoneNumbers must have at least 1 item", aMinimalRequest().copy(phoneNumbers = emptyList())),
-      Arguments.of("createdBy must be <= 100 characters", aMinimalRequest().copy(createdBy = "".padStart(101, 'X'))),
     )
 
     private fun aMinimalRequest() = CreateMultiplePhoneNumbersRequest(
@@ -308,7 +302,6 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
           phoneNumber = "+44777777777 (0123)",
         ),
       ),
-      createdBy = "created",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
@@ -27,7 +27,7 @@ class DeleteContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
   @BeforeEach
   fun initialiseData() {
-    setCurrentUser(StubUser.READ_WRITE_USER)
+    setCurrentUser(StubUser.CREATING_USER)
     savedContactId = testAPIClient.createAContact(
       CreateContactRequest(
         lastName = "address-phone",
@@ -54,9 +54,9 @@ class DeleteContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
         phoneType = "HOME",
         phoneNumber = "123456",
         extNumber = "2",
-        createdBy = "CREATED",
       ),
     ).contactAddressPhoneId
+    setCurrentUser(StubUser.DELETING_USER)
   }
 
   override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.delete()
@@ -119,7 +119,7 @@ class DeleteContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED,
-      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId, Source.DPS),
+      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId, Source.DPS, "deleted"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactAddressPhoneIntegrationTest.kt
@@ -54,7 +54,6 @@ class GetContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
           phoneType = "HOME",
           phoneNumber = "123456",
           extNumber = "2",
-          createdBy = "CREATED",
         ),
 
       ).contactAddressPhoneId
@@ -102,7 +101,7 @@ class GetContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
       assertThat(contactId).isEqualTo(savedContactId)
       assertThat(phoneNumber).isEqualTo("123456")
       assertThat(extNumber).isEqualTo("2")
-      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(createdBy).isEqualTo("read_write_user")
       assertThat(createdTime).isBefore(LocalDateTime.now())
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactPhoneIntegrationTest.kt
@@ -67,10 +67,11 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
   @ParameterizedTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
   fun `Sync endpoints should return forbidden without an authorised role on the token`(role: String) {
+    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER.copy(roles = listOf(role)))
     webTestClient.get()
       .uri("/sync/contact-phone/1")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -80,7 +81,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(createContactPhoneRequest(savedContactId))
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -90,7 +91,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(updateContactPhoneRequest(savedContactId))
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -98,7 +99,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
     webTestClient.delete()
       .uri("/sync/contact-phone/1")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf(role)))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isForbidden
@@ -111,7 +112,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
     val contactPhone = webTestClient.get()
       .uri("/sync/contact-phone/{contactPhoneId}", contactPhoneId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isOk
@@ -131,7 +132,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-phone")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(createContactPhoneRequest(savedContactId))
       .exchange()
       .expectStatus()
@@ -152,7 +153,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS),
+      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS, "SYS"),
       personReference = PersonReference(dpsContactId = contactPhone.contactId),
     )
   }
@@ -163,7 +164,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-phone")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(createContactPhoneRequest(savedContactId))
       .exchange()
       .expectStatus()
@@ -184,7 +185,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
       .uri("/sync/contact-phone/{contactPhoneId}", contactPhone.contactPhoneId)
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .bodyValue(updateContactPhoneRequest(savedContactId))
       .exchange()
       .expectStatus()
@@ -206,7 +207,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_UPDATED,
-      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS),
+      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS, "SYS"),
       personReference = PersonReference(dpsContactId = contactPhone.contactId),
     )
   }
@@ -218,7 +219,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
     webTestClient.delete()
       .uri("/sync/contact-phone/{contactPhoneId}", contactPhoneId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isOk
@@ -226,13 +227,13 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
     webTestClient.get()
       .uri("/sync/contact-phone/{contactPhoneId}", contactPhoneId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("PERSONAL_RELATIONSHIPS_MIGRATION")))
+      .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_DELETED,
-      additionalInfo = ContactPhoneInfo(contactPhoneId, Source.NOMIS),
+      additionalInfo = ContactPhoneInfo(contactPhoneId, Source.NOMIS, "SYS"),
       personReference = PersonReference(dpsContactId = 10),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneControllerTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactPhoneFacade
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactPhoneNumberDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.phone.UpdatePhoneRequest
@@ -20,6 +21,7 @@ class ContactPhoneControllerTest {
 
   private val facade: ContactPhoneFacade = mock()
   private val controller = ContactPhoneController(facade)
+  private val user = aUser()
 
   @Nested
   inner class CreateContactPhone {
@@ -30,15 +32,14 @@ class ContactPhoneControllerTest {
         "MOB",
         "+07777777777",
         null,
-        "JAMES",
       )
-      whenever(facade.create(1, request)).thenReturn(createdPhone)
+      whenever(facade.create(1, request, user)).thenReturn(createdPhone)
 
-      val response = controller.createPhone(1, request)
+      val response = controller.createPhone(1, request, user)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
       assertThat(response.body).isEqualTo(createdPhone)
-      verify(facade).create(1, request)
+      verify(facade).create(1, request, user)
     }
 
     @Test
@@ -47,17 +48,16 @@ class ContactPhoneControllerTest {
         "MOB",
         "+07777777777",
         null,
-        "JAMES",
       )
       val expected = EntityNotFoundException("Couldn't find contact")
-      whenever(facade.create(1, request)).thenThrow(expected)
+      whenever(facade.create(1, request, user)).thenThrow(expected)
 
       val exception = assertThrows<EntityNotFoundException> {
-        controller.createPhone(1, request)
+        controller.createPhone(1, request, user)
       }
 
       assertThat(exception).isEqualTo(expected)
-      verify(facade).create(1, request)
+      verify(facade).create(1, request, user)
     }
   }
 
@@ -104,15 +104,14 @@ class ContactPhoneControllerTest {
         "MOB",
         "+07777777777",
         null,
-        "JAMES",
       )
-      whenever(facade.update(1, 2, request)).thenReturn(updatedPhone)
+      whenever(facade.update(1, 2, request, user)).thenReturn(updatedPhone)
 
-      val response = controller.updatePhone(1, 2, request)
+      val response = controller.updatePhone(1, 2, request, user)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
       assertThat(response.body).isEqualTo(updatedPhone)
-      verify(facade).update(1, 2, request)
+      verify(facade).update(1, 2, request, user)
     }
 
     @Test
@@ -121,17 +120,16 @@ class ContactPhoneControllerTest {
         "MOB",
         "+07777777777",
         null,
-        "JAMES",
       )
       val expected = EntityNotFoundException("Couldn't find contact")
-      whenever(facade.update(1, 2, request)).thenThrow(expected)
+      whenever(facade.update(1, 2, request, user)).thenThrow(expected)
 
       val exception = assertThrows<EntityNotFoundException> {
-        controller.updatePhone(1, 2, request)
+        controller.updatePhone(1, 2, request, user)
       }
 
       assertThat(exception).isEqualTo(expected)
-      verify(facade).update(1, 2, request)
+      verify(facade).update(1, 2, request, user)
     }
   }
 
@@ -139,25 +137,25 @@ class ContactPhoneControllerTest {
   inner class DeleteContactPhone {
     @Test
     fun `should return 204 if deleted successfully`() {
-      whenever(facade.delete(1, 2)).then { }
+      whenever(facade.delete(1, 2, user)).then { }
 
-      val response = controller.deletePhone(1, 2)
+      val response = controller.deletePhone(1, 2, user)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
-      verify(facade).delete(1, 2)
+      verify(facade).delete(1, 2, user)
     }
 
     @Test
     fun `should propagate exceptions if delete fails`() {
       val expected = EntityNotFoundException("Couldn't find contact")
-      whenever(facade.delete(1, 2)).thenThrow(expected)
+      whenever(facade.delete(1, 2, user)).thenThrow(expected)
 
       val exception = assertThrows<EntityNotFoundException> {
-        controller.deletePhone(1, 2)
+        controller.deletePhone(1, 2, user)
       }
 
       assertThat(exception).isEqualTo(expected)
-      verify(facade).delete(1, 2)
+      verify(facade).delete(1, 2, user)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
@@ -136,10 +136,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact phone created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_PHONE_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_CREATED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_CREATED, 1L, 1L, user = aUser("phone"))
     verify(
       expectedEventType = "contacts-api.contact-phone.created",
-      expectedAdditionalInformation = ContactPhoneInfo(contactPhoneId = 1L, source = Source.DPS),
+      expectedAdditionalInformation = ContactPhoneInfo(contactPhoneId = 1L, source = Source.DPS, username = "phone"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact phone number has been created",
     )
@@ -148,10 +148,10 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact phone updated event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_PHONE_UPDATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_UPDATED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_UPDATED, 1L, 1L, user = aUser("phone"))
     verify(
       expectedEventType = "contacts-api.contact-phone.updated",
-      expectedAdditionalInformation = ContactPhoneInfo(contactPhoneId = 1, source = Source.DPS),
+      expectedAdditionalInformation = ContactPhoneInfo(contactPhoneId = 1, source = Source.DPS, username = "phone"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact phone number has been updated",
     )
@@ -160,12 +160,48 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact phone deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_PHONE_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_DELETED, 1L, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_DELETED, 1L, 1L, user = aUser("phone"))
     verify(
       expectedEventType = "contacts-api.contact-phone.deleted",
-      expectedAdditionalInformation = ContactPhoneInfo(contactPhoneId = 1, source = Source.DPS),
+      expectedAdditionalInformation = ContactPhoneInfo(contactPhoneId = 1, source = Source.DPS, username = "phone"),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact phone number has been deleted",
+    )
+  }
+
+  @Test
+  fun `contact address phone created event with id 1 is sent to the events publisher`() {
+    featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED) } doReturn true }
+    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED, 1L, 1L, secondIdentifier = 99L, user = aUser("phone"))
+    verify(
+      expectedEventType = "contacts-api.contact-address-phone.created",
+      expectedAdditionalInformation = ContactAddressPhoneInfo(contactAddressPhoneId = 1L, contactAddressId = 99L, source = Source.DPS, username = "phone"),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
+      expectedDescription = "A contact address phone number has been created",
+    )
+  }
+
+  @Test
+  fun `contact address phone updated event with id 1 is sent to the events publisher`() {
+    featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED) } doReturn true }
+    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, 1L, 1L, secondIdentifier = 99L, user = aUser("phone"))
+    verify(
+      expectedEventType = "contacts-api.contact-address-phone.updated",
+      expectedAdditionalInformation = ContactAddressPhoneInfo(contactAddressPhoneId = 1, contactAddressId = 99L, source = Source.DPS, username = "phone"),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
+      expectedDescription = "A contact address phone number has been updated",
+    )
+  }
+
+  @Test
+  fun `contact address phone deleted event with id 1 is sent to the events publisher`() {
+    featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED) } doReturn true }
+    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED, 1L, 1L, secondIdentifier = 99L, user = aUser("phone"))
+    verify(
+      expectedEventType = "contacts-api.contact-address-phone.deleted",
+      expectedAdditionalInformation = ContactAddressPhoneInfo(contactAddressPhoneId = 1, contactAddressId = 99L, source = Source.DPS, username = "phone"),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
+      expectedDescription = "A contact address phone number has been deleted",
     )
   }
 


### PR DESCRIPTION
Use username from the token rather than created/updated by.  Also add username to events.