### PR TITLE
PRC-725 & PRC-696: Reject duplicate relationships

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/HmppsContactsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/HmppsContactsApiExceptionHandler.kt
@@ -24,6 +24,7 @@ import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.exception.DuplicateEmailException
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.exception.InvalidReferenceCodeGroupException
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.DuplicatePersonException
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.DuplicateRelationshipException
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.format.DateTimeParseException
 
@@ -132,7 +133,7 @@ class HmppsContactsApiExceptionHandler {
       ),
     )
 
-  @ExceptionHandler(DuplicatePersonException::class, DuplicateEmailException::class)
+  @ExceptionHandler(DuplicatePersonException::class, DuplicateEmailException::class, DuplicateRelationshipException::class)
   fun handleDuplicateException(e: RuntimeException): ResponseEntity<ErrorResponse> = ResponseEntity
     .status(CONFLICT)
     .body(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRepository.kt
@@ -19,4 +19,14 @@ interface PrisonerContactRepository : JpaRepository<PrisonerContactEntity, Long>
   @Modifying
   @Query("delete from PrisonerContactEntity pc where pc.prisonerNumber = :prisonerNumber")
   fun deleteAllByPrisonerNumber(prisonerNumber: String): Int
+
+  @Query(
+    """
+    SELECT pc FROM PrisonerContactEntity pc 
+    WHERE pc.prisonerNumber = :prisonerNumber 
+    AND pc.contactId = :contactId
+    AND pc.relationshipToPrisoner = :relationshipToPrisoner
+    AND pc.currentTerm = true""",
+  )
+  fun findDuplicateRelationships(prisonerNumber: String, contactId: Long, relationshipToPrisoner: String): List<PrisonerContactEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
@@ -103,6 +103,11 @@ class PrisonerContactController(
         description = "Could not find the prisoner contact that this relationship relates to",
         content = [Content(schema = Schema(implementation = ErrorResponse::class))],
       ),
+      ApiResponse(
+        responseCode = "409",
+        description = "The requested combination of prisoner, contact and relationship to prisoner already exists.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
     ],
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__RW')")
@@ -146,6 +151,11 @@ class PrisonerContactController(
       ApiResponse(
         responseCode = "404",
         description = "Could not find the prisoner or contact that this relationship relates to",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "The requested combination of prisoner, contact and relationship to prisoner already exists.",
         content = [Content(schema = Schema(implementation = ErrorResponse::class))],
       ),
     ],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactSyncController.kt
@@ -117,6 +117,11 @@ class PrisonerContactSyncController(
         description = "The request has invalid or missing fields",
         content = [Content(schema = Schema(implementation = ErrorResponse::class))],
       ),
+      ApiResponse(
+        responseCode = "409",
+        description = "The requested combination of prisoner, contact and relationship to prisoner already exists.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
     ],
   )
   @PreAuthorize("hasAnyRole('PERSONAL_RELATIONSHIPS_MIGRATION')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/DuplicateRelationshipException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/DuplicateRelationshipException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate
+
+class DuplicateRelationshipException(prisonerNumber: String, contactId: Long, relationshipToPrisonerCode: String) : RuntimeException("There is an existing relationship between prisoner $prisonerNumber and contact $contactId with type $relationshipToPrisonerCode")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -1218,7 +1218,7 @@ class ContactServiceTest {
       }
 
       @Test
-      fun `should allow a duplicate relationship if it is the same id for when code was supplied but is the same`() {
+      fun `should not flag as a duplicate if the only existing matching relationship is the one being updated`() {
         prisonerContact = prisonerContact.copy(relationshipToPrisoner = "BRO")
 
         val request = PatchRelationshipRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -64,6 +64,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactPhoneDeta
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactSearchRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.DuplicateRelationshipException
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -1173,6 +1174,63 @@ class ContactServiceTest {
 
           assertUnchangedFields()
         }
+      }
+
+      @Test
+      fun `should reject a duplicate relationship if it is a different id`() {
+        prisonerContact = prisonerContact.copy(relationshipToPrisoner = "BRO")
+        val otherExistingRelationshipWithSisCode = prisonerContact.copy(prisonerContactId = 123456789, relationshipToPrisoner = "SIS")
+
+        val request = PatchRelationshipRequest(
+          relationshipToPrisonerCode = JsonNullable.of("SIS"),
+        )
+        mockBrotherRelationshipReferenceCode()
+        whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.SOCIAL_RELATIONSHIP, "SIS")).thenReturn(
+          ReferenceCode(1, ReferenceCodeGroup.SOCIAL_RELATIONSHIP, "SIS", "Sister", 1, true),
+        )
+        whenever(prisonerContactRepository.findDuplicateRelationships(prisonerContact.prisonerNumber, prisonerContact.contactId, "SIS"))
+          .thenReturn(listOf(otherExistingRelationshipWithSisCode))
+        whenever(prisonerContactRepository.findById(prisonerContactId)).thenReturn(Optional.of(prisonerContact))
+        whenever(prisonerContactRepository.saveAndFlush(any())).thenAnswer { i -> i.arguments[0] }
+
+        assertThrows<DuplicateRelationshipException> {
+          service.updateContactRelationship(prisonerContactId, request, user)
+        }
+        verify(prisonerContactRepository, never()).saveAndFlush(any())
+      }
+
+      @Test
+      fun `should skip duplicate relationship check if we're not changing it`() {
+        prisonerContact = prisonerContact.copy(relationshipToPrisoner = "BRO")
+        val otherExistingRelationshipWithSisCode = prisonerContact.copy(prisonerContactId = 123456789, relationshipToPrisoner = "BRO")
+
+        val request = PatchRelationshipRequest(
+          relationshipToPrisonerCode = JsonNullable.undefined(),
+        )
+        mockBrotherRelationshipReferenceCode()
+        whenever(prisonerContactRepository.findDuplicateRelationships(prisonerContact.prisonerNumber, prisonerContact.contactId, "SIS"))
+          .thenReturn(listOf(prisonerContact, otherExistingRelationshipWithSisCode))
+        whenever(prisonerContactRepository.findById(prisonerContactId)).thenReturn(Optional.of(prisonerContact))
+        whenever(prisonerContactRepository.saveAndFlush(any())).thenAnswer { i -> i.arguments[0] }
+        service.updateContactRelationship(prisonerContactId, request, user)
+        verify(prisonerContactRepository).saveAndFlush(any())
+        verify(prisonerContactRepository, never()).findDuplicateRelationships(any(), any(), any())
+      }
+
+      @Test
+      fun `should allow a duplicate relationship if it is the same id for when code was supplied but is the same`() {
+        prisonerContact = prisonerContact.copy(relationshipToPrisoner = "BRO")
+
+        val request = PatchRelationshipRequest(
+          relationshipToPrisonerCode = JsonNullable.of("BRO"),
+        )
+        mockBrotherRelationshipReferenceCode()
+        whenever(prisonerContactRepository.findDuplicateRelationships(prisonerContact.prisonerNumber, prisonerContact.contactId, "BRO"))
+          .thenReturn(listOf(prisonerContact))
+        whenever(prisonerContactRepository.findById(prisonerContactId)).thenReturn(Optional.of(prisonerContact))
+        whenever(prisonerContactRepository.saveAndFlush(any())).thenAnswer { i -> i.arguments[0] }
+        service.updateContactRelationship(prisonerContactId, request, user)
+        verify(prisonerContactRepository).saveAndFlush(any())
       }
 
       @Test


### PR DESCRIPTION
Reject duplicate relationships (same prisoner number, contact id and relationship to prisoner code) when a new relationship is created by sync or DPS API. Also reject duplicate relationships when updating a contact relationship but only if the user is changing the relationship. Do not reject sync updates to relationships.

This allows existing duplicates in NOMIS to be updated but blocks the creation of new duplicates, we trust NOMIS not to create any more new duplicates as it is validated in the NOMIS UI now.