### PR TITLE
PRC-651: Use username from token for domestic status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerDomesticStatusFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerDomesticStatusFacade.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerDomesticStatusRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerDomesticStatusResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.PrisonerDomesticStatusService
@@ -18,13 +19,15 @@ class PrisonerDomesticStatusFacade(
   fun createOrUpdateDomesticStatus(
     prisonerNumber: String,
     request: CreateOrUpdatePrisonerDomesticStatusRequest,
-  ): PrisonerDomesticStatusResponse = prisonerDomesticStatusService.createOrUpdateDomesticStatus(prisonerNumber, request)
+    user: User,
+  ): PrisonerDomesticStatusResponse = prisonerDomesticStatusService.createOrUpdateDomesticStatus(prisonerNumber, request, user)
     .also {
       outboundEventsService.send(
         outboundEvent = OutboundEvent.PRISONER_DOMESTIC_STATUS_CREATED,
         identifier = it.id,
         noms = prisonerNumber,
         source = Source.DPS,
+        user = user,
       )
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateOrUpdatePrisonerDomesticStatusRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateOrUpdatePrisonerDomesticStatusRequest.kt
@@ -9,8 +9,4 @@ data class CreateOrUpdatePrisonerDomesticStatusRequest(
   @Schema(description = "The domestic status code for DOMESTIC_STS group code", example = "M")
   @field:Size(max = 12, message = "domesticStatusCode must be less than or equal to 12 characters")
   val domesticStatusCode: String?,
-
-  @Schema(description = "User who requesting to create or update", example = "admin")
-  @field:Size(max = 100, message = "requestedBy must be <= 100 characters")
-  val requestedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerDomesticStatusController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerDomesticStatusController.kt
@@ -12,9 +12,11 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.PrisonerDomesticStatusFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerDomesticStatusRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerDomesticStatusResponse
@@ -95,5 +97,6 @@ class PrisonerDomesticStatusController(
   fun createOrUpdateDomesticStatus(
     @PathVariable prisonerNumber: String,
     @Valid @RequestBody request: CreateOrUpdatePrisonerDomesticStatusRequest,
-  ): PrisonerDomesticStatusResponse = prisonerDomesticStatusFacade.createOrUpdateDomesticStatus(prisonerNumber, request)
+    @RequestAttribute user: User,
+  ): PrisonerDomesticStatusResponse = prisonerDomesticStatusFacade.createOrUpdateDomesticStatus(prisonerNumber, request, user)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerDomesticStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerDomesticStatusService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerDomesticStatus
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.ReferenceCodeGroup
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerDomesticStatusRequest
@@ -32,6 +33,7 @@ class PrisonerDomesticStatusService(
   fun createOrUpdateDomesticStatus(
     prisonerNumber: String,
     request: CreateOrUpdatePrisonerDomesticStatusRequest,
+    user: User,
   ): PrisonerDomesticStatusResponse {
     prisonerService.getPrisoner(prisonerNumber)
       ?: throw EntityNotFoundException("Prisoner number $prisonerNumber - not found")
@@ -49,7 +51,7 @@ class PrisonerDomesticStatusService(
     val newDomesticStatus = PrisonerDomesticStatus(
       prisonerNumber = prisonerNumber,
       domesticStatusCode = request.domesticStatusCode,
-      createdBy = request.requestedBy,
+      createdBy = user.username,
       createdTime = LocalDateTime.now(),
       active = true,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -323,7 +323,7 @@ data class ContactRestrictionInfo(val contactRestrictionId: Long, override val s
 data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class EmploymentInfo(val employmentId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class PrisonerDomesticStatus(val domesticStatusId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class PrisonerDomesticStatus(val domesticStatusId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 data class PrisonerNumberOfChildren(val prisonerNumberOfChildrenId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
 
 /**
@@ -380,6 +380,8 @@ class PersonReference(personIdentifiers: List<PersonIdentifier>) {
 
     return identifiers == other.identifiers
   }
+
+  override fun hashCode(): Int = identifiers.hashCode()
 
   override fun toString(): String = this.identifiers.toString()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -143,7 +143,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            PrisonerDomesticStatus(identifier, source),
+            PrisonerDomesticStatus(identifier, source, user.username),
             PersonReference(noms),
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/PrisonerMergeControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/PrisonerMergeControllerIntegrationTest.kt
@@ -174,7 +174,7 @@ class PrisonerMergeControllerIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_DOMESTIC_STATUS_CREATED,
-      additionalInfo = PrisonerDomesticStatus(retainedDomesticStatus.id, Source.DPS),
+      additionalInfo = PrisonerDomesticStatus(retainedDomesticStatus.id, Source.DPS, "SYS"),
       personReference = PersonReference(nomsNumber = KEEP_PRISONER),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerDomesticStatusControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerDomesticStatusControllerTest.kt
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.PrisonerDomesticStatusFacade
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateOrUpdatePrisonerDomesticStatusRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerDomesticStatusResponse
 @ExtendWith(MockitoExtension::class)
@@ -22,6 +23,8 @@ class PrisonerDomesticStatusControllerTest {
 
   @InjectMocks
   private lateinit var controller: PrisonerDomesticStatusController
+
+  private val user = aUser("test-user")
 
   @Nested
   inner class GetDomesticStatus {
@@ -61,14 +64,12 @@ class PrisonerDomesticStatusControllerTest {
 
   @Nested
   inner class CreateOrUpdateDomesticStatus {
-
     @Test
     fun `should create or update domestic status successfully`() {
       // Given
       val prisonerNumber = "A1234BC"
       val request = CreateOrUpdatePrisonerDomesticStatusRequest(
         domesticStatusCode = "MARRIED",
-        requestedBy = "test-user",
       )
       val expectedResponse = PrisonerDomesticStatusResponse(
         id = 1L,
@@ -76,15 +77,15 @@ class PrisonerDomesticStatusControllerTest {
         active = true,
       )
       whenever(
-        prisonerDomesticStatusFacade.createOrUpdateDomesticStatus(prisonerNumber, request),
+        prisonerDomesticStatusFacade.createOrUpdateDomesticStatus(prisonerNumber, request, user),
       ).thenReturn(expectedResponse)
 
       // When
-      val result = controller.createOrUpdateDomesticStatus(prisonerNumber, request)
+      val result = controller.createOrUpdateDomesticStatus(prisonerNumber, request, user)
 
       // Then
       assertThat(result).isEqualTo(expectedResponse)
-      verify(prisonerDomesticStatusFacade).createOrUpdateDomesticStatus(prisonerNumber, request)
+      verify(prisonerDomesticStatusFacade).createOrUpdateDomesticStatus(prisonerNumber, request, user)
     }
 
     @Test
@@ -93,17 +94,16 @@ class PrisonerDomesticStatusControllerTest {
       val prisonerNumber = "A1234BC"
       val request = CreateOrUpdatePrisonerDomesticStatusRequest(
         domesticStatusCode = "MARRIED",
-        requestedBy = "test-user",
       )
       whenever(
-        prisonerDomesticStatusFacade.createOrUpdateDomesticStatus(prisonerNumber, request),
+        prisonerDomesticStatusFacade.createOrUpdateDomesticStatus(prisonerNumber, request, user),
       ).thenThrow(EntityNotFoundException("Prisoner not found"))
 
       // When/Then
       assertThrows<EntityNotFoundException> {
-        controller.createOrUpdateDomesticStatus(prisonerNumber, request)
+        controller.createOrUpdateDomesticStatus(prisonerNumber, request, user)
       }
-      verify(prisonerDomesticStatusFacade).createOrUpdateDomesticStatus(prisonerNumber, request)
+      verify(prisonerDomesticStatusFacade).createOrUpdateDomesticStatus(prisonerNumber, request, user)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerDomesticStatusServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerDomesticStatusServiceTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerDomesticStatus
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ReferenceCodeEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.prisoner
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.ReferenceCodeGroup
@@ -40,6 +41,8 @@ class PrisonerDomesticStatusServiceTest {
   private lateinit var prisonerDomesticStatusService: PrisonerDomesticStatusService
 
   private val prisonerNumber = "A1234BC"
+
+  private val user = aUser("test-user")
 
   @Nested
   inner class GetDomesticStatusByPrisonerNumber {
@@ -101,7 +104,6 @@ class PrisonerDomesticStatusServiceTest {
       // Given
       val request = CreateOrUpdatePrisonerDomesticStatusRequest(
         domesticStatusCode = "S",
-        requestedBy = "USER1",
       )
 
       whenever(prisonerDomesticStatusRepository.findByPrisonerNumberAndActiveTrue(prisonerNumber))
@@ -130,6 +132,7 @@ class PrisonerDomesticStatusServiceTest {
       val result = prisonerDomesticStatusService.createOrUpdateDomesticStatus(
         prisonerNumber,
         request,
+        user,
       )
 
       // Then
@@ -147,7 +150,6 @@ class PrisonerDomesticStatusServiceTest {
       // Given
       val request = CreateOrUpdatePrisonerDomesticStatusRequest(
         domesticStatusCode = null,
-        requestedBy = "USER1",
       )
       whenever(prisonerService.getPrisoner(any())).thenReturn(prisoner("A1234BC", prisonId = "MDI"))
       whenever(prisonerDomesticStatusRepository.findByPrisonerNumberAndActiveTrue(prisonerNumber))
@@ -169,6 +171,7 @@ class PrisonerDomesticStatusServiceTest {
       val result = prisonerDomesticStatusService.createOrUpdateDomesticStatus(
         prisonerNumber,
         request,
+        user,
       )
 
       // Then
@@ -196,7 +199,6 @@ class PrisonerDomesticStatusServiceTest {
 
       val request = CreateOrUpdatePrisonerDomesticStatusRequest(
         domesticStatusCode = "D",
-        requestedBy = "USER1",
       )
       whenever(prisonerService.getPrisoner(any())).thenReturn(prisoner("A1234BC", prisonId = "MDI"))
       whenever(prisonerDomesticStatusRepository.findByPrisonerNumberAndActiveTrue(prisonerNumber))
@@ -217,6 +219,7 @@ class PrisonerDomesticStatusServiceTest {
       val result = prisonerDomesticStatusService.createOrUpdateDomesticStatus(
         prisonerNumber,
         request,
+        user,
       )
 
       val statusCaptor = argumentCaptor<PrisonerDomesticStatus>()
@@ -242,7 +245,6 @@ class PrisonerDomesticStatusServiceTest {
       // Given
       val request = CreateOrUpdatePrisonerDomesticStatusRequest(
         domesticStatusCode = "M",
-        requestedBy = "test-user",
       )
       whenever(prisonerService.getPrisoner(any())).thenReturn(prisoner("A1234BC", prisonId = "MDI"))
       whenever(
@@ -257,6 +259,7 @@ class PrisonerDomesticStatusServiceTest {
         prisonerDomesticStatusService.createOrUpdateDomesticStatus(
           prisonerNumber,
           request,
+          user,
         )
       }.message isEqualTo "No reference data found for groupCode: DOMESTIC_STS and code: M"
     }
@@ -266,7 +269,6 @@ class PrisonerDomesticStatusServiceTest {
       // Given
       val request = CreateOrUpdatePrisonerDomesticStatusRequest(
         domesticStatusCode = "M",
-        requestedBy = "test-user",
       )
       whenever(prisonerService.getPrisoner(any())).thenReturn(null)
 
@@ -275,6 +277,7 @@ class PrisonerDomesticStatusServiceTest {
         prisonerDomesticStatusService.createOrUpdateDomesticStatus(
           prisonerNumber,
           request,
+          user,
         )
       }.message isEqualTo "Prisoner number $prisonerNumber - not found"
     }


### PR DESCRIPTION
Use username from the token rather than requested by.  Also add username to events.