### PR TITLE
PRC-775: Deleted relationships history

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/DeletedPrisonerContactEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/DeletedPrisonerContactEntity.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "deleted_prisoner_contact")
+data class DeletedPrisonerContactEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val deletedPrisonerContactId: Long,
+
+  val prisonerContactId: Long,
+
+  val contactId: Long,
+
+  val prisonerNumber: String,
+
+  val relationshipType: String?,
+
+  val relationshipToPrisoner: String?,
+
+  val nextOfKin: Boolean?,
+
+  val emergencyContact: Boolean?,
+
+  val comments: String?,
+
+  val active: Boolean?,
+
+  val approvedVisitor: Boolean?,
+
+  val currentTerm: Boolean?,
+
+  val createdBy: String?,
+
+  val createdTime: LocalDateTime?,
+
+  val approvedBy: String?,
+
+  val approvedTime: LocalDateTime?,
+
+  val expiryDate: LocalDate?,
+
+  val createdAtPrison: String?,
+
+  val updatedBy: String?,
+
+  val updatedTime: LocalDateTime?,
+
+  val deletedBy: String,
+
+  val deletedTime: LocalDateTime,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactFacade.kt
@@ -148,7 +148,7 @@ class ContactFacade(
   }
 
   fun deleteContactRelationship(prisonerContactId: Long, user: User) {
-    contactService.deleteContactRelationship(prisonerContactId)
+    contactService.deleteContactRelationship(prisonerContactId, user)
       .also {
         outboundEventsService.send(
           outboundEvent = OutboundEvent.PRISONER_CONTACT_DELETED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/DeletedPrisonerContactRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/DeletedPrisonerContactRepository.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.DeletedPrisonerContactEntity
+
+@Repository
+interface DeletedPrisonerContactRepository : JpaRepository<DeletedPrisonerContactEntity, Long> {
+  fun findByPrisonerContactId(prisonerContactId: Long): List<DeletedPrisonerContactEntity>
+}

--- a/src/main/resources/migrations/common/V2025.06.02.35__create_deleted_prison_contacts.sql
+++ b/src/main/resources/migrations/common/V2025.06.02.35__create_deleted_prison_contacts.sql
@@ -1,0 +1,27 @@
+-- Table to keep a history of deleted prisoner contacts
+
+CREATE TABLE deleted_prisoner_contact
+(
+    deleted_prisoner_contact_id bigserial      NOT NULL CONSTRAINT deleted_prisoner_contact_id_pk PRIMARY KEY,
+    prisoner_contact_id         bigint         NOT NULL,
+    contact_id                  bigint         NOT NULL,
+    prisoner_number             varchar(7)     NOT NULL,
+    active                      boolean,
+    relationship_type           varchar(12),
+    relationship_to_prisoner    varchar(12),
+    current_term                boolean,
+    approved_visitor            boolean,
+    next_of_kin                 boolean,
+    emergency_contact           boolean,
+    comments                    varchar(240),
+    approved_by                 varchar(100),
+    approved_time               timestamp,
+    expiry_date                 date,
+    created_at_prison           varchar(5),
+    created_by                  varchar(100),
+    created_time                timestamp,
+    updated_by                  varchar(100),
+    updated_time                timestamp,
+    deleted_by                  varchar(100)   NOT NULL,
+    deleted_time                timestamp      NOT NULL
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactRelationshipIntegrationTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -11,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelati
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.restrictions.CreateContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.restrictions.CreatePrisonerContactRestrictionRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.DeletedPrisonerContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PrisonerContactInfo
@@ -25,6 +27,9 @@ class DeleteContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() 
   private var savedPrisonerContactId = 0L
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW")
+
+  @Autowired
+  private lateinit var deletedPrisonerContactRepository: DeletedPrisonerContactRepository
 
   @BeforeEach
   fun initialiseData() {
@@ -103,6 +108,8 @@ class DeleteContactRelationshipIntegrationTest : SecureAPIIntegrationTestBase() 
       additionalInfo = PrisonerContactInfo(savedPrisonerContactId, Source.DPS, "deleted", "BXI"),
       personReference = PersonReference(dpsContactId = savedContactId, nomsNumber = prisonerNumber),
     )
+    val deleted = deletedPrisonerContactRepository.findByPrisonerContactId(savedPrisonerContactId)
+    assertThat(deleted).isNotNull
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactFacadeTest.kt
@@ -376,13 +376,13 @@ class ContactFacadeTest {
       val prisonerNumber = "A1234BC"
       val user = aUser("deleted")
 
-      whenever(contactService.deleteContactRelationship(prisonerContactId)).thenReturn(
+      whenever(contactService.deleteContactRelationship(prisonerContactId, user)).thenReturn(
         DeletedRelationshipIds(contactId, prisonerNumber, prisonerContactId),
       )
 
       contactFacade.deleteContactRelationship(prisonerContactId, user)
 
-      verify(contactService).deleteContactRelationship(prisonerContactId)
+      verify(contactService).deleteContactRelationship(prisonerContactId, user)
       verify(outboundEventsService).send(
         OutboundEvent.PRISONER_CONTACT_DELETED,
         prisonerContactId,
@@ -400,14 +400,14 @@ class ContactFacadeTest {
       val user = aUser("deleted")
       val expectedException = RuntimeException("Boom")
 
-      whenever(contactService.deleteContactRelationship(prisonerContactId)).thenThrow(expectedException)
+      whenever(contactService.deleteContactRelationship(prisonerContactId, user)).thenThrow(expectedException)
 
       val exception = assertThrows<RuntimeException> {
         contactFacade.deleteContactRelationship(prisonerContactId, user)
       }
 
       assertThat(exception).isEqualTo(expectedException)
-      verify(contactService).deleteContactRelationship(prisonerContactId)
+      verify(contactService).deleteContactRelationship(prisonerContactId, user)
       verify(outboundEventsService, never()).send(
         OutboundEvent.PRISONER_CONTACT_DELETED,
         prisonerContactId,


### PR DESCRIPTION
When a relationship is deleted via the DPS API keep a copy of the relationship with the deleting user.