### PR TITLE
Suppress gatling deps from dependency check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,10 @@ tasks {
   }
 }
 
+dependencyCheck {
+  suppressionFiles.add("dependencyCheck/suppression.xml")
+}
+
 val configValues = mapOf(
   "dateLibrary" to "java8-localdatetime",
   "serializationLibrary" to "jackson",

--- a/dependencyCheck/suppression.xml
+++ b/dependencyCheck/suppression.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <!-- Dependencies of Gatling gradle plugin, not used in production code -->
+    <suppress>
+        <notes><![CDATA[
+      file name: pebble-3.2.4.jar
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.pebbletemplates/pebble@.*$</packageUrl>
+        <cve>CVE-2025-1686</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    file name: pebble-3.2.4.jar
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.pebbletemplates/pebble@.*$</packageUrl>
+        <cve>CVE-2022-37767</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+      file name: xercesImpl-2.12.2.jar
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/xerces/xercesImpl@.*$</packageUrl>
+        <vulnerabilityName>CVE-2017-10355</vulnerabilityName>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
The listed high priority CVEs are all considered to be false positives by the library authors. We also don't package gatling with production code so it is being suppressed.