### PR TITLE
PRC-749: Add active caseload id to telemetry

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/manage/users/UserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/client/manage/users/UserDetails.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.client.manage.users
 data class UserDetails(
   val username: String,
   val name: String?,
+  val activeCaseloadId: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/User.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/User.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.config
 
-data class User(val username: String) {
+data class User(val username: String, val activeCaseloadId: String? = null) {
   companion object {
     val SYS_USER = User("SYS")
     const val REQUEST_ATTRIBUTE = "user"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/UserRequestContextConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/UserRequestContextConfiguration.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.config
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.servlet.HandlerInterceptor
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ManageUsersService
 import uk.gov.justice.hmpps.kotlin.auth.AuthAwareAuthenticationToken
 
 @Configuration
@@ -21,16 +23,30 @@ class UserRequestContextConfiguration(private val userRequestContextInterceptor:
 }
 
 @Configuration
-class UserRequestContextInterceptor : HandlerInterceptor {
+class UserRequestContextInterceptor(private val manageUsersService: ManageUsersService) : HandlerInterceptor {
+  companion object {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+  }
+
   override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
     val username = authentication().name?.trim()
     // Require a valid username for all modifying methods
     if (username === null && request.method in arrayOf("POST", "PUT", "PATCH", "DELETE")) {
       throw AccessDeniedException("Username is missing from token")
     }
-    val user = username?.let { User(username = it) } ?: User.SYS_USER
+    val user = username?.let { enrichUserIfPossible(it) } ?: User.SYS_USER
     request.setAttribute(User.REQUEST_ATTRIBUTE, user)
     return true
+  }
+
+  private fun enrichUserIfPossible(username: String): User {
+    val userDetails = try {
+      manageUsersService.getUserByUsername(username)
+    } catch (e: Exception) {
+      logger.error("Unhandled exception getting user {}", username, e)
+      null
+    }
+    return User(username = username, userDetails?.activeCaseloadId)
   }
 
   private fun authentication(): AuthAwareAuthenticationToken = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -295,12 +295,7 @@ enum class OutboundEvent(val eventType: String) {
  * This is inherited and expanded individually for each event type.
  */
 
-open class AdditionalInformation(open val source: Source, open val username: String) {
-  open fun toTelemetryValues(): List<Pair<String, String>> = listOf(
-    "source" to source.toString(),
-    "username" to username,
-  )
-}
+open class AdditionalInformation(open val source: Source, open val username: String, open val activeCaseloadId: String?)
 
 /**
  * The class representing outbound domain events
@@ -321,6 +316,7 @@ data class OutboundHMPPSDomainEvent(
     "occurred_at" to occurredAt.format(DateTimeFormatter.ISO_DATE_TIME),
     "source" to additionalInformation.source.toString(),
     "username" to additionalInformation.username,
+    "active_caseload_id" to (additionalInformation.activeCaseloadId ?: "unknown"),
   ).toMap()
 }
 
@@ -330,18 +326,18 @@ data class OutboundHMPPSDomainEvent(
  * The additional information is mapped into JSON by the ObjectMapper as part of the event body.
  */
 
-data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class EmploymentInfo(val employmentId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class PrisonerDomesticStatus(val domesticStatusId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
-data class PrisonerNumberOfChildren(val prisonerNumberOfChildrenId: Long, override val source: Source = Source.DPS, override val username: String) : AdditionalInformation(source, username)
+data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class EmploymentInfo(val employmentId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class PrisonerDomesticStatus(val domesticStatusId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
+data class PrisonerNumberOfChildren(val prisonerNumberOfChildrenId: Long, override val source: Source = Source.DPS, override val username: String, override val activeCaseloadId: String? = null) : AdditionalInformation(source, username, activeCaseloadId)
 
 /**
  * The event source.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -36,7 +36,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactInfo(identifier, source, user.username),
+            ContactInfo(identifier, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }
@@ -47,7 +47,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactAddressInfo(identifier, source, user.username),
+            ContactAddressInfo(identifier, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }
@@ -58,7 +58,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactPhoneInfo(identifier, source, user.username),
+            ContactPhoneInfo(identifier, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }
@@ -69,7 +69,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactAddressPhoneInfo(identifier, secondIdentifier!!, source, user.username),
+            ContactAddressPhoneInfo(identifier, secondIdentifier!!, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }
@@ -80,7 +80,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactEmailInfo(identifier, source, user.username),
+            ContactEmailInfo(identifier, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }
@@ -91,7 +91,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactIdentityInfo(identifier, source, user.username),
+            ContactIdentityInfo(identifier, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }
@@ -102,7 +102,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            ContactRestrictionInfo(identifier, source, user.username),
+            ContactRestrictionInfo(identifier, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(dpsContactId = it) },
           )
         }
@@ -113,7 +113,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            PrisonerContactInfo(identifier, source, user.username),
+            PrisonerContactInfo(identifier, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(dpsContactId = it, nomsNumber = noms) },
           )
         }
@@ -124,7 +124,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            PrisonerContactRestrictionInfo(identifier, source, user.username),
+            PrisonerContactRestrictionInfo(identifier, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(dpsContactId = it, nomsNumber = noms) },
           )
         }
@@ -135,7 +135,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            EmploymentInfo(identifier, source, user.username),
+            EmploymentInfo(identifier, source, user.username, user.activeCaseloadId),
             contactId?.let { PersonReference(it) },
           )
         }
@@ -145,7 +145,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            PrisonerDomesticStatus(identifier, source, user.username),
+            PrisonerDomesticStatus(identifier, source, user.username, user.activeCaseloadId),
             PersonReference(noms),
           )
         }
@@ -155,7 +155,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            PrisonerNumberOfChildren(identifier, source, user.username),
+            PrisonerNumberOfChildren(identifier, source, user.username, user.activeCaseloadId),
             PersonReference(noms),
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
@@ -711,4 +711,4 @@ fun createOrganisationSummary(
   businessPhoneNumberExtension,
 )
 
-fun aUser(username: String = "USER1"): User = User(username)
+fun aUser(username: String = "USER1", activeCaseloadId: String? = null): User = User(username, activeCaseloadId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
@@ -95,7 +95,7 @@ abstract class IntegrationTestBase {
   fun setCurrentUser(user: StubUser?) {
     testAPIClient.currentUser = user
     if (user != null && !user.isSystemUser) {
-      manageUsersApiMockServer.stubGetUser(UserDetails(username = user.username, name = user.displayName))
+      manageUsersApiMockServer.stubGetUser(UserDetails(username = user.username, name = user.displayName, activeCaseloadId = user.activeCaseloadId))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
@@ -178,6 +178,7 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
         createdRelationship.prisonerContactId,
         source = Source.DPS,
         "read_write_user",
+        "BXI",
       ),
       personReference = PersonReference(dpsContactId = contact.id, nomsNumber = request.relationship.prisonerNumber),
     )
@@ -236,6 +237,7 @@ class AddContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
         createdRelationship.prisonerContactId,
         source = Source.DPS,
         "read_write_user",
+        "BXI",
       ),
       personReference = PersonReference(dpsContactId = contact.id, nomsNumber = request.relationship.prisonerNumber),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
@@ -94,7 +94,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(savedContactId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(savedContactId, Source.DPS, "created", "BXI"),
     )
   }
 
@@ -118,7 +118,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(savedContactId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(savedContactId, Source.DPS, "created", "BXI"),
     )
   }
 
@@ -154,7 +154,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -179,14 +179,14 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
 
     created.phoneNumberIds.map {
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
-        additionalInfo = ContactAddressPhoneInfo(it, created.contactAddressId, Source.DPS, "created"),
+        additionalInfo = ContactAddressPhoneInfo(it, created.contactAddressId, Source.DPS, "created", "BXI"),
         personReference = PersonReference(dpsContactId = created.contactId),
       )
     }
@@ -229,7 +229,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -248,12 +248,12 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -272,7 +272,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasNoEvents(event = OutboundEvent.CONTACT_ADDRESS_UPDATED)
@@ -292,12 +292,12 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -316,7 +316,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasNoEvents(event = OutboundEvent.CONTACT_ADDRESS_UPDATED)
@@ -344,22 +344,22 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS, "created", "BXI"),
     )
   }
 
@@ -382,12 +382,12 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
@@ -171,7 +171,7 @@ class CreateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
-      additionalInfo = ContactAddressPhoneInfo(created.contactAddressPhoneId, created.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressPhoneInfo(created.contactAddressPhoneId, created.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactEmailIntegrationTest.kt
@@ -173,7 +173,7 @@ class CreateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_EMAIL_CREATED,
-      additionalInfo = ContactEmailInfo(created.contactEmailId, Source.DPS, "created"),
+      additionalInfo = ContactEmailInfo(created.contactEmailId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
@@ -202,7 +202,7 @@ class CreateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_CREATED,
-      additionalInfo = ContactIdentityInfo(created.contactIdentityId, Source.DPS, "created"),
+      additionalInfo = ContactIdentityInfo(created.contactIdentityId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -221,7 +221,7 @@ class CreateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_CREATED,
-      additionalInfo = ContactIdentityInfo(created.contactIdentityId, Source.DPS, "created"),
+      additionalInfo = ContactIdentityInfo(created.contactIdentityId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(created.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -199,7 +199,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "created"),
+      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactReturnedOnCreate.id),
     )
   }
@@ -231,14 +231,14 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "created"),
+      additionalInfo = ContactInfo(contactReturnedOnCreate.id, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactReturnedOnCreate.id),
     )
 
     contactReturnedOnCreate.identities.forEach { identity ->
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_IDENTITY_CREATED,
-        additionalInfo = ContactIdentityInfo(identity.contactIdentityId, Source.DPS, "created"),
+        additionalInfo = ContactIdentityInfo(identity.contactIdentityId, Source.DPS, "created", "BXI"),
         personReference = PersonReference(dpsContactId = contactReturnedOnCreate.id),
       )
     }
@@ -347,19 +347,19 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS, "created"),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(minimalCreated.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(minimalCreated.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_CREATED,
-      additionalInfo = ContactAddressInfo(everythingCreated.contactAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressInfo(everythingCreated.contactAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
@@ -370,6 +370,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
         everythingCreated.contactAddressId,
         Source.DPS,
         "created",
+        "BXI",
       ),
       personReference = PersonReference(dpsContactId = contactId),
     )
@@ -446,19 +447,19 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS, "created"),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(minimalCreated.contactPhoneId, Source.DPS, "created"),
+      additionalInfo = ContactPhoneInfo(minimalCreated.contactPhoneId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(everythingCreated.contactPhoneId, Source.DPS, "created"),
+      additionalInfo = ContactPhoneInfo(everythingCreated.contactPhoneId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
   }
@@ -502,19 +503,19 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS, "created"),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_EMAIL_CREATED,
-      additionalInfo = ContactEmailInfo(firstCreated!!.contactEmailId, Source.DPS, "created"),
+      additionalInfo = ContactEmailInfo(firstCreated!!.contactEmailId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_EMAIL_CREATED,
-      additionalInfo = ContactEmailInfo(secondCreated!!.contactEmailId, Source.DPS, "created"),
+      additionalInfo = ContactEmailInfo(secondCreated!!.contactEmailId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
   }
@@ -562,19 +563,19 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contactId, Source.DPS, "created"),
+      additionalInfo = ContactInfo(contactId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_CREATED,
-      additionalInfo = EmploymentInfo(firstCreated.employmentId, Source.DPS, "created"),
+      additionalInfo = EmploymentInfo(firstCreated.employmentId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_CREATED,
-      additionalInfo = EmploymentInfo(secondCreated.employmentId, Source.DPS, "created"),
+      additionalInfo = EmploymentInfo(secondCreated.employmentId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = contactId),
     )
   }
@@ -627,7 +628,7 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(contact.id, Source.DPS, "created"),
+      additionalInfo = ContactInfo(contact.id, Source.DPS, "created", "BXI"),
       personReference = PersonReference(contact.id),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
@@ -184,7 +184,7 @@ class CreateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(created.contactPhoneId, Source.DPS, "created"),
+      additionalInfo = ContactPhoneInfo(created.contactPhoneId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -205,7 +205,7 @@ class CreateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(created.contactPhoneId, Source.DPS, "created"),
+      additionalInfo = ContactPhoneInfo(created.contactPhoneId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactRestrictionIntegrationTest.kt
@@ -163,7 +163,7 @@ class CreateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_RESTRICTION_CREATED,
-      additionalInfo = ContactRestrictionInfo(created.contactRestrictionId, Source.DPS, "created"),
+      additionalInfo = ContactRestrictionInfo(created.contactRestrictionId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }
@@ -196,7 +196,7 @@ class CreateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_RESTRICTION_CREATED,
-      additionalInfo = ContactRestrictionInfo(created.contactRestrictionId, Source.DPS, "created"),
+      additionalInfo = ContactRestrictionInfo(created.contactRestrictionId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
@@ -191,13 +191,13 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "created"),
+      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.createdContact.id),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
-      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "created"),
+      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.createdContact.id, nomsNumber = request.relationship!!.prisonerNumber),
     )
   }
@@ -229,13 +229,13 @@ class CreateContactWithRelationshipIntegrationTest : PostgresIntegrationTestBase
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_CREATED,
-      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "created"),
+      additionalInfo = ContactInfo(created.createdContact.id, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.createdContact.id),
     )
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
-      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "created"),
+      additionalInfo = PrisonerContactInfo(created.createdRelationship!!.prisonerContactId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.createdContact.id, nomsNumber = request.relationship!!.prisonerNumber),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateEmploymentIntegrationTest.kt
@@ -99,7 +99,7 @@ class CreateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_CREATED,
-      additionalInfo = EmploymentInfo(created.employmentId, Source.DPS, "created"),
+      additionalInfo = EmploymentInfo(created.employmentId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleAddressPhoneIntegrationTest.kt
@@ -243,7 +243,7 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
     assertThat(mobile).isNotNull()
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
-      additionalInfo = ContactAddressPhoneInfo(mobile!!.contactAddressPhoneId, savedAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressPhoneInfo(mobile!!.contactAddressPhoneId, savedAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
 
@@ -251,7 +251,7 @@ class CreateMultipleAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase()
     assertThat(home).isNotNull()
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
-      additionalInfo = ContactAddressPhoneInfo(home!!.contactAddressPhoneId, savedAddressId, Source.DPS, "created"),
+      additionalInfo = ContactAddressPhoneInfo(home!!.contactAddressPhoneId, savedAddressId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleContactPhoneIntegrationTest.kt
@@ -206,7 +206,7 @@ class CreateMultipleContactPhoneIntegrationTest : SecureAPIIntegrationTestBase()
     assertThat(mobile).isNotNull()
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(mobile!!.contactPhoneId, Source.DPS, "created"),
+      additionalInfo = ContactPhoneInfo(mobile!!.contactPhoneId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
 
@@ -214,7 +214,7 @@ class CreateMultipleContactPhoneIntegrationTest : SecureAPIIntegrationTestBase()
     assertThat(home).isNotNull()
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_CREATED,
-      additionalInfo = ContactPhoneInfo(home!!.contactPhoneId, Source.DPS, "created"),
+      additionalInfo = ContactPhoneInfo(home!!.contactPhoneId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleEmailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleEmailsIntegrationTest.kt
@@ -208,7 +208,7 @@ class CreateMultipleEmailsIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_EMAIL_CREATED,
-        additionalInfo = ContactEmailInfo(createdEmailAddress!!.contactEmailId, Source.DPS, "created"),
+        additionalInfo = ContactEmailInfo(createdEmailAddress!!.contactEmailId, Source.DPS, "created", "BXI"),
         personReference = PersonReference(dpsContactId = savedContactId),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateMultipleIdentityIntegrationTest.kt
@@ -242,7 +242,7 @@ class CreateMultipleIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       assertThat(createdTime).isNotNull()
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_IDENTITY_CREATED,
-        additionalInfo = ContactIdentityInfo(contactIdentityId, Source.DPS, "created"),
+        additionalInfo = ContactIdentityInfo(contactIdentityId, Source.DPS, "created", "BXI"),
         personReference = PersonReference(savedContactId),
       )
     }
@@ -257,7 +257,7 @@ class CreateMultipleIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
       assertThat(createdTime).isNotNull()
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_IDENTITY_CREATED,
-        additionalInfo = ContactIdentityInfo(contactIdentityId, Source.DPS, "created"),
+        additionalInfo = ContactIdentityInfo(contactIdentityId, Source.DPS, "created", "BXI"),
         personReference = PersonReference(savedContactId),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateOrUpdatePrisonerDomesticStatusIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateOrUpdatePrisonerDomesticStatusIntegrationTest.kt
@@ -72,7 +72,7 @@ class CreateOrUpdatePrisonerDomesticStatusIntegrationTest : SecureAPIIntegration
       )
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_DOMESTIC_STATUS_CREATED,
-      additionalInfo = PrisonerDomesticStatus(response!!.id, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerDomesticStatus(response!!.id, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(nomsNumber = prisonerNumber),
     )
   }
@@ -109,7 +109,7 @@ class CreateOrUpdatePrisonerDomesticStatusIntegrationTest : SecureAPIIntegration
       )
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_DOMESTIC_STATUS_CREATED,
-      additionalInfo = PrisonerDomesticStatus(response!!.id, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerDomesticStatus(response!!.id, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(nomsNumber = prisonerNumber),
     )
   }
@@ -157,7 +157,7 @@ class CreateOrUpdatePrisonerDomesticStatusIntegrationTest : SecureAPIIntegration
       )
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_DOMESTIC_STATUS_CREATED,
-      additionalInfo = PrisonerDomesticStatus(response.id, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerDomesticStatus(response.id, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(nomsNumber = prisonerNumber),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateOrUpdatePrisonerNumberOfChildrenIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateOrUpdatePrisonerNumberOfChildrenIntegrationTest.kt
@@ -67,7 +67,7 @@ class CreateOrUpdatePrisonerNumberOfChildrenIntegrationTest : SecureAPIIntegrati
       )
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_NUMBER_OF_CHILDREN_CREATED,
-      additionalInfo = PrisonerNumberOfChildren(response!!.id, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerNumberOfChildren(response!!.id, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(nomsNumber = prisonerNumber),
     )
   }
@@ -103,7 +103,7 @@ class CreateOrUpdatePrisonerNumberOfChildrenIntegrationTest : SecureAPIIntegrati
       )
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_NUMBER_OF_CHILDREN_CREATED,
-      additionalInfo = PrisonerNumberOfChildren(response!!.id, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerNumberOfChildren(response!!.id, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(nomsNumber = prisonerNumber),
     )
   }
@@ -150,7 +150,7 @@ class CreateOrUpdatePrisonerNumberOfChildrenIntegrationTest : SecureAPIIntegrati
       )
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_NUMBER_OF_CHILDREN_CREATED,
-      additionalInfo = PrisonerNumberOfChildren(response.id, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerNumberOfChildren(response.id, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(nomsNumber = prisonerNumber),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreatePrisonerContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreatePrisonerContactRestrictionIntegrationTest.kt
@@ -151,7 +151,7 @@ class CreatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
   @Test
   fun `should create the restriction with minimal fields`() {
-    stubGetUserByUsername(UserDetails("created", "Created User"))
+    stubGetUserByUsername(UserDetails("created", "Created User", "BXI"))
     val request = CreatePrisonerContactRestrictionRequest(
       restrictionType = "BAN",
       startDate = LocalDate.of(2020, 1, 1),
@@ -178,7 +178,7 @@ class CreatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED,
-      additionalInfo = PrisonerContactRestrictionInfo(created.prisonerContactRestrictionId, Source.DPS, "created"),
+      additionalInfo = PrisonerContactRestrictionInfo(created.prisonerContactRestrictionId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId, nomsNumber = prisonerNumberCreatedAgainst),
     )
   }
@@ -187,7 +187,7 @@ class CreatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW"])
   fun `should create the restriction with all fields`(role: String) {
     setCurrentUser(StubUser.CREATING_USER.copy(roles = listOf(role)))
-    stubGetUserByUsername(UserDetails("created", "Created User"))
+    stubGetUserByUsername(UserDetails("created", "Created User", "BXI"))
     val request = CreatePrisonerContactRestrictionRequest(
       restrictionType = "BAN",
       startDate = LocalDate.of(2020, 1, 1),
@@ -214,7 +214,7 @@ class CreatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED,
-      additionalInfo = PrisonerContactRestrictionInfo(created.prisonerContactRestrictionId, Source.DPS, "created"),
+      additionalInfo = PrisonerContactRestrictionInfo(created.prisonerContactRestrictionId, Source.DPS, "created", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId, nomsNumber = prisonerNumberCreatedAgainst),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
@@ -70,7 +70,7 @@ class DeleteContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_DELETED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "deleted"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "deleted", "BXI"),
     )
   }
 
@@ -114,7 +114,7 @@ class DeleteContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_DELETED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "deleted"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "deleted", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
@@ -119,7 +119,7 @@ class DeleteContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED,
-      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId, Source.DPS, "deleted"),
+      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId, Source.DPS, "deleted", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactEmailIntegrationTest.kt
@@ -62,7 +62,7 @@ class DeleteContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_EMAIL_DELETED,
-      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "deleted"),
+      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "deleted", "BXI"),
     )
   }
 
@@ -83,7 +83,7 @@ class DeleteContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_EMAIL_DELETED,
-      additionalInfo = ContactEmailInfo(-99, Source.DPS, "deleted"),
+      additionalInfo = ContactEmailInfo(-99, Source.DPS, "deleted", "BXI"),
     )
   }
 
@@ -109,7 +109,7 @@ class DeleteContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_EMAIL_DELETED,
-      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "deleted"),
+      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "deleted", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactIdentityIntegrationTest.kt
@@ -63,7 +63,7 @@ class DeleteContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_IDENTITY_DELETED,
-      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "deleted"),
+      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "deleted", "BXI"),
     )
   }
 
@@ -84,7 +84,7 @@ class DeleteContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_IDENTITY_DELETED,
-      additionalInfo = ContactIdentityInfo(-99, Source.DPS, "deleted"),
+      additionalInfo = ContactIdentityInfo(-99, Source.DPS, "deleted", "BXI"),
     )
   }
 
@@ -108,7 +108,7 @@ class DeleteContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_DELETED,
-      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "deleted"),
+      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "deleted", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactPhoneIntegrationTest.kt
@@ -115,7 +115,7 @@ class DeleteContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_DELETED,
-      additionalInfo = ContactPhoneInfo(savedContactPhoneId, Source.DPS, "deleted"),
+      additionalInfo = ContactPhoneInfo(savedContactPhoneId, Source.DPS, "deleted", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -171,7 +171,7 @@ class DeleteContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_DELETED,
-      additionalInfo = ContactPhoneInfo(savedContactPhoneId, Source.DPS, "deleted"),
+      additionalInfo = ContactPhoneInfo(savedContactPhoneId, Source.DPS, "deleted", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteEmploymentIntegrationTest.kt
@@ -92,7 +92,7 @@ class DeleteEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_DELETED,
-      additionalInfo = EmploymentInfo(savedEmploymentId, Source.DPS, "deleted"),
+      additionalInfo = EmploymentInfo(savedEmploymentId, Source.DPS, "deleted", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
@@ -240,7 +240,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -261,7 +261,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -284,12 +284,12 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -312,7 +312,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -335,12 +335,12 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -363,7 +363,7 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -397,22 +397,22 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS, "updated", "BXI"),
     )
   }
 
@@ -442,12 +442,12 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactIntegrationTest.kt
@@ -58,7 +58,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -78,7 +78,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -95,7 +95,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported language (FOO)")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"))
     }
 
     @Test
@@ -113,7 +113,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -150,7 +150,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -168,7 +168,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -188,7 +188,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported interpreter required type null.")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"))
     }
 
     private fun resetInterpreterRequired(resetValue: Boolean) {
@@ -221,7 +221,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -240,7 +240,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -260,7 +260,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -277,7 +277,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported domestic status (FOO)")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"))
     }
 
     private fun resetDomesticStatus() {
@@ -312,7 +312,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -330,7 +330,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactId),
       )
     }
@@ -350,7 +350,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported staff flag value null.")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactId, Source.DPS, "read_write_user", "BXI"))
     }
 
     private fun resetStaffFlag(resetValue: Boolean) {
@@ -393,7 +393,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactIdThatHasDOB),
       )
     }
@@ -411,7 +411,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactIdThatHasDOB),
       )
     }
@@ -429,7 +429,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactIdThatHasDOB, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactIdThatHasDOB),
       )
     }
@@ -465,7 +465,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactThatHasAllNameFields),
       )
     }
@@ -497,7 +497,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactThatHasAllNameFields),
       )
     }
@@ -518,7 +518,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactThatHasAllNameFields),
       )
     }
@@ -539,7 +539,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactThatHasAllNameFields),
       )
     }
@@ -558,7 +558,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasNoEvents(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user", "BXI"),
       )
     }
 
@@ -576,7 +576,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasNoEvents(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactThatHasAllNameFields, Source.DPS, "read_write_user", "BXI"),
       )
     }
   }
@@ -608,7 +608,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactWithAGender),
       )
     }
@@ -625,7 +625,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactWithAGender),
       )
     }
@@ -642,7 +642,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactWithAGender, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactWithAGender),
       )
     }
@@ -659,7 +659,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported gender (FOO)")
 
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactWithAGender, Source.DPS, "read_write_user"))
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactWithAGender, Source.DPS, "read_write_user", "BXI"))
     }
   }
 
@@ -696,7 +696,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactWithDeceasedDate),
       )
     }
@@ -715,7 +715,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactWithDeceasedDate),
       )
     }
@@ -733,7 +733,7 @@ class PatchContactIntegrationTest : SecureAPIIntegrationTestBase() {
 
       stubEvents.assertHasEvent(
         event = OutboundEvent.CONTACT_UPDATED,
-        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "read_write_user"),
+        additionalInfo = ContactInfo(contactWithDeceasedDate, Source.DPS, "read_write_user", "BXI"),
         personReference = PersonReference(dpsContactId = contactWithDeceasedDate),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactRelationshipIntegrationTest.kt
@@ -125,7 +125,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].relationshipToPrisonerCode).isEqualTo("SIS")
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -187,7 +187,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].relationshipToPrisonerCode).isEqualTo("DR")
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -211,7 +211,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isNextOfKin).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -235,7 +235,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isApprovedVisitor).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -259,7 +259,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isEmergencyContact).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -283,7 +283,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].isRelationshipActive).isTrue
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -307,7 +307,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts[0].comments).isEqualTo("New comment")
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -328,7 +328,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertThat(updatedPrisonerContacts).hasSize(1)
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }
@@ -360,7 +360,7 @@ class PatchContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
     assertUpdatedPrisonerContactEquals(updatedPrisonerContacts[0], updateRequest)
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_UPDATED,
-      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user"),
+      additionalInfo = PrisonerContactInfo(prisonerContactId, Source.DPS, "read_write_user", "BXI"),
       personReference = PersonReference(prisonerNumber, prisonerContact.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchEmploymentsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchEmploymentsIntegrationTest.kt
@@ -211,22 +211,22 @@ class PatchEmploymentsIntegrationTest : SecureAPIIntegrationTestBase() {
     }
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_CREATED,
-      additionalInfo = EmploymentInfo(newEmployment.employmentId, source = Source.DPS, "updated"),
+      additionalInfo = EmploymentInfo(newEmployment.employmentId, source = Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_UPDATED,
-      additionalInfo = EmploymentInfo(employmentToBeUpdated.employmentId, source = Source.DPS, "updated"),
+      additionalInfo = EmploymentInfo(employmentToBeUpdated.employmentId, source = Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_DELETED,
-      additionalInfo = EmploymentInfo(employmentToBeDeleted.employmentId, source = Source.DPS, "updated"),
+      additionalInfo = EmploymentInfo(employmentToBeDeleted.employmentId, source = Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.EMPLOYMENT_UPDATED,
-      additionalInfo = EmploymentInfo(employmentToRemainUntouched.employmentId, source = Source.DPS, "updated"),
+      additionalInfo = EmploymentInfo(employmentToRemainUntouched.employmentId, source = Source.DPS, "updated", "BXI"),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
@@ -219,7 +219,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -242,7 +242,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -266,12 +266,12 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -295,7 +295,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -319,12 +319,12 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -348,7 +348,7 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -380,22 +380,22 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS, "updated", "BXI"),
     )
   }
 
@@ -424,12 +424,12 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
-      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
@@ -245,7 +245,7 @@ class UpdateContactAddressPhoneIntegrationTest : SecureAPIIntegrationTestBase() 
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED,
-      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId, Source.DPS, "updated"),
+      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactEmailIntegrationTest.kt
@@ -81,7 +81,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated"),
+      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated", "BXI"),
     )
   }
 
@@ -105,7 +105,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated"),
+      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated", "BXI"),
     )
   }
 
@@ -130,7 +130,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated"),
+      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated", "BXI"),
     )
   }
 
@@ -155,7 +155,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-      additionalInfo = ContactEmailInfo(-99, Source.DPS, "updated"),
+      additionalInfo = ContactEmailInfo(-99, Source.DPS, "updated", "BXI"),
     )
   }
 
@@ -182,7 +182,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-      additionalInfo = ContactEmailInfo(-99, Source.DPS, "updated"),
+      additionalInfo = ContactEmailInfo(-99, Source.DPS, "updated", "BXI"),
     )
   }
 
@@ -205,7 +205,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated"),
+      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -235,7 +235,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasNoEvents(
       event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-      additionalInfo = ContactEmailInfo(-99, Source.DPS, "updated"),
+      additionalInfo = ContactEmailInfo(-99, Source.DPS, "updated", "BXI"),
     )
   }
 
@@ -256,7 +256,7 @@ class UpdateContactEmailIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_EMAIL_UPDATED,
-      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated"),
+      additionalInfo = ContactEmailInfo(savedContactEmailId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
@@ -214,7 +214,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_UPDATED,
-      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "updated"),
+      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }
@@ -247,7 +247,7 @@ class UpdateContactIdentityIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_IDENTITY_UPDATED,
-      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "updated"),
+      additionalInfo = ContactIdentityInfo(savedContactIdentityId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
@@ -219,7 +219,7 @@ class UpdateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_UPDATED,
-      additionalInfo = ContactPhoneInfo(savedContactPhoneId, Source.DPS, "updated"),
+      additionalInfo = ContactPhoneInfo(savedContactPhoneId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(savedContactId),
     )
   }
@@ -248,7 +248,7 @@ class UpdateContactPhoneIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_PHONE_UPDATED,
-      additionalInfo = ContactPhoneInfo(savedContactPhoneId, Source.DPS, "updated"),
+      additionalInfo = ContactPhoneInfo(savedContactPhoneId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactRestrictionIntegrationTest.kt
@@ -199,7 +199,7 @@ class UpdateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_RESTRICTION_UPDATED,
-      additionalInfo = ContactRestrictionInfo(updated.contactRestrictionId, Source.DPS, "updated"),
+      additionalInfo = ContactRestrictionInfo(updated.contactRestrictionId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }
@@ -238,7 +238,7 @@ class UpdateContactRestrictionIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_RESTRICTION_UPDATED,
-      additionalInfo = ContactRestrictionInfo(updated.contactRestrictionId, Source.DPS, "updated"),
+      additionalInfo = ContactRestrictionInfo(updated.contactRestrictionId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateEmploymentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateEmploymentIntegrationTest.kt
@@ -132,7 +132,7 @@ class UpdateEmploymentIntegrationTest : SecureAPIIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.EMPLOYMENT_UPDATED,
-      additionalInfo = EmploymentInfo(updated.employmentId, Source.DPS, "updated"),
+      additionalInfo = EmploymentInfo(updated.employmentId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = updated.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdatePrisonerContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdatePrisonerContactRestrictionIntegrationTest.kt
@@ -196,7 +196,7 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
   @Test
   fun `should update the restriction with minimal fields`() {
-    stubGetUserByUsername(UserDetails("updated", "Updated User"))
+    stubGetUserByUsername(UserDetails("updated", "Updated User", "BXI"))
     val request = UpdatePrisonerContactRestrictionRequest(
       restrictionType = "CCTV",
       startDate = LocalDate.of(1990, 1, 1),
@@ -230,7 +230,7 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_RESTRICTION_UPDATED,
-      additionalInfo = PrisonerContactRestrictionInfo(updated.prisonerContactRestrictionId, Source.DPS, "updated"),
+      additionalInfo = PrisonerContactRestrictionInfo(updated.prisonerContactRestrictionId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId, nomsNumber = prisonerNumberCreatedAgainst),
     )
   }
@@ -239,7 +239,7 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW"])
   fun `should update the restriction with all fields`(role: String) {
     setCurrentUser(StubUser.UPDATING_USER.copy(roles = listOf(role)))
-    stubGetUserByUsername(UserDetails("updated", "Updated User"))
+    stubGetUserByUsername(UserDetails("updated", "Updated User", "BXI"))
     val request = UpdatePrisonerContactRestrictionRequest(
       restrictionType = "CCTV",
       startDate = LocalDate.of(1990, 1, 1),
@@ -272,7 +272,7 @@ class UpdatePrisonerContactRestrictionIntegrationTest : SecureAPIIntegrationTest
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_RESTRICTION_UPDATED,
-      additionalInfo = PrisonerContactRestrictionInfo(updated.prisonerContactRestrictionId, Source.DPS, "updated"),
+      additionalInfo = PrisonerContactRestrictionInfo(updated.prisonerContactRestrictionId, Source.DPS, "updated", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId, nomsNumber = prisonerNumberCreatedAgainst),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigrateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigrateContactIntegrationTest.kt
@@ -55,7 +55,7 @@ class MigrateContactIntegrationTest : PostgresIntegrationTestBase() {
   @ParameterizedTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
   fun `should return forbidden without an authorised role on the token`(authRole: String) {
-    setCurrentUser(StubUser(authRole, authRole, listOf(authRole), caseload = null, isSystemUser = true))
+    setCurrentUser(StubUser(authRole, authRole, listOf(authRole), activeCaseloadId = null, isSystemUser = true))
     webTestClient.post()
       .uri("/migrate/contact")
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/wiremock/ManageUsersApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/wiremock/ManageUsersApiMockServer.kt
@@ -20,6 +20,7 @@ class ManageUsersApiMockServer : MockServer(8093) {
                 {
                   "username": "${user.username}",
                   "name": "${user.name}"
+                  ${user.activeCaseloadId?.let {", \"activeCaseloadId\": \"${user.activeCaseloadId}\""} ?: ""}
                 }
               """.trimIndent(),
             )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
@@ -407,7 +407,7 @@ class OutboundEventsServiceTest {
       1L,
       1L,
       "A1234AA",
-      user = aUser("restriction_user"),
+      user = aUser("restriction_user", "CLI"),
     )
     verify(
       expectedEventType = "contacts-api.prisoner-contact-restriction.created",
@@ -415,6 +415,7 @@ class OutboundEventsServiceTest {
         prisonerContactRestrictionId = 1L,
         source = Source.DPS,
         username = "restriction_user",
+        activeCaseloadId = "CLI",
       ),
       expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact restriction has been created",
@@ -511,6 +512,11 @@ class OutboundEventsServiceTest {
       assertThat(properties()["source"]).isEqualTo(expectedAdditionalInformation.source.toString())
       assertThat(properties()["username"]).isEqualTo(expectedAdditionalInformation.username)
       assertThat(properties()["occurred_at"]).isNotNull()
+      if (expectedAdditionalInformation.activeCaseloadId != null) {
+        assertThat(properties()["active_caseload_id"]).isEqualTo(expectedAdditionalInformation.activeCaseloadId)
+      } else {
+        assertThat(properties()["active_caseload_id"]).isEqualTo("unknown")
+      }
     }
 
     verifyNoMoreInteractions(eventsPublisher)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/StubUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/util/StubUser.kt
@@ -4,18 +4,18 @@ data class StubUser(
   val username: String,
   val displayName: String,
   val roles: List<String>,
-  val caseload: String? = null,
+  val activeCaseloadId: String? = null,
   // isSystemUser indicates a user that does not have a user_name claim, i.e. syscon
   val isSystemUser: Boolean = false,
 ) {
   companion object {
     val USER_WITH_NO_ROLES = StubUser("unauthorised", "Unauthorised", emptyList())
     val USER_WITH_WRONG_ROLES = StubUser("wrong_roles", "Wrong", listOf("ROLE_WRONG"))
-    val SYNC_AND_MIGRATE_USER = StubUser("sys", "System", listOf("PERSONAL_RELATIONSHIPS_MIGRATION"), caseload = null, isSystemUser = true)
-    val READ_ONLY_USER = StubUser("read_only_user", "Read Only", listOf("ROLE_CONTACTS__R"), caseload = "BXI")
-    val READ_WRITE_USER = StubUser("read_write_user", "Read Write", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
-    val CREATING_USER = StubUser("created", "Created", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
-    val UPDATING_USER = StubUser("updated", "Updated", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
-    val DELETING_USER = StubUser("deleted", "Deleted", listOf("ROLE_CONTACTS__RW"), caseload = "BXI")
+    val SYNC_AND_MIGRATE_USER = StubUser("sys", "System", listOf("PERSONAL_RELATIONSHIPS_MIGRATION"), activeCaseloadId = null, isSystemUser = true)
+    val READ_ONLY_USER = StubUser("read_only_user", "Read Only", listOf("ROLE_CONTACTS__R"), activeCaseloadId = "BXI")
+    val READ_WRITE_USER = StubUser("read_write_user", "Read Write", listOf("ROLE_CONTACTS__RW"), activeCaseloadId = "BXI")
+    val CREATING_USER = StubUser("created", "Created", listOf("ROLE_CONTACTS__RW"), activeCaseloadId = "BXI")
+    val UPDATING_USER = StubUser("updated", "Updated", listOf("ROLE_CONTACTS__RW"), activeCaseloadId = "BXI")
+    val DELETING_USER = StubUser("deleted", "Deleted", listOf("ROLE_CONTACTS__RW"), activeCaseloadId = "BXI")
   }
 }


### PR DESCRIPTION
Currently only set for DPS API calls