### PR TITLE
PRC-747: Custom events on data change

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/TelemetryConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/TelemetryConfiguration.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.config
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class TelemetryConfiguration {
+  @Bean
+  fun telemetryClient() = TelemetryClient()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/HmppsQueueOutboundEventsPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/HmppsQueueOutboundEventsPublisher.kt
@@ -37,11 +37,9 @@ class HmppsQueueOutboundEventsPublisher(
           .message(mapper.writeValueAsString(event))
           .messageAttributes(metaData(event))
           .build(),
-      ).also { log.debug("Published {}", event) }
-
+      )
       return
     }
-
     log.info("Ignoring publishing of event $event (feature switched off)")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -5,11 +5,13 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.telemetry.TelemetryService
 
 @Service
 class OutboundEventsService(
   private val publisher: OutboundEventsPublisher,
   private val featureSwitches: FeatureSwitches,
+  private val telemetryService: TelemetryService,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -169,7 +171,9 @@ class OutboundEventsService(
     personReference: PersonReference? = null,
   ) {
     try {
-      publisher.send(outboundEvent.event(additionalInformation, personReference))
+      val event = outboundEvent.event(additionalInformation, personReference)
+      publisher.send(event)
+      telemetryService.track(event)
     } catch (e: Exception) {
       log.error(
         "Unable to send event with type {}, info {}, person {}",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/telemetry/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/telemetry/TelemetryService.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.telemetry
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.springframework.stereotype.Service
+
+@Service
+class TelemetryService(private val telemetryClient: TelemetryClient) {
+  fun track(event: TelemetryEvent) {
+    when (event) {
+      is MetricTelemetryEvent -> telemetryClient.trackEvent(event.eventType, event.properties(), event.metrics())
+      is StandardTelemetryEvent -> telemetryClient.trackEvent(event.eventType, event.properties(), null)
+    }
+  }
+}
+
+sealed class TelemetryEvent(open val eventType: String) {
+  abstract fun properties(): Map<String, String>
+}
+
+abstract class MetricTelemetryEvent(eventType: String) : TelemetryEvent(eventType) {
+  abstract fun metrics(): Map<String, Double>
+}
+
+abstract class StandardTelemetryEvent(eventType: String) : TelemetryEvent(eventType)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
@@ -17,14 +17,18 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.aUser
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.telemetry.StandardTelemetryEvent
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.telemetry.TelemetryService
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
 class OutboundEventsServiceTest {
   private val eventsPublisher: OutboundEventsPublisher = mock()
   private val featureSwitches: FeatureSwitches = mock()
-  private val outboundEventsService = OutboundEventsService(eventsPublisher, featureSwitches)
+  private val telemetryService: TelemetryService = mock()
+  private val outboundEventsService = OutboundEventsService(eventsPublisher, featureSwitches, telemetryService)
   private val eventCaptor = argumentCaptor<OutboundHMPPSDomainEvent>()
+  private val telemetryCaptor = argumentCaptor<StandardTelemetryEvent>()
 
   @Test
   fun `contact created event with id 1 is sent to the events publisher`() {
@@ -68,7 +72,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_CREATED, 1L, 1L, user = aUser("address"))
     verify(
       expectedEventType = "contacts-api.contact-address.created",
-      expectedAdditionalInformation = ContactAddressInfo(contactAddressId = 1L, source = Source.DPS, username = "address"),
+      expectedAdditionalInformation = ContactAddressInfo(
+        contactAddressId = 1L,
+        source = Source.DPS,
+        username = "address",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address has been created",
     )
@@ -80,7 +88,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_UPDATED, 1L, 1L, user = aUser("address"))
     verify(
       expectedEventType = "contacts-api.contact-address.updated",
-      expectedAdditionalInformation = ContactAddressInfo(contactAddressId = 1L, source = Source.DPS, username = "address"),
+      expectedAdditionalInformation = ContactAddressInfo(
+        contactAddressId = 1L,
+        source = Source.DPS,
+        username = "address",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address has been updated",
     )
@@ -92,7 +104,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_DELETED, 1L, 1L, user = aUser("address"))
     verify(
       expectedEventType = "contacts-api.contact-address.deleted",
-      expectedAdditionalInformation = ContactAddressInfo(contactAddressId = 1L, source = Source.DPS, username = "address"),
+      expectedAdditionalInformation = ContactAddressInfo(
+        contactAddressId = 1L,
+        source = Source.DPS,
+        username = "address",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address has been deleted",
     )
@@ -173,10 +189,21 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact address phone created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED, 1L, 1L, secondIdentifier = 99L, user = aUser("phone"))
+    outboundEventsService.send(
+      OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
+      1L,
+      1L,
+      secondIdentifier = 99L,
+      user = aUser("phone"),
+    )
     verify(
       expectedEventType = "contacts-api.contact-address-phone.created",
-      expectedAdditionalInformation = ContactAddressPhoneInfo(contactAddressPhoneId = 1L, contactAddressId = 99L, source = Source.DPS, username = "phone"),
+      expectedAdditionalInformation = ContactAddressPhoneInfo(
+        contactAddressPhoneId = 1L,
+        contactAddressId = 99L,
+        source = Source.DPS,
+        username = "phone",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address phone number has been created",
     )
@@ -185,10 +212,21 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact address phone updated event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, 1L, 1L, secondIdentifier = 99L, user = aUser("phone"))
+    outboundEventsService.send(
+      OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED,
+      1L,
+      1L,
+      secondIdentifier = 99L,
+      user = aUser("phone"),
+    )
     verify(
       expectedEventType = "contacts-api.contact-address-phone.updated",
-      expectedAdditionalInformation = ContactAddressPhoneInfo(contactAddressPhoneId = 1, contactAddressId = 99L, source = Source.DPS, username = "phone"),
+      expectedAdditionalInformation = ContactAddressPhoneInfo(
+        contactAddressPhoneId = 1,
+        contactAddressId = 99L,
+        source = Source.DPS,
+        username = "phone",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address phone number has been updated",
     )
@@ -197,10 +235,21 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact address phone deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED, 1L, 1L, secondIdentifier = 99L, user = aUser("phone"))
+    outboundEventsService.send(
+      OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED,
+      1L,
+      1L,
+      secondIdentifier = 99L,
+      user = aUser("phone"),
+    )
     verify(
       expectedEventType = "contacts-api.contact-address-phone.deleted",
-      expectedAdditionalInformation = ContactAddressPhoneInfo(contactAddressPhoneId = 1, contactAddressId = 99L, source = Source.DPS, username = "phone"),
+      expectedAdditionalInformation = ContactAddressPhoneInfo(
+        contactAddressPhoneId = 1,
+        contactAddressId = 99L,
+        source = Source.DPS,
+        username = "phone",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address phone number has been deleted",
     )
@@ -212,7 +261,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_CREATED, 1L, 1L, user = aUser("id_user"))
     verify(
       expectedEventType = "contacts-api.contact-identity.created",
-      expectedAdditionalInformation = ContactIdentityInfo(contactIdentityId = 1L, source = Source.DPS, username = "id_user"),
+      expectedAdditionalInformation = ContactIdentityInfo(
+        contactIdentityId = 1L,
+        source = Source.DPS,
+        username = "id_user",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact proof of identity has been created",
     )
@@ -224,7 +277,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_UPDATED, 1L, 1L, user = aUser("id_user"))
     verify(
       expectedEventType = "contacts-api.contact-identity.updated",
-      expectedAdditionalInformation = ContactIdentityInfo(contactIdentityId = 1, source = Source.DPS, username = "id_user"),
+      expectedAdditionalInformation = ContactIdentityInfo(
+        contactIdentityId = 1,
+        source = Source.DPS,
+        username = "id_user",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact proof of identity has been updated",
     )
@@ -236,7 +293,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_DELETED, 1L, 1L, user = aUser("id_user"))
     verify(
       expectedEventType = "contacts-api.contact-identity.deleted",
-      expectedAdditionalInformation = ContactIdentityInfo(contactIdentityId = 1, source = Source.DPS, username = "id_user"),
+      expectedAdditionalInformation = ContactIdentityInfo(
+        contactIdentityId = 1,
+        source = Source.DPS,
+        username = "id_user",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact proof of identity has been deleted",
     )
@@ -248,7 +309,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.CONTACT_RESTRICTION_CREATED, 1L, 1L, user = aUser("restriction_user"))
     verify(
       expectedEventType = "contacts-api.contact-restriction.created",
-      expectedAdditionalInformation = ContactRestrictionInfo(contactRestrictionId = 1L, source = Source.DPS, username = "restriction_user"),
+      expectedAdditionalInformation = ContactRestrictionInfo(
+        contactRestrictionId = 1L,
+        source = Source.DPS,
+        username = "restriction_user",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact restriction has been created",
     )
@@ -260,7 +325,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.CONTACT_RESTRICTION_UPDATED, 1L, 1L, user = aUser("restriction_user"))
     verify(
       expectedEventType = "contacts-api.contact-restriction.updated",
-      expectedAdditionalInformation = ContactRestrictionInfo(contactRestrictionId = 1L, source = Source.DPS, username = "restriction_user"),
+      expectedAdditionalInformation = ContactRestrictionInfo(
+        contactRestrictionId = 1L,
+        source = Source.DPS,
+        username = "restriction_user",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact restriction has been updated",
     )
@@ -272,7 +341,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.CONTACT_RESTRICTION_DELETED, 1L, 1L, user = aUser("restriction_user"))
     verify(
       expectedEventType = "contacts-api.contact-restriction.deleted",
-      expectedAdditionalInformation = ContactRestrictionInfo(contactRestrictionId = 1L, source = Source.DPS, username = "restriction_user"),
+      expectedAdditionalInformation = ContactRestrictionInfo(
+        contactRestrictionId = 1L,
+        source = Source.DPS,
+        username = "restriction_user",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact restriction has been deleted",
     )
@@ -284,7 +357,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_CREATED, 1L, 1L, "A1234AA", user = aUser("foo"))
     verify(
       expectedEventType = "contacts-api.prisoner-contact.created",
-      expectedAdditionalInformation = PrisonerContactInfo(prisonerContactId = 1L, source = Source.DPS, username = "foo"),
+      expectedAdditionalInformation = PrisonerContactInfo(
+        prisonerContactId = 1L,
+        source = Source.DPS,
+        username = "foo",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact has been created",
     )
@@ -296,7 +373,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_UPDATED, 1L, 1L, "A1234AA", user = aUser("foo"))
     verify(
       expectedEventType = "contacts-api.prisoner-contact.updated",
-      expectedAdditionalInformation = PrisonerContactInfo(prisonerContactId = 1L, source = Source.DPS, username = "foo"),
+      expectedAdditionalInformation = PrisonerContactInfo(
+        prisonerContactId = 1L,
+        source = Source.DPS,
+        username = "foo",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact has been updated",
     )
@@ -308,7 +389,11 @@ class OutboundEventsServiceTest {
     outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_DELETED, 1L, 1L, "A1234AA", user = aUser("foo"))
     verify(
       expectedEventType = "contacts-api.prisoner-contact.deleted",
-      expectedAdditionalInformation = PrisonerContactInfo(prisonerContactId = 1L, source = Source.DPS, username = "foo"),
+      expectedAdditionalInformation = PrisonerContactInfo(
+        prisonerContactId = 1L,
+        source = Source.DPS,
+        username = "foo",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact has been deleted",
     )
@@ -317,10 +402,20 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact restriction created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED, 1L, 1L, "A1234AA", user = aUser("restriction_user"))
+    outboundEventsService.send(
+      OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED,
+      1L,
+      1L,
+      "A1234AA",
+      user = aUser("restriction_user"),
+    )
     verify(
       expectedEventType = "contacts-api.prisoner-contact-restriction.created",
-      expectedAdditionalInformation = PrisonerContactRestrictionInfo(prisonerContactRestrictionId = 1L, source = Source.DPS, username = "restriction_user"),
+      expectedAdditionalInformation = PrisonerContactRestrictionInfo(
+        prisonerContactRestrictionId = 1L,
+        source = Source.DPS,
+        username = "restriction_user",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact restriction has been created",
     )
@@ -329,10 +424,20 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact restriction updated event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_RESTRICTION_UPDATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_RESTRICTION_UPDATED, 1L, 1L, "A1234AA", user = aUser("restriction_user"))
+    outboundEventsService.send(
+      OutboundEvent.PRISONER_CONTACT_RESTRICTION_UPDATED,
+      1L,
+      1L,
+      "A1234AA",
+      user = aUser("restriction_user"),
+    )
     verify(
       expectedEventType = "contacts-api.prisoner-contact-restriction.updated",
-      expectedAdditionalInformation = PrisonerContactRestrictionInfo(prisonerContactRestrictionId = 1L, source = Source.DPS, username = "restriction_user"),
+      expectedAdditionalInformation = PrisonerContactRestrictionInfo(
+        prisonerContactRestrictionId = 1L,
+        source = Source.DPS,
+        username = "restriction_user",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact restriction has been updated",
     )
@@ -341,10 +446,20 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact resrtiction deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED, 1L, 1L, "A1234AA", user = aUser("restriction_user"))
+    outboundEventsService.send(
+      OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED,
+      1L,
+      1L,
+      "A1234AA",
+      user = aUser("restriction_user"),
+    )
     verify(
       expectedEventType = "contacts-api.prisoner-contact-restriction.deleted",
-      expectedAdditionalInformation = PrisonerContactRestrictionInfo(prisonerContactRestrictionId = 1L, source = Source.DPS, username = "restriction_user"),
+      expectedAdditionalInformation = PrisonerContactRestrictionInfo(
+        prisonerContactRestrictionId = 1L,
+        source = Source.DPS,
+        username = "restriction_user",
+      ),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact restriction has been deleted",
     )
@@ -384,6 +499,18 @@ class OutboundEventsServiceTest {
       assertThat(personReference?.nomsNumber()).isEqualTo(expectedPersonReference.nomsNumber())
       assertThat(occurredAt).isCloseTo(expectedOccurredAt, within(60, ChronoUnit.SECONDS))
       assertThat(description).isEqualTo(expectedDescription)
+    }
+
+    verify(telemetryService).track(telemetryCaptor.capture())
+    with(telemetryCaptor.firstValue) {
+      assertThat(eventType).isEqualTo(expectedEventType)
+      assertThat(properties()["prisoner_number"]).isEqualTo(expectedPersonReference.nomsNumber())
+      assertThat(properties()["contact_id"]).isEqualTo(expectedPersonReference.dpsContactId())
+      assertThat(properties()["version"]).isEqualTo("1")
+      assertThat(properties()["description"]).isEqualTo(expectedDescription)
+      assertThat(properties()["source"]).isEqualTo(expectedAdditionalInformation.source.toString())
+      assertThat(properties()["username"]).isEqualTo(expectedAdditionalInformation.username)
+      assertThat(properties()["occurred_at"]).isNotNull()
     }
 
     verifyNoMoreInteractions(eventsPublisher)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/telemetry/TelemetryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/telemetry/TelemetryServiceTest.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.telemetry
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class TelemetryServiceTest {
+
+  private val telemetryClient: TelemetryClient = mock()
+  private val telemetryService = TelemetryService(telemetryClient)
+
+  @Test
+  fun `should raise a standard telemetry event`() {
+    val standardEvent = object : StandardTelemetryEvent("FAKE-standard-event") {
+      override fun properties() = mapOf("standard key" to "standard value")
+    }
+
+    telemetryService.track(standardEvent)
+
+    verify(telemetryClient).trackEvent("FAKE-standard-event", mapOf("standard key" to "standard value"), null)
+  }
+
+  @Test
+  fun `should raise a metric telemetry event`() {
+    val standardEvent = object : MetricTelemetryEvent("FAKE-metric-event") {
+      override fun properties() = mapOf("metric property key" to "metric property value")
+      override fun metrics() = mapOf("metric metric key" to 1.0)
+    }
+
+    telemetryService.track(standardEvent)
+
+    verify(telemetryClient).trackEvent("FAKE-metric-event", mapOf("metric property key" to "metric property value"), mapOf("metric metric key" to 1.0))
+  }
+}


### PR DESCRIPTION
Integrate telemetry service (stole from BVLS) and send telemetry alongside every outbound event. This will give us customEvents in app insight on every data change regardless of NOMIS or DPS. To be expanded further with user details from NOMIS and current caseload if possible.