### PR TITLE
Change dependabot to group updates into production and development so…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
… we don't delay updates when there are more than 5 dependencies updated.