### PR TITLE
Increase max page size for rec

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     web:
       pageable:
         default-page-size: 10
-        max-page-size: 300
+        max-page-size: 500
 
   datasource:
     url: 'jdbc:postgresql://${DB_SERVER}/${DB_NAME}?sslmode=${DB_SSL_MODE}'


### PR DESCRIPTION
Rec is currently failing due to a prisoner with 300 linked contacts.