### PR TITLE
PRC-842 : Change merge endpoint to accept list of changes for the keeping prisoner restrictions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerRestrictionsAdminFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/sync/PrisonerRestrictionsAdminFacade.kt
@@ -2,9 +2,9 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.sync
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.User
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.MergePrisonerRestrictionsRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.ResetPrisonerRestrictionsRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ChangedRestrictionsResponse
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.MergedRestrictionsResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
@@ -16,8 +16,8 @@ class PrisonerRestrictionsAdminFacade(
   private val outboundEventsService: OutboundEventsService,
 ) {
 
-  fun merge(keepingPrisonerNumber: String, removingPrisonerNumber: String): MergedRestrictionsResponse {
-    val response = restrictionsAdminService.mergePrisonerRestrictions(keepingPrisonerNumber, removingPrisonerNumber)
+  fun merge(request: MergePrisonerRestrictionsRequest): ChangedRestrictionsResponse {
+    val response = restrictionsAdminService.mergePrisonerRestrictions(request)
 
     if (response.hasChanged) {
       // Send CREATED events for new restrictions
@@ -26,7 +26,7 @@ class PrisonerRestrictionsAdminFacade(
           outboundEvent = OutboundEvent.PRISONER_RESTRICTION_CREATED,
           identifier = restrictionId,
           source = Source.NOMIS,
-          noms = keepingPrisonerNumber,
+          noms = request.keepingPrisonerNumber,
           user = User.SYS_USER,
         )
       }
@@ -37,7 +37,7 @@ class PrisonerRestrictionsAdminFacade(
           outboundEvent = OutboundEvent.PRISONER_RESTRICTION_DELETED,
           identifier = restrictionId,
           source = Source.NOMIS,
-          noms = removingPrisonerNumber,
+          noms = request.removingPrisonerNumber,
           user = User.SYS_USER,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/MergePrisonerRestrictionsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/MergePrisonerRestrictionsRequest.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.PrisonerRestrictionDetailsRequest
+
+@Schema(description = "The request to merge restrictions from one prisoner to another, resetting the retained prisoner's restrictions to those in the request and deleting all from the removed prisoner.")
+data class MergePrisonerRestrictionsRequest(
+  @Schema(description = "The prisoner number to retain restrictions for", example = "A1234BC", required = true)
+  @field:NotBlank
+  val keepingPrisonerNumber: String,
+
+  @Schema(description = "The prisoner number to remove restrictions from", example = "A1234BD", required = true)
+  @field:NotBlank
+  val removingPrisonerNumber: String,
+
+  @Schema(description = "Restriction records to be set for the retained prisoner", required = true)
+  @field:Valid
+  val restrictions: List<PrisonerRestrictionDetailsRequest>,
+)


### PR DESCRIPTION
 Convert `/prisoner-restrictions/keep/{keepingPrisonerNumber}/remove/{removedPrisonerNumber} ` into a POST and accept a list of restrictions for the retainingPrisonerNumber and return the IDs.  Delete all the ones from removingPrisonerNumber and resetting the list for retainingPrisonerNumber