### PR TITLE
PRC-651: Ensure user set on all events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.MergePrisonerContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.ResetPrisonerContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreateContactAddressPhoneRequest
@@ -89,6 +90,7 @@ class SyncFacade(
         identifier = it.id,
         contactId = it.id,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -99,6 +101,7 @@ class SyncFacade(
         identifier = it.id,
         contactId = it.id,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -109,6 +112,7 @@ class SyncFacade(
         identifier = contactId,
         contactId = contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -127,6 +131,7 @@ class SyncFacade(
         identifier = it.contactPhoneId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -137,6 +142,7 @@ class SyncFacade(
         identifier = it.contactPhoneId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -147,6 +153,7 @@ class SyncFacade(
         identifier = contactPhoneId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -163,6 +170,7 @@ class SyncFacade(
         identifier = it.contactEmailId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -173,6 +181,7 @@ class SyncFacade(
         identifier = it.contactEmailId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -183,6 +192,7 @@ class SyncFacade(
         identifier = it.contactEmailId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -199,6 +209,7 @@ class SyncFacade(
         identifier = it.contactIdentityId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -209,6 +220,7 @@ class SyncFacade(
         identifier = it.contactIdentityId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -219,6 +231,7 @@ class SyncFacade(
         identifier = it.contactIdentityId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -235,6 +248,7 @@ class SyncFacade(
         identifier = it.contactRestrictionId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -245,6 +259,7 @@ class SyncFacade(
         identifier = it.contactRestrictionId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -255,6 +270,7 @@ class SyncFacade(
         identifier = it.contactRestrictionId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -271,6 +287,7 @@ class SyncFacade(
         identifier = it.contactAddressId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -281,6 +298,7 @@ class SyncFacade(
         identifier = it.contactAddressId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -291,6 +309,7 @@ class SyncFacade(
         identifier = it.contactAddressId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -307,6 +326,7 @@ class SyncFacade(
         contactId = it.contactId,
         source = Source.NOMIS,
         secondIdentifier = it.contactAddressId,
+        user = User.SYS_USER,
       )
     }
 
@@ -318,6 +338,7 @@ class SyncFacade(
         contactId = it.contactId,
         source = Source.NOMIS,
         secondIdentifier = it.contactAddressId,
+        user = User.SYS_USER,
       )
     }
 
@@ -329,6 +350,7 @@ class SyncFacade(
         contactId = it.contactId,
         source = Source.NOMIS,
         secondIdentifier = it.contactAddressId,
+        user = User.SYS_USER,
       )
     }
 
@@ -346,6 +368,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -357,6 +380,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -368,6 +392,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -385,6 +410,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -396,6 +422,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -407,6 +434,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -423,6 +451,7 @@ class SyncFacade(
         identifier = it.employmentId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -433,6 +462,7 @@ class SyncFacade(
         identifier = it.employmentId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -443,6 +473,7 @@ class SyncFacade(
         identifier = it.employmentId,
         contactId = it.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -490,6 +521,7 @@ class SyncFacade(
         contactId = removed.contactId,
         noms = removed.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -499,6 +531,7 @@ class SyncFacade(
       contactId = removed.contactId,
       noms = removed.prisonerNumber,
       source = Source.NOMIS,
+      user = User.SYS_USER,
     )
   }
 
@@ -513,6 +546,7 @@ class SyncFacade(
         contactId = created.contactId,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -522,6 +556,7 @@ class SyncFacade(
       contactId = created.contactId,
       noms = prisonerNumber,
       source = Source.NOMIS,
+      user = User.SYS_USER,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerDomesticStatusSyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerDomesticStatusSyncFacade.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.sync
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdatePrisonerDomesticStatusRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.Status
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPrisonerDomesticStatusResponse
@@ -68,6 +69,7 @@ class PrisonerDomesticStatusSyncFacade(
       identifier = identifier,
       noms = prisonerNumber,
       source = Source.NOMIS,
+      user = User.SYS_USER,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerMergeFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerMergeFacade.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.sync
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
@@ -24,6 +25,7 @@ class PrisonerMergeFacade(
             identifier = it.id,
             noms = keepingPrisonerNumber,
             source = Source.DPS,
+            user = User.SYS_USER,
           )
         }
       }
@@ -36,6 +38,7 @@ class PrisonerMergeFacade(
             identifier = it.id,
             noms = keepingPrisonerNumber,
             source = Source.DPS,
+            user = User.SYS_USER,
           )
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerNumberOfChildrenSyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerNumberOfChildrenSyncFacade.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.sync
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdatePrisonerNumberOfChildrenRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.Status
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPrisonerNumberOfChildrenData
@@ -67,6 +68,7 @@ class PrisonerNumberOfChildrenSyncFacade(
       identifier = identifier,
       noms = prisonerNumber,
       source = Source.NOMIS,
+      user = User.SYS_USER,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -293,7 +293,7 @@ enum class OutboundEvent(val eventType: String) {
  * This is inherited and expanded individually for each event type.
  */
 
-open class AdditionalInformation(open val source: Source)
+open class AdditionalInformation(open val source: Source, open val username: String)
 
 /**
  * The class representing outbound domain events
@@ -313,18 +313,18 @@ data class OutboundHMPPSDomainEvent(
  * The additional information is mapped into JSON by the ObjectMapper as part of the event body.
  */
 
-data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class EmploymentInfo(val employmentId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class PrisonerDomesticStatus(val domesticStatusId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
-data class PrisonerNumberOfChildren(val prisonerNumberOfChildrenId: Long, override val source: Source = Source.DPS, val username: String) : AdditionalInformation(source)
+data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class EmploymentInfo(val employmentId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class PrisonerDomesticStatus(val domesticStatusId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class PrisonerNumberOfChildren(val prisonerNumberOfChildrenId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
 
 /**
  * The event source.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -22,7 +22,7 @@ class OutboundEventsService(
     noms: String = "",
     source: Source = Source.DPS,
     secondIdentifier: Long? = 0,
-    user: User = User.SYS_USER,
+    user: User,
   ) {
     if (featureSwitches.isEnabled(outboundEvent)) {
       log.info("Sending outbound event $outboundEvent with source $source for identifier $identifier (contactId $contactId, noms $noms, secondIdentifier ${secondIdentifier ?: "N/A"})")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreateContactEmailRequest
@@ -108,6 +109,7 @@ class SyncFacadeTest {
         identifier = result.id,
         contactId = result.id,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -148,6 +150,7 @@ class SyncFacadeTest {
         identifier = result.id,
         contactId = result.id,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -183,6 +186,7 @@ class SyncFacadeTest {
         identifier = 1L,
         contactId = 1L,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -246,6 +250,7 @@ class SyncFacadeTest {
         identifier = result.contactPhoneId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -265,6 +270,7 @@ class SyncFacadeTest {
         identifier = result.contactPhoneId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -284,6 +290,7 @@ class SyncFacadeTest {
         identifier = result.contactPhoneId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -333,6 +340,7 @@ class SyncFacadeTest {
         identifier = result.contactEmailId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -352,6 +360,7 @@ class SyncFacadeTest {
         identifier = result.contactEmailId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -371,6 +380,7 @@ class SyncFacadeTest {
         identifier = result.contactEmailId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -416,6 +426,7 @@ class SyncFacadeTest {
         identifier = result.contactIdentityId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -435,6 +446,7 @@ class SyncFacadeTest {
         identifier = result.contactIdentityId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -454,6 +466,7 @@ class SyncFacadeTest {
         identifier = result.contactIdentityId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -505,6 +518,7 @@ class SyncFacadeTest {
         identifier = result.contactRestrictionId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -524,6 +538,7 @@ class SyncFacadeTest {
         identifier = result.contactRestrictionId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -543,6 +558,7 @@ class SyncFacadeTest {
         identifier = result.contactRestrictionId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -597,6 +613,7 @@ class SyncFacadeTest {
         identifier = result.contactAddressId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -616,6 +633,7 @@ class SyncFacadeTest {
         identifier = result.contactAddressId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -635,6 +653,7 @@ class SyncFacadeTest {
         identifier = result.contactAddressId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -695,6 +714,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         source = Source.NOMIS,
         secondIdentifier = result.contactAddressId,
+        user = User.SYS_USER,
       )
     }
 
@@ -715,6 +735,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         source = Source.NOMIS,
         secondIdentifier = result.contactAddressId,
+        user = User.SYS_USER,
       )
     }
 
@@ -735,6 +756,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         source = Source.NOMIS,
         secondIdentifier = result.contactAddressId,
+        user = User.SYS_USER,
       )
     }
 
@@ -788,6 +810,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -808,6 +831,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -828,6 +852,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -898,6 +923,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -918,6 +944,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -938,6 +965,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -993,6 +1021,7 @@ class SyncFacadeTest {
         identifier = result.employmentId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -1012,6 +1041,7 @@ class SyncFacadeTest {
         identifier = result.employmentId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -1031,6 +1061,7 @@ class SyncFacadeTest {
         identifier = result.employmentId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerDomesticStatusSyncFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerDomesticStatusSyncFacadeTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdatePrisonerDomesticStatusRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.Status
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPrisonerDomesticStatusResponse
@@ -79,6 +80,7 @@ class PrisonerDomesticStatusSyncFacadeTest {
         identifier = response.id,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
       assertThat(result).isEqualTo(response)
     }
@@ -114,12 +116,14 @@ class PrisonerDomesticStatusSyncFacadeTest {
         identifier = 1L,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
       verify(outboundEventsService).send(
         outboundEvent = OutboundEvent.PRISONER_DOMESTIC_STATUS_UPDATED,
         identifier = 0L,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -153,6 +157,7 @@ class PrisonerDomesticStatusSyncFacadeTest {
         identifier = response.id,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerMergeFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerMergeFacadeTest.kt
@@ -6,6 +6,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
@@ -41,12 +42,14 @@ class PrisonerMergeFacadeTest {
         identifier = updatedResponse.id,
         noms = retainingPrisonerNumber,
         source = Source.DPS,
+        user = User.SYS_USER,
       )
       verify(outboundEventsService).send(
         outboundEvent = OutboundEvent.PRISONER_DOMESTIC_STATUS_CREATED,
         identifier = updatedResponse.id,
         noms = retainingPrisonerNumber,
         source = Source.DPS,
+        user = User.SYS_USER,
       )
     }
 
@@ -98,6 +101,7 @@ class PrisonerMergeFacadeTest {
         identifier = childrenResponse.id,
         noms = retainingPrisonerNumber,
         source = Source.DPS,
+        user = User.SYS_USER,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerNumberOfChildrenSyncFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerNumberOfChildrenSyncFacadeTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerNumberOfChildren
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdatePrisonerNumberOfChildrenRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.Status
@@ -82,12 +83,14 @@ class PrisonerNumberOfChildrenSyncFacadeTest {
         identifier = response.id,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
       verify(outboundEventsService, times(1)).send(
         outboundEvent = OutboundEvent.PRISONER_NUMBER_OF_CHILDREN_CREATED,
         identifier = response.id,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -122,12 +125,14 @@ class PrisonerNumberOfChildrenSyncFacadeTest {
         identifier = 0L,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
       verify(outboundEventsService).send(
         outboundEvent = OutboundEvent.PRISONER_NUMBER_OF_CHILDREN_CREATED,
         identifier = 1L,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
 
@@ -172,12 +177,14 @@ class PrisonerNumberOfChildrenSyncFacadeTest {
         identifier = existingRecord.prisonerNumberOfChildrenId,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
       verify(outboundEventsService, never()).send(
         outboundEvent = OutboundEvent.PRISONER_NUMBER_OF_CHILDREN_CREATED,
         identifier = response.data.id,
         noms = prisonerNumber,
         source = Source.NOMIS,
+        user = User.SYS_USER,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -352,7 +353,7 @@ class OutboundEventsServiceTest {
   @Test
   fun `events are not published for any outbound event when not enabled`() {
     featureSwitches.stub { on { isEnabled(any<OutboundEvent>(), any()) } doReturn false }
-    OutboundEvent.entries.forEach { outboundEventsService.send(it, 1L, 1L) }
+    OutboundEvent.entries.forEach { outboundEventsService.send(it, 1L, 1L, user = User.SYS_USER) }
     verifyNoInteractions(eventsPublisher)
   }
 
@@ -362,7 +363,7 @@ class OutboundEventsServiceTest {
     featureSwitches.stub { on { isEnabled(event) } doReturn true }
     whenever(eventsPublisher.send(any())).thenThrow(RuntimeException("Boom!"))
 
-    outboundEventsService.send(event, 1L, 1L)
+    outboundEventsService.send(event, 1L, 1L, user = User.SYS_USER)
 
     verify(eventsPublisher).send(any())
   }


### PR DESCRIPTION
Move username to common property of AdditionalInformation and remove the default user from the outbound event service. Specify system user directly for migrate & sync events.