### PR TITLE
Increase connection timeout

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,8 +20,8 @@ spring:
     password: ${DB_PASS}
     hikari:
       pool-name: PERSONAL-RELATIONSHIPS-DB-CP
-      connection-timeout: 1000
-      validation-timeout: 500
+      connection-timeout: 15000
+      validation-timeout: 2000
       maximum-pool-size: 25
 
   jpa:


### PR DESCRIPTION
Seeing a large number of connection timeout related errors in prod. Although the old settings are widely used across hmpps projects others have much higher timeouts.

Increase to match A&A settings of 15s timeout and 2s revalidate.  Performance tests are being built and we can review whether the service needs additional resources in RDS or API pods.