### PR TITLE
PRC-767: Only check prisoner exists if no results

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerService.kt
@@ -1,11 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.PrisonerSearchClient
 
 @Service
 class PrisonerService(private val prisonerSearchClient: PrisonerSearchClient) {
+  fun checkPrisonerExists(prisonerNumber: String) {
+    getPrisoner(prisonerNumber) ?: throw EntityNotFoundException("Prisoner not found ($prisonerNumber)")
+  }
   fun getPrisoner(prisonerNumber: String): Prisoner? = prisonerSearchClient.getPrisoner(prisonerNumber)
   fun getPrisoners(prisonerNumbers: Set<String>): List<Prisoner> = prisonerSearchClient.getPrisoners(prisonerNumbers)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsIntegrationTest.kt
@@ -40,14 +40,31 @@ class GetPrisonerContactsIntegrationTest : SecureAPIIntegrationTestBase() {
 
   @Test
   fun `should return not found if no prisoner found`() {
-    stubPrisonSearchWithNotFoundResponse("A4385DZ")
+    stubPrisonSearchWithNotFoundResponse("A9999AA")
 
     webTestClient.get()
-      .uri("/prisoner/A4385DZ/contact")
+      .uri("/prisoner/A9999AA/contact")
       .headers(setAuthorisationUsingCurrentUser())
       .exchange()
       .expectStatus()
       .isNotFound
+  }
+
+  @Test
+  fun `should return no results if no contacts`() {
+    stubPrisonSearchWithResponse("A9999AA")
+
+    val contacts = webTestClient.get()
+      .uri("/prisoner/A9999AA/contact")
+      .headers(setAuthorisationUsingCurrentUser())
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(PrisonerContactSummaryResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(contacts.content).hasSize(0)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerServiceTest.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
+
+import jakarta.persistence.EntityNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.Prisoner
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.PrisonerSearchClient
+
+class PrisonerServiceTest {
+  private val prisonerSearchClient: PrisonerSearchClient = mock()
+  private val service = PrisonerService(prisonerSearchClient)
+  private val prisonerNumber = "A1234BC"
+  private val prisoner = Prisoner(prisonerNumber, "BXI", "Brixton", "Last", "First", "Middle Names")
+
+  @Test
+  fun `check should do nothing if prisoner exists`() {
+    whenever(prisonerSearchClient.getPrisoner(prisonerNumber)).thenReturn(prisoner)
+
+    service.checkPrisonerExists(prisonerNumber)
+
+    verify(prisonerSearchClient).getPrisoner(prisonerNumber)
+  }
+
+  @Test
+  fun `check should throw exception if prisoner not found`() {
+    whenever(prisonerSearchClient.getPrisoner(prisonerNumber)).thenReturn(null)
+
+    val exception = assertThrows<EntityNotFoundException> {
+      service.checkPrisonerExists(prisonerNumber)
+    }
+
+    assertThat(exception.message).isEqualTo("Prisoner not found (A1234BC)")
+    verify(prisonerSearchClient).getPrisoner(prisonerNumber)
+  }
+
+  @Test
+  fun `get prisoner should return a prisoner`() {
+    whenever(prisonerSearchClient.getPrisoner(prisonerNumber)).thenReturn(prisoner)
+
+    val result = service.getPrisoner(prisonerNumber)
+
+    assertThat(result).isEqualTo(prisoner)
+    verify(prisonerSearchClient).getPrisoner(prisonerNumber)
+  }
+
+  @Test
+  fun `get prisoner should return null if prisoner not found`() {
+    whenever(prisonerSearchClient.getPrisoner(prisonerNumber)).thenReturn(null)
+
+    val result = service.getPrisoner(prisonerNumber)
+
+    assertThat(result).isNull()
+    verify(prisonerSearchClient).getPrisoner(prisonerNumber)
+  }
+
+  @Test
+  fun `should return all prisoners`() {
+    val anotherPrisonerNumber = "Z1234YX"
+    val anotherPrisoner = Prisoner(anotherPrisonerNumber, "BXI", "Brixton", "Last", "First", "Middle Names")
+    whenever(prisonerSearchClient.getPrisoners(setOf(prisonerNumber, anotherPrisonerNumber))).thenReturn(listOf(prisoner, anotherPrisoner))
+
+    val result = service.getPrisoners(setOf(prisonerNumber, anotherPrisonerNumber))
+
+    assertThat(result).isEqualTo(listOf(prisoner, anotherPrisoner))
+    verify(prisonerSearchClient).getPrisoners(setOf(prisonerNumber, anotherPrisonerNumber))
+  }
+}


### PR DESCRIPTION
For contact list only check the prisoner exists if we get no results, this prevents unnecessary calls to prisoner service.