### PR TITLE
PRC-803 : migrate single restriction of the prisoner

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigratePrisonerRestrictionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigratePrisonerRestrictionRequest.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Schema(description = "Request to migrate a prisoner's restriction")
+data class MigratePrisonerRestrictionRequest(
+
+  @Schema(description = "The restriction type", example = "NO_VISIT")
+  @field:Size(max = 12, message = "restrictionType must be less than or equal to 12 characters")
+  val restrictionType: String,
+
+  @Schema(description = "Effective date of the restriction", example = "2024-06-11")
+  val effectiveDate: LocalDate,
+
+  @Schema(description = "Expiry date of the restriction", example = "2024-12-31")
+  val expiryDate: LocalDate? = null,
+
+  @Schema(description = "Comment text", example = "No visits allowed")
+  @field:Size(max = 240, message = "commentText must be less than or equal to 240 characters")
+  val commentText: String? = null,
+
+  @Schema(description = "Authorised staff user name", example = "JSMITH")
+  @field:NotNull(message = "The NOMIS authorised staff user name must be present in the request")
+  val authorisedUsername: String,
+
+  @Schema(description = "True if this restriction applies to the latest or current term in prison, false if a previous term", example = "true")
+  val currentTerm: Boolean,
+
+  @Schema(description = "Username of the person who created the record", example = "JSMITH_ADM")
+  val createdBy: String,
+
+  @Schema(description = "Timestamp when the record was created")
+  val createdTime: LocalDateTime,
+
+  @Schema(description = "Username of the person who last updated the record", example = "JDOE_ADM")
+  val updatedBy: String? = null,
+
+  @Schema(description = "Timestamp when the record was last updated")
+  val updatedTime: LocalDateTime? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/PrisonerRestrictionMigrationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/PrisonerRestrictionMigrationResponse.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Response after migrating prisoner restriction")
+data class PrisonerRestrictionMigrationResponse(
+  @Schema(description = "The prisoner number", example = "A1234BC")
+  val prisonerNumber: String,
+
+  @Schema(description = "ID of the migrated restriction record")
+  val prisonerRestrictionId: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigratePrisonerRestrictionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigratePrisonerRestrictionController.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.resource.migrate
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigratePrisonerRestrictionRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.PrisonerRestrictionMigrationResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.PrisonerRestrictionsMigrationService
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+
+@Tag(name = "Migrate and sync")
+@RestController
+@RequestMapping(value = ["migrate/prisoner-restriction/{prisonerNumber}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@AuthApiResponses
+class MigratePrisonerRestrictionController(
+  private val migrationService: PrisonerRestrictionsMigrationService,
+) {
+  @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @Operation(
+    summary = "Migrate restriction for prisoner",
+    description = "Migrate a prisoner's restriction from NOMIS.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The restriction was migrated successfully",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = PrisonerRestrictionMigrationResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The request failed validation with invalid or missing data supplied",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Could not find reference data for the supplied restriction type",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('PERSONAL_RELATIONSHIPS_MIGRATION')")
+  fun migratePrisonerRestrictions(
+    @Parameter(description = "The internal ID for the prisoner in NOMIS.", required = true)
+    @PathVariable prisonerNumber: String,
+    @Valid @RequestBody request: MigratePrisonerRestrictionRequest,
+  ): PrisonerRestrictionMigrationResponse = migrationService.migratePrisonerRestriction(prisonerNumber, request)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigratePrisonerRestrictionsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigratePrisonerRestrictionsIntegrationTest.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.migra
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.PostgresIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigratePrisonerRestrictionRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigratePrisonerRestrictionsRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.PrisonerRestrictionDetailsRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.PrisonerRestrictionsMigrationResponse
@@ -26,228 +28,328 @@ class MigratePrisonerRestrictionsIntegrationTest : PostgresIntegrationTestBase()
     setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER)
   }
 
-  @Test
-  fun `should return unauthorized if no token provided`() {
-    webTestClient.post()
-      .uri("/migrate/prisoner-restrictions")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(
-        basicMigrationRequest(
-          restrictionsList = listOf(
-            prisonerRestrictionDetailsRequest(),
+  @Nested
+  inner class PrisonerRestrictionsMerge {
+
+    @Test
+    fun `should return unauthorized if no token provided`() {
+      webTestClient.post()
+        .uri("/migrate/prisoner-restrictions")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+          basicMigrationRequest(
+            restrictionsList = listOf(
+              prisonerRestrictionDetailsRequest(),
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
+    fun `should return forbidden without an authorised role on the token`(authRole: String) {
+      setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER.copy(roles = listOf(authRole)))
+      webTestClient.post()
+        .uri("/migrate/prisoner-restrictions")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+          basicMigrationRequest(
+            restrictionsList = listOf(
+              prisonerRestrictionDetailsRequest(),
+            ),
+          ),
+        )
+        .headers(setAuthorisationUsingCurrentUser())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should migrate prisoner restrictions and return IDs`() {
+      val request = basicMigrationRequest(
+        restrictionsList = listOf(
+          prisonerRestrictionDetailsRequest(),
+          prisonerRestrictionDetailsRequest(restrictionType = "DIHCON"),
+          prisonerRestrictionDetailsRequest(restrictionType = "NONCON"),
+        ),
+      )
+
+      webTestClient.post()
+        .uri("/migrate/prisoner-restrictions")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(PrisonerRestrictionsMigrationResponse::class.java)
+        .consumeWith { response ->
+          assertThat(response.responseBody?.prisonerNumber).isEqualTo("A1234ZZ")
+          assertThat(response.responseBody?.prisonerRestrictionsIds).isNotEmpty
+        }
+
+      val restrictions = prisonerRestrictionsRepository.findByPrisonerNumber("A1234ZZ")
+      assertThat(restrictions).hasSize(3)
+      assertThat(restrictions[0].restrictionType).isEqualTo("CCTV")
+      assertThat(restrictions[0].commentText).isEqualTo("No visits allowed")
+
+      assertThat(restrictions[1].restrictionType).isEqualTo("DIHCON")
+      assertThat(restrictions[1].commentText).isEqualTo("No visits allowed")
+
+      assertThat(restrictions[2].restrictionType).isEqualTo("NONCON")
+      assertThat(restrictions[2].commentText).isEqualTo("No visits allowed")
+    }
+
+    @Test
+    fun `should not migrate prisoner restrictions when comment text max size validation failed`() {
+      val invalidRequest = basicMigrationRequest(
+        restrictionsList = listOf(
+          prisonerRestrictionDetailsRequest(
+            commentText = "a".repeat(241),
+            authorisedUsername = "JSMITH",
           ),
         ),
       )
-      .exchange()
-      .expectStatus()
-      .isUnauthorized
-  }
 
-  @ParameterizedTest
-  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
-  fun `should return forbidden without an authorised role on the token`(authRole: String) {
-    setCurrentUser(StubUser.SYNC_AND_MIGRATE_USER.copy(roles = listOf(authRole)))
-    webTestClient.post()
-      .uri("/migrate/prisoner-restrictions")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(
-        basicMigrationRequest(
-          restrictionsList = listOf(
-            prisonerRestrictionDetailsRequest(),
+      webTestClient.post()
+        .uri("/migrate/prisoner-restrictions")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(invalidRequest)
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.userMessage")
+        .value { userMessage: String ->
+          assertThat(userMessage).contains("restrictions[0].commentText must be less than or equal to 240 characters")
+        }
+    }
+
+    @Test
+    fun `should not migrate prisoner restrictions when restriction type max size validation failed`() {
+      val invalidRequest = basicMigrationRequest(
+        restrictionsList = listOf(
+          prisonerRestrictionDetailsRequest(restrictionType = "LONGER_THAN_12_CHARACTERS"),
+          prisonerRestrictionDetailsRequest(restrictionType = "invalid"),
+        ),
+      )
+
+      webTestClient.post()
+        .uri("/migrate/prisoner-restrictions")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(invalidRequest)
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.userMessage")
+        .isEqualTo(
+          "Validation failure(s): " +
+            "restrictions[0].restrictionType must be less than or equal to 12 characters",
+        )
+    }
+
+    @Test
+    fun `should not migrate prisoner restrictions when invalid restriction type`() {
+      val invalidRequest = basicMigrationRequest(
+        restrictionsList = listOf(
+          prisonerRestrictionDetailsRequest(restrictionType = "CCTV"),
+          prisonerRestrictionDetailsRequest(restrictionType = "invalid"),
+        ),
+      )
+
+      webTestClient.post()
+        .uri("/migrate/prisoner-restrictions")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(invalidRequest)
+        .exchange()
+        .expectStatus()
+        .isNotFound
+        .expectBody()
+        .jsonPath("$.userMessage")
+        .isEqualTo(
+          "Entity not found : No reference data found for groupCode: ReferenceCodeGroup.RESTRICTION and code: invalid",
+        )
+    }
+
+    @Test
+    fun `should not migrate prisoner restrictions when restrictions list is empty`() {
+      val invalidRequest = basicMigrationRequest(
+        restrictionsList = emptyList(),
+      )
+
+      webTestClient.post()
+        .uri("/migrate/prisoner-restrictions")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(invalidRequest)
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.userMessage")
+        .isEqualTo("Validation failure(s): restrictions must contain at least one record")
+    }
+
+    @Test
+    fun `should delete existing restrictions before migration`() {
+      webTestClient.post()
+        .uri("/migrate/prisoner-restrictions")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+          basicMigrationRequest(
+            prisonerNumber = "A1234ZZ",
+            restrictionsList = listOf(
+              prisonerRestrictionDetailsRequest(restrictionType = "CCTV"),
+              prisonerRestrictionDetailsRequest(restrictionType = "BAN"),
+              prisonerRestrictionDetailsRequest(restrictionType = "CHILD"),
+            ),
           ),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(PrisonerRestrictionsMigrationResponse::class.java)
+        .consumeWith { response ->
+          assertThat(response.responseBody?.prisonerNumber).isEqualTo("A1234ZZ")
+          assertThat(response.responseBody?.prisonerRestrictionsIds).hasSize(3)
+        }
+
+      val request = basicMigrationRequest(
+        prisonerNumber = "A1234ZZ",
+        restrictionsList = listOf(
+          prisonerRestrictionDetailsRequest(restrictionType = "DIHCON"),
+          prisonerRestrictionDetailsRequest(restrictionType = "NONCON"),
         ),
       )
-      .headers(setAuthorisationUsingCurrentUser())
-      .exchange()
-      .expectStatus()
-      .isForbidden
+
+      webTestClient.post()
+        .uri("/migrate/prisoner-restrictions")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(PrisonerRestrictionsMigrationResponse::class.java)
+        .consumeWith { response ->
+          assertThat(response.responseBody?.prisonerNumber).isEqualTo("A1234ZZ")
+          assertThat(response.responseBody?.prisonerRestrictionsIds).hasSize(2)
+        }
+
+      val restrictions = prisonerRestrictionsRepository.findByPrisonerNumber("A1234ZZ")
+      assertThat(restrictions).hasSize(2)
+      assertThat(restrictions.map { it.restrictionType }).containsExactlyInAnyOrder("DIHCON", "NONCON")
+    }
   }
 
-  @Test
-  fun `should migrate prisoner restrictions and return IDs`() {
-    val request = basicMigrationRequest(
-      restrictionsList = listOf(
-        prisonerRestrictionDetailsRequest(),
-        prisonerRestrictionDetailsRequest(restrictionType = "DIHCON"),
-        prisonerRestrictionDetailsRequest(restrictionType = "NONCON"),
-      ),
+  @Nested
+  inner class PrisonerRestrictionMerge {
+    @Test
+    fun `should migrate a single prisoner restriction`() {
+      val request = migratePrisonerRestrictionRequest()
+
+      webTestClient.post()
+        .uri("/migrate/prisoner-restriction/A1234ZZ")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .jsonPath("$.prisonerNumber").isEqualTo("A1234ZZ")
+        .jsonPath("$.prisonerRestrictionId").isNumber
+
+      val restrictions = prisonerRestrictionsRepository.findByPrisonerNumber("A1234ZZ")
+      assertThat(restrictions).hasSize(1)
+      assertThat(restrictions[0].restrictionType).isEqualTo("CCTV")
+    }
+
+    @Test
+    fun `should not migrate a single prisoner restriction when restriction type is invalid`() {
+      val request = migratePrisonerRestrictionRequest()
+
+      webTestClient.post()
+        .uri("/migrate/prisoner-restriction/A1234ZZ")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request.copy(restrictionType = "INVALID_TYPE"))
+        .exchange()
+        .expectStatus()
+        .isNotFound
+        .expectBody()
+        .jsonPath("$.userMessage")
+        .isEqualTo("Entity not found : No reference data found for groupCode: ReferenceCodeGroup.RESTRICTION and code: INVALID_TYPE")
+    }
+
+    @Test
+    fun `should not migrate a single prisoner restriction when restrictionType exceeds max length`() {
+      val request = migratePrisonerRestrictionRequest()
+
+      webTestClient.post()
+        .uri("/migrate/prisoner-restriction/A1234ZZ")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request.copy(restrictionType = "LONG_RESTRICTION_INVALID_TYPE"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.userMessage")
+        .value { userMessage: String ->
+          assertThat(userMessage).contains("restrictionType must be less than or equal to 12 characters")
+        }
+    }
+
+    @Test
+    fun `should not migrate a single prisoner restriction when commentText exceeds max length`() {
+      val request = migratePrisonerRestrictionRequest()
+
+      webTestClient.post()
+        .uri("/migrate/prisoner-restriction/A1234ZZ")
+        .headers(setAuthorisationUsingCurrentUser())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request.copy(commentText = "a".repeat(241)))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .expectBody()
+        .jsonPath("$.userMessage")
+        .value { userMessage: String ->
+          assertThat(userMessage).contains("commentText must be less than or equal to 240 characters")
+        }
+    }
+
+    private fun migratePrisonerRestrictionRequest(
+      restrictionType: String = "CCTV",
+      now: LocalDateTime = LocalDateTime.now(),
+    ) = MigratePrisonerRestrictionRequest(
+      restrictionType,
+      effectiveDate = now.toLocalDate(),
+      expiryDate = now.toLocalDate().plusDays(10),
+      commentText = "CCTV",
+      authorisedUsername = "JSMITH",
+      currentTerm = true,
+      createdBy = "user1",
+      createdTime = now,
+      updatedBy = "user2",
+      updatedTime = now.plusDays(1),
     )
-
-    webTestClient.post()
-      .uri("/migrate/prisoner-restrictions")
-      .headers(setAuthorisationUsingCurrentUser())
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(request)
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(PrisonerRestrictionsMigrationResponse::class.java)
-      .consumeWith { response ->
-        assertThat(response.responseBody?.prisonerNumber).isEqualTo("A1234ZZ")
-        assertThat(response.responseBody?.prisonerRestrictionsIds).isNotEmpty
-      }
-
-    val restrictions = prisonerRestrictionsRepository.findByPrisonerNumber("A1234ZZ")
-    assertThat(restrictions).hasSize(3)
-    assertThat(restrictions[0].restrictionType).isEqualTo("CCTV")
-    assertThat(restrictions[0].commentText).isEqualTo("No visits allowed")
-
-    assertThat(restrictions[1].restrictionType).isEqualTo("DIHCON")
-    assertThat(restrictions[1].commentText).isEqualTo("No visits allowed")
-
-    assertThat(restrictions[2].restrictionType).isEqualTo("NONCON")
-    assertThat(restrictions[2].commentText).isEqualTo("No visits allowed")
-  }
-
-  @Test
-  fun `should not migrate prisoner restrictions when comment text max size validation failed`() {
-    val invalidRequest = basicMigrationRequest(
-      restrictionsList = listOf(
-        prisonerRestrictionDetailsRequest(
-          commentText = "a".repeat(241),
-          authorisedUsername = "JSMITH",
-        ),
-      ),
-    )
-
-    webTestClient.post()
-      .uri("/migrate/prisoner-restrictions")
-      .headers(setAuthorisationUsingCurrentUser())
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(invalidRequest)
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-      .expectBody()
-      .jsonPath("$.userMessage")
-      .value { userMessage: String ->
-        assertThat(userMessage).contains("restrictions[0].commentText must be less than or equal to 240 characters")
-      }
-  }
-
-  @Test
-  fun `should not migrate prisoner restrictions when restriction type max size validation failed`() {
-    val invalidRequest = basicMigrationRequest(
-      restrictionsList = listOf(
-        prisonerRestrictionDetailsRequest(restrictionType = "LONGER_THAN_12_CHARACTERS"),
-        prisonerRestrictionDetailsRequest(restrictionType = "invalid"),
-      ),
-    )
-
-    webTestClient.post()
-      .uri("/migrate/prisoner-restrictions")
-      .headers(setAuthorisationUsingCurrentUser())
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(invalidRequest)
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-      .expectBody()
-      .jsonPath("$.userMessage")
-      .isEqualTo(
-        "Validation failure(s): " +
-          "restrictions[0].restrictionType must be less than or equal to 12 characters",
-      )
-  }
-
-  @Test
-  fun `should not migrate prisoner restrictions when invalid restriction type`() {
-    val invalidRequest = basicMigrationRequest(
-      restrictionsList = listOf(
-        prisonerRestrictionDetailsRequest(restrictionType = "CCTV"),
-        prisonerRestrictionDetailsRequest(restrictionType = "invalid"),
-      ),
-    )
-
-    webTestClient.post()
-      .uri("/migrate/prisoner-restrictions")
-      .headers(setAuthorisationUsingCurrentUser())
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(invalidRequest)
-      .exchange()
-      .expectStatus()
-      .isNotFound
-      .expectBody()
-      .jsonPath("$.userMessage")
-      .isEqualTo(
-        "Entity not found : No reference data found for groupCode: ReferenceCodeGroup.RESTRICTION and code: invalid",
-      )
-  }
-
-  @Test
-  fun `should not migrate prisoner restrictions when restrictions list is empty`() {
-    val invalidRequest = basicMigrationRequest(
-      restrictionsList = emptyList(),
-    )
-
-    webTestClient.post()
-      .uri("/migrate/prisoner-restrictions")
-      .headers(setAuthorisationUsingCurrentUser())
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(invalidRequest)
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-      .expectBody()
-      .jsonPath("$.userMessage")
-      .isEqualTo("Validation failure(s): restrictions must contain at least one record")
-  }
-
-  @Test
-  fun `should delete existing restrictions before migration`() {
-    webTestClient.post()
-      .uri("/migrate/prisoner-restrictions")
-      .headers(setAuthorisationUsingCurrentUser())
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(
-        basicMigrationRequest(
-          prisonerNumber = "A1234ZZ",
-          restrictionsList = listOf(
-            prisonerRestrictionDetailsRequest(restrictionType = "CCTV"),
-            prisonerRestrictionDetailsRequest(restrictionType = "BAN"),
-            prisonerRestrictionDetailsRequest(restrictionType = "CHILD"),
-          ),
-        ),
-      )
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(PrisonerRestrictionsMigrationResponse::class.java)
-      .consumeWith { response ->
-        assertThat(response.responseBody?.prisonerNumber).isEqualTo("A1234ZZ")
-        assertThat(response.responseBody?.prisonerRestrictionsIds).hasSize(3)
-      }
-
-    val request = basicMigrationRequest(
-      prisonerNumber = "A1234ZZ",
-      restrictionsList = listOf(
-        prisonerRestrictionDetailsRequest(restrictionType = "DIHCON"),
-        prisonerRestrictionDetailsRequest(restrictionType = "NONCON"),
-      ),
-    )
-
-    webTestClient.post()
-      .uri("/migrate/prisoner-restrictions")
-      .headers(setAuthorisationUsingCurrentUser())
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(request)
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(PrisonerRestrictionsMigrationResponse::class.java)
-      .consumeWith { response ->
-        assertThat(response.responseBody?.prisonerNumber).isEqualTo("A1234ZZ")
-        assertThat(response.responseBody?.prisonerRestrictionsIds).hasSize(2)
-      }
-
-    val restrictions = prisonerRestrictionsRepository.findByPrisonerNumber("A1234ZZ")
-    assertThat(restrictions).hasSize(2)
-    assertThat(restrictions.map { it.restrictionType }).containsExactlyInAnyOrder("DIHCON", "NONCON")
   }
 
   private fun basicMigrationRequest(


### PR DESCRIPTION
This is to migrate a single restriction for a prisoner, 
This will not delete existing restrictions during the migration. Instead, Sycon will detect if something goes wrong during the migration, such as accidentally calling the endpoint twice.


Keep the other version for now in case we decide to pivot back to the batch approach.