### PR TITLE
PRC-704: API to get all summaries for prisoner and contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSummaryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSummaryRepository.kt
@@ -6,4 +6,5 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSumma
 @Repository
 interface PrisonerContactSummaryRepository : ReadOnlyRepository<PrisonerContactSummaryEntity, Long> {
   fun findByContactId(contactId: Long): List<PrisonerContactSummaryEntity>
+  fun findByPrisonerNumberAndContactId(prisonerNumber: String, contactId: Long): List<PrisonerContactSummaryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
@@ -102,6 +102,41 @@ class PrisonerController(private val prisonerContactService: PrisonerContactServ
     return prisonerContactService.getAllContacts(params)
   }
 
+  @Operation(
+    summary = "Get all relationships between a specific prisoner and contact",
+    description = """Prisoners can have multiple relationships defined with a single contact which is a security risk and highly discouraged.
+      |This API should be used to help dissuade users from creating multiple relationships between a single prisoner and contact wherever possible.
+    """,
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "A page of matching contact relationships for the prisoner",
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The Prisoner was not found.",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @GetMapping(value = ["/{prisonNumber}/contact/{contactId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
+  fun getAllSummariesForPrisonerAndContact(
+    @PathVariable("prisonNumber") @PrisonNumberDoc prisonerNumber: String,
+    @PathVariable("contactId") @Parameter(
+      name = "contactId",
+      description = "The id of the contact",
+      example = "123456",
+    ) contactId: Long,
+  ): List<PrisonerContactSummary> = prisonerContactService.getAllSummariesForPrisonerAndContact(prisonerNumber, contactId)
+
   @Operation(summary = "Count of a prisoner's active contact relationships for their current term by relationship type")
   @ApiResponses(
     value = [

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -147,6 +147,16 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
     .expectBody(PrisonerContactSummaryResponse::class.java)
     .returnResult().responseBody!!
 
+  fun getAllSummariesForPrisonerAndContact(prisonerNumber: String, contactId: Long): List<PrisonerContactSummary> = webTestClient.get()
+    .uri("/prisoner/$prisonerNumber/contact/$contactId")
+    .headers(setAuthorisationUsingCurrentUser())
+    .exchange()
+    .expectStatus()
+    .isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBodyList(PrisonerContactSummary::class.java)
+    .returnResult().responseBody!!
+
   fun getPrisonerContactRelationshipCount(prisonerNumber: String): PrisonerContactRelationshipCount = webTestClient.get()
     .uri("/prisoner/$prisonerNumber/contact/count")
     .headers(setAuthorisationUsingCurrentUser())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetAllSummariesForPrisonerAndContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetAllSummariesForPrisonerAndContactIntegrationTest.kt
@@ -1,0 +1,134 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.SecureAPIIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.restrictions.CreateContactRestrictionRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.restrictions.CreatePrisonerContactRestrictionRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.RestrictionTypeDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.RestrictionsSummary
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.util.StubUser
+import java.time.LocalDate
+
+class GetAllSummariesForPrisonerAndContactIntegrationTest : SecureAPIIntegrationTestBase() {
+  companion object {
+    private const val GET_PRISONER_CONTACT = "/prisoner/A4385DZ/contact"
+  }
+
+  private val prisonerNumber = "A1234BC"
+  private var savedContactId: Long = 0
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.CREATING_USER)
+    stubPrisonSearchWithResponse(prisonerNumber)
+    savedContactId = testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "Last",
+        firstName = "First",
+      ),
+    ).id
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
+
+  override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
+
+  override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.get()
+    .uri("/prisoner/A4385DZ/contact/$savedContactId")
+
+  @Test
+  fun `should return not found if no prisoner found`() {
+    stubPrisonSearchWithNotFoundResponse("A4385DZ")
+
+    webTestClient.get()
+      .uri("/prisoner/A4385DZ/contact/$savedContactId")
+      .headers(setAuthorisationUsingCurrentUser())
+      .exchange()
+      .expectStatus()
+      .isNotFound
+  }
+
+  @Test
+  fun `should return all relationships with restrictions summary`() {
+    doWithTemporaryWritePermission {
+      val sisterRelationship = testAPIClient.addAContactRelationship(
+        AddContactRelationshipRequest(
+          contactId = savedContactId,
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "SIS",
+            isNextOfKin = true,
+            isEmergencyContact = true,
+            isApprovedVisitor = true,
+          ),
+        ),
+      )
+      val brotherRelationship = testAPIClient.addAContactRelationship(
+        AddContactRelationshipRequest(
+          contactId = savedContactId,
+          relationship = ContactRelationship(
+            prisonerNumber = prisonerNumber,
+            relationshipTypeCode = "S",
+            relationshipToPrisonerCode = "BRO",
+            isNextOfKin = false,
+            isEmergencyContact = false,
+            isApprovedVisitor = false,
+          ),
+        ),
+      )
+
+      testAPIClient.createContactGlobalRestriction(
+        savedContactId,
+        CreateContactRestrictionRequest(
+          "BAN",
+          LocalDate.now().minusDays(1),
+          null,
+          "global",
+        ),
+      )
+
+      testAPIClient.createPrisonerContactRestriction(
+        sisterRelationship.prisonerContactId,
+        CreatePrisonerContactRestrictionRequest(
+          "CCTV",
+          LocalDate.now().minusDays(1),
+          null,
+          "rel1",
+        ),
+      )
+
+      testAPIClient.createPrisonerContactRestriction(
+        brotherRelationship.prisonerContactId,
+        CreatePrisonerContactRestrictionRequest(
+          "NONCON",
+          LocalDate.now().minusDays(1),
+          null,
+          "rel2",
+        ),
+      )
+    }
+
+    val summaries = testAPIClient.getAllSummariesForPrisonerAndContact(prisonerNumber, savedContactId)
+    assertThat(summaries).hasSize(2)
+    assertThat(summaries.find { it.relationshipToPrisonerCode == "SIS" }!!.restrictionSummary).isEqualTo(
+      RestrictionsSummary(
+        setOf(RestrictionTypeDetails("BAN", "Banned"), RestrictionTypeDetails("CCTV", "CCTV")),
+        2,
+        0,
+      ),
+    )
+    assertThat(summaries.find { it.relationshipToPrisonerCode == "BRO" }!!.restrictionSummary).isEqualTo(
+      RestrictionsSummary(
+        setOf(RestrictionTypeDetails("BAN", "Banned"), RestrictionTypeDetails("NONCON", "Non-contact visit")),
+        2,
+        0,
+      ),
+    )
+  }
+}


### PR DESCRIPTION
This API is to enable showing duplicate relationships and for otherwise dissuading users from creating multiple relationships between a prisoner and contact.