### PR TITLE
PRC-747: Set username on NOMIS source events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -90,7 +90,7 @@ class SyncFacade(
         identifier = it.id,
         contactId = it.id,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -101,7 +101,7 @@ class SyncFacade(
         identifier = it.id,
         contactId = it.id,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -112,7 +112,7 @@ class SyncFacade(
         identifier = contactId,
         contactId = contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -131,7 +131,7 @@ class SyncFacade(
         identifier = it.contactPhoneId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -142,7 +142,7 @@ class SyncFacade(
         identifier = it.contactPhoneId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -153,7 +153,7 @@ class SyncFacade(
         identifier = contactPhoneId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -170,7 +170,7 @@ class SyncFacade(
         identifier = it.contactEmailId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -181,7 +181,7 @@ class SyncFacade(
         identifier = it.contactEmailId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -192,7 +192,7 @@ class SyncFacade(
         identifier = it.contactEmailId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -209,7 +209,7 @@ class SyncFacade(
         identifier = it.contactIdentityId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -220,7 +220,7 @@ class SyncFacade(
         identifier = it.contactIdentityId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -231,7 +231,7 @@ class SyncFacade(
         identifier = it.contactIdentityId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -248,7 +248,7 @@ class SyncFacade(
         identifier = it.contactRestrictionId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -259,7 +259,7 @@ class SyncFacade(
         identifier = it.contactRestrictionId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -270,7 +270,7 @@ class SyncFacade(
         identifier = it.contactRestrictionId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -287,7 +287,7 @@ class SyncFacade(
         identifier = it.contactAddressId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -298,7 +298,7 @@ class SyncFacade(
         identifier = it.contactAddressId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -309,7 +309,7 @@ class SyncFacade(
         identifier = it.contactAddressId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -326,7 +326,7 @@ class SyncFacade(
         contactId = it.contactId,
         source = Source.NOMIS,
         secondIdentifier = it.contactAddressId,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -338,7 +338,7 @@ class SyncFacade(
         contactId = it.contactId,
         source = Source.NOMIS,
         secondIdentifier = it.contactAddressId,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -350,7 +350,7 @@ class SyncFacade(
         contactId = it.contactId,
         source = Source.NOMIS,
         secondIdentifier = it.contactAddressId,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -368,7 +368,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -380,7 +380,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -392,7 +392,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -410,7 +410,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -422,7 +422,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -434,7 +434,7 @@ class SyncFacade(
         contactId = it.contactId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -451,7 +451,7 @@ class SyncFacade(
         identifier = it.employmentId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.createdBy),
       )
     }
 
@@ -462,7 +462,7 @@ class SyncFacade(
         identifier = it.employmentId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(request.updatedBy),
       )
     }
 
@@ -473,7 +473,7 @@ class SyncFacade(
         identifier = it.employmentId,
         contactId = it.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -521,7 +521,7 @@ class SyncFacade(
         contactId = removed.contactId,
         noms = removed.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(null),
       )
     }
 
@@ -531,7 +531,7 @@ class SyncFacade(
       contactId = removed.contactId,
       noms = removed.prisonerNumber,
       source = Source.NOMIS,
-      user = User.SYS_USER,
+      user = userOrDefault(null),
     )
   }
 
@@ -546,7 +546,7 @@ class SyncFacade(
         contactId = created.contactId,
         noms = prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = userOrDefault(),
       )
     }
 
@@ -556,7 +556,9 @@ class SyncFacade(
       contactId = created.contactId,
       noms = prisonerNumber,
       source = Source.NOMIS,
-      user = User.SYS_USER,
+      user = userOrDefault(),
     )
   }
+
+  private fun userOrDefault(username: String? = null): User = username?.let { User(username) } ?: User.SYS_USER
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
@@ -109,7 +109,7 @@ class SyncFacadeTest {
         identifier = result.id,
         contactId = result.id,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -150,7 +150,7 @@ class SyncFacadeTest {
         identifier = result.id,
         contactId = result.id,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 
@@ -211,14 +211,14 @@ class SyncFacadeTest {
       firstName = "John",
       lastName = "Doe",
       dateOfBirth = LocalDate.of(1980, 1, 1),
-      createdBy = "ANYONE",
+      createdBy = "CREATOR",
     )
 
     private fun contactResponse(contactId: Long) = SyncContact(
       id = contactId,
       firstName = "John",
       lastName = "Doe",
-      createdBy = "ANYONE",
+      createdBy = "CREATOR",
       createdTime = LocalDateTime.now(),
       updatedBy = null,
       updatedTime = null,
@@ -227,7 +227,7 @@ class SyncFacadeTest {
     private fun updateContactSyncRequest() = SyncUpdateContactRequest(
       firstName = "John",
       lastName = "Doe",
-      updatedBy = "ANYONE",
+      updatedBy = "UPDATER",
       updatedTime = LocalDateTime.now(),
     )
   }
@@ -250,7 +250,7 @@ class SyncFacadeTest {
         identifier = result.contactPhoneId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -270,7 +270,7 @@ class SyncFacadeTest {
         identifier = result.contactPhoneId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 
@@ -340,7 +340,7 @@ class SyncFacadeTest {
         identifier = result.contactEmailId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -360,7 +360,7 @@ class SyncFacadeTest {
         identifier = result.contactEmailId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 
@@ -426,7 +426,7 @@ class SyncFacadeTest {
         identifier = result.contactIdentityId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -446,7 +446,7 @@ class SyncFacadeTest {
         identifier = result.contactIdentityId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 
@@ -518,7 +518,7 @@ class SyncFacadeTest {
         identifier = result.contactRestrictionId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -538,7 +538,7 @@ class SyncFacadeTest {
         identifier = result.contactRestrictionId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 
@@ -613,7 +613,7 @@ class SyncFacadeTest {
         identifier = result.contactAddressId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -633,7 +633,7 @@ class SyncFacadeTest {
         identifier = result.contactAddressId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 
@@ -714,7 +714,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         source = Source.NOMIS,
         secondIdentifier = result.contactAddressId,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -735,7 +735,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         source = Source.NOMIS,
         secondIdentifier = result.contactAddressId,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 
@@ -810,7 +810,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -831,7 +831,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 
@@ -923,7 +923,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -944,7 +944,7 @@ class SyncFacadeTest {
         contactId = result.contactId,
         noms = result.prisonerNumber,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 
@@ -1021,7 +1021,7 @@ class SyncFacadeTest {
         identifier = result.employmentId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("CREATOR"),
       )
     }
 
@@ -1041,7 +1041,7 @@ class SyncFacadeTest {
         identifier = result.employmentId,
         contactId = result.contactId,
         source = Source.NOMIS,
-        user = User.SYS_USER,
+        user = User("UPDATER"),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactAddressIntegrationTest.kt
@@ -159,7 +159,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS, "CREATE"),
       personReference = PersonReference(dpsContactId = contactId),
     )
   }
@@ -214,7 +214,7 @@ class SyncContactAddressIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactAddressInfo(contactAddress.contactAddressId, Source.NOMIS, "UPDATE"),
       personReference = PersonReference(dpsContactId = contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactEmailIntegrationTest.kt
@@ -148,7 +148,7 @@ class SyncContactEmailIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_EMAIL_CREATED,
-      additionalInfo = ContactEmailInfo(contactEmail.contactEmailId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactEmailInfo(contactEmail.contactEmailId, Source.NOMIS, "CREATE"),
       personReference = PersonReference(dpsContactId = contactEmail.contactId),
     )
   }
@@ -199,7 +199,7 @@ class SyncContactEmailIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-      additionalInfo = ContactEmailInfo(contactEmail.contactEmailId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactEmailInfo(contactEmail.contactEmailId, Source.NOMIS, "UPDATE"),
       personReference = PersonReference(dpsContactId = contactEmail.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIdentityIntegrationTest.kt
@@ -152,7 +152,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_CREATED,
-      additionalInfo = ContactIdentityInfo(contactIdentity.contactIdentityId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactIdentityInfo(contactIdentity.contactIdentityId, Source.NOMIS, "CREATE"),
       personReference = PersonReference(dpsContactId = contactIdentity.contactId),
     )
   }
@@ -213,7 +213,7 @@ class SyncContactIdentityIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_UPDATED,
-      additionalInfo = ContactIdentityInfo(updatedIdentity.contactIdentityId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactIdentityInfo(updatedIdentity.contactIdentityId, Source.NOMIS, "UPDATE"),
       personReference = PersonReference(dpsContactId = updatedIdentity.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactIntegrationTest.kt
@@ -161,7 +161,7 @@ class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
+      additionalInfo = ContactInfo(contact.id, Source.NOMIS, "JD000001"),
       personReference = PersonReference(dpsContactId = contact.id),
     )
   }
@@ -182,7 +182,7 @@ class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
+      additionalInfo = ContactInfo(contact.id, Source.NOMIS, "JD000001"),
       personReference = PersonReference(dpsContactId = contact.id),
     )
 
@@ -221,7 +221,7 @@ class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_UPDATED,
-      additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
+      additionalInfo = ContactInfo(contact.id, Source.NOMIS, "UPDATE"),
       personReference = PersonReference(dpsContactId = contact.id),
     )
   }
@@ -248,7 +248,7 @@ class SyncContactIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contact.id, Source.NOMIS, User.SYS_USER.username),
+      additionalInfo = ContactInfo(contact.id, Source.NOMIS, "JD000001"),
       personReference = PersonReference(dpsContactId = contact.id),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactPhoneIntegrationTest.kt
@@ -153,7 +153,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS, "CREATE"),
       personReference = PersonReference(dpsContactId = contactPhone.contactId),
     )
   }
@@ -207,7 +207,7 @@ class SyncContactPhoneIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_UPDATED,
-      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactPhoneInfo(contactPhone.contactPhoneId, Source.NOMIS, "UPDATE"),
       personReference = PersonReference(dpsContactId = contactPhone.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncContactRestrictionIntegrationTest.kt
@@ -156,7 +156,7 @@ class SyncContactRestrictionIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_RESTRICTION_CREATED,
-      additionalInfo = ContactRestrictionInfo(contactRestriction.contactRestrictionId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactRestrictionInfo(contactRestriction.contactRestrictionId, Source.NOMIS, "CREATE"),
       personReference = PersonReference(dpsContactId = contactRestriction.contactId),
     )
   }
@@ -212,7 +212,7 @@ class SyncContactRestrictionIntegrationTest : PostgresIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_RESTRICTION_UPDATED,
-      additionalInfo = ContactRestrictionInfo(updatedRestriction.contactRestrictionId, Source.NOMIS, "SYS"),
+      additionalInfo = ContactRestrictionInfo(updatedRestriction.contactRestrictionId, Source.NOMIS, "UPDATE"),
       personReference = PersonReference(dpsContactId = updatedRestriction.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncEmploymentIntegrationTest.kt
@@ -156,7 +156,7 @@ class SyncEmploymentIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_CREATED,
-      additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS, "SYS"),
+      additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS, "CREATOR"),
       personReference = PersonReference(dpsContactId = employment.contactId),
     )
   }
@@ -191,7 +191,7 @@ class SyncEmploymentIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_UPDATED,
-      additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS, "SYS"),
+      additionalInfo = EmploymentInfo(employment.employmentId, Source.NOMIS, updateEmploymentRequest.updatedBy),
       personReference = PersonReference(dpsContactId = updatedEmployment.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactIntegrationTest.kt
@@ -175,7 +175,7 @@ class SyncPrisonerContactIntegrationTest : PostgresIntegrationTestBase() {
       }
       stubEvents.assertHasEvent(
         event = OutboundEvent.PRISONER_CONTACT_CREATED,
-        additionalInfo = PrisonerContactInfo(prisonerContact.id, Source.NOMIS, "SYS"),
+        additionalInfo = PrisonerContactInfo(prisonerContact.id, Source.NOMIS, "adminUser"),
         personReference = PersonReference(dpsContactId = prisonerContact.contactId, nomsNumber = prisonerContact.prisonerNumber),
       )
     }
@@ -248,7 +248,7 @@ class SyncPrisonerContactIntegrationTest : PostgresIntegrationTestBase() {
       }
       stubEvents.assertHasEvent(
         event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-        additionalInfo = PrisonerContactInfo(updatedPrisonerContact.id, Source.NOMIS, "SYS"),
+        additionalInfo = PrisonerContactInfo(updatedPrisonerContact.id, Source.NOMIS, "UpdatedUser"),
         personReference = PersonReference(dpsContactId = updatedPrisonerContact.contactId, nomsNumber = updatedPrisonerContact.prisonerNumber),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactRestrictionIntegrationTest.kt
@@ -161,7 +161,7 @@ class SyncPrisonerContactRestrictionIntegrationTest : PostgresIntegrationTestBas
       }
       stubEvents.assertHasEvent(
         event = OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED,
-        additionalInfo = PrisonerContactRestrictionInfo(prisonerContactRestriction.prisonerContactRestrictionId, Source.NOMIS, "SYS"),
+        additionalInfo = PrisonerContactRestrictionInfo(prisonerContactRestriction.prisonerContactRestrictionId, Source.NOMIS, "admin"),
         personReference = PersonReference(dpsContactId = prisonerContactRestriction.contactId, nomsNumber = prisonerContactRestriction.prisonerNumber),
       )
     }
@@ -222,7 +222,7 @@ class SyncPrisonerContactRestrictionIntegrationTest : PostgresIntegrationTestBas
       }
       stubEvents.assertHasEvent(
         event = OutboundEvent.PRISONER_CONTACT_RESTRICTION_UPDATED,
-        additionalInfo = PrisonerContactRestrictionInfo(updatedPrisonerContactRestriction.prisonerContactRestrictionId, Source.NOMIS, "SYS"),
+        additionalInfo = PrisonerContactRestrictionInfo(updatedPrisonerContactRestriction.prisonerContactRestrictionId, Source.NOMIS, "UpdatedUser"),
         personReference = PersonReference(dpsContactId = updatedPrisonerContactRestriction.contactId, nomsNumber = updatedPrisonerContactRestriction.prisonerNumber),
       )
     }


### PR DESCRIPTION
Where possible set the username for events based on created by or updated by fields in the request. This is unknown for delete events and also admin functions such as merge and reset where the user remains as SYS.