### PR TITLE
PRC-746: Allow sync to create dupes if not current term

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactService.kt
@@ -25,7 +25,7 @@ class SyncPrisonerContactService(
   }
 
   fun createPrisonerContact(request: SyncCreatePrisonerContactRequest): SyncPrisonerContact {
-    if (prisonerContactRepository.findDuplicateRelationships(request.prisonerNumber, request.contactId, request.relationshipType).isNotEmpty()) {
+    if (request.currentTerm == true && prisonerContactRepository.findDuplicateRelationships(request.prisonerNumber, request.contactId, request.relationshipType).isNotEmpty()) {
       throw DuplicateRelationshipException(request.prisonerNumber, request.contactId, request.relationshipType)
     }
     return prisonerContactRepository.saveAndFlush(request.toEntity()).toResponse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactIntegrationTest.kt
@@ -313,6 +313,31 @@ class SyncPrisonerContactIntegrationTest : PostgresIntegrationTestBase() {
         .isEqualTo(HttpStatus.CONFLICT)
     }
 
+    @Test
+    fun `should allow create duplicate relationship if not current term`() {
+      val prisonerNumber = "A1234BF"
+      val request = createPrisonerContactRequest(prisonerNumber).copy(currentTerm = false)
+      webTestClient.post()
+        .uri("/sync/prisoner-contact")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisationUsingCurrentUser())
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      webTestClient.post()
+        .uri("/sync/prisoner-contact")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisationUsingCurrentUser())
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk
+    }
+
     private fun updatePrisonerContactRequest(prisonerNumber: String = "A1234BC") = SyncUpdatePrisonerContactRequest(
       contactId = 1L,
       prisonerNumber = prisonerNumber,


### PR DESCRIPTION
Sometimes users do weird things like create a contact and then create the same contact on an old booking for seemingly no reason. When currentTerm=false skip the duplicate check as we only care about current duplicates.

There is an edge case where a dupe is created on old bookings and then the old booking is reactivated but we feel this is the safest overall option.