### PR TITLE
PRC-832 : get all prisoner restrictions with paging - update swagger docs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerRestrictionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerRestrictionsController.kt
@@ -40,7 +40,6 @@ class PrisonerRestrictionsController(
       ApiResponse(
         responseCode = "200",
         description = "Found restrictions",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = PrisonerRestrictionDetails::class))],
       ),
       ApiResponse(
         responseCode = "400",


### PR DESCRIPTION
Fix the swagger doc to include paging object into the response object

Test evidence:
<img width="1800" height="1300" alt="image" src="https://github.com/user-attachments/assets/d8ff6f29-8a50-4b46-a842-03131674740a" />