### PR TITLE
PRC-881 : increase property field size

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/Address.kt
@@ -29,7 +29,7 @@ data class Address(
   override val flat: String? = null,
 
   @Schema(description = "Building or house number or name", example = "Mansion House", nullable = true)
-  @field:Size(max = 50, message = "property must be <= 50 characters")
+  @field:Size(max = 130, message = "property must be <= 130 characters")
   override val property: String? = null,
 
   @Schema(description = "Street or road name", example = "Acacia Avenue", nullable = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/CreateContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/CreateContactAddressRequest.kt
@@ -30,7 +30,7 @@ data class CreateContactAddressRequest(
   override val flat: String? = null,
 
   @Schema(description = "Building or house number or name", example = "Mansion House", nullable = true)
-  @field:Size(max = 50, message = "property must be <= 50 characters")
+  @field:Size(max = 130, message = "property must be <= 130 characters")
   override val property: String? = null,
 
   @Schema(description = "Street or road name", example = "Acacia Avenue", nullable = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/PatchContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/PatchContactAddressRequest.kt
@@ -30,7 +30,7 @@ data class PatchContactAddressRequest(
   val flat: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "Building or house number or name", example = "Mansion House", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @field:Size(max = 50, message = "property must be <= 50 characters")
+  @field:Size(max = 130, message = "property must be <= 130 characters")
   val property: JsonNullable<String?> = JsonNullable.undefined(),
 
   @Schema(description = "Street or road name", example = "Acacia Avenue", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/UpdateContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/address/UpdateContactAddressRequest.kt
@@ -27,7 +27,7 @@ data class UpdateContactAddressRequest(
   override val flat: String? = null,
 
   @Schema(description = "Building or house number or name", example = "Mansion House", nullable = true)
-  @field:Size(max = 50, message = "property must be <= 50 characters")
+  @field:Size(max = 130, message = "property must be <= 130 characters")
   override val property: String? = null,
 
   @Schema(description = "Street or road name", example = "Acacia Avenue", nullable = true)

--- a/src/main/resources/migrations/common/V2025.08.04.38__increase_property_length.sql
+++ b/src/main/resources/migrations/common/V2025.08.04.38__increase_property_length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE contact_address ALTER COLUMN property TYPE VARCHAR(130);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressIntegrationTest.kt
@@ -416,7 +416,7 @@ class CreateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
     @JvmStatic
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
       Arguments.of("flat must be <= 30 characters", aMinimalAddressRequest().copy(flat = "".padStart(31, 'X'))),
-      Arguments.of("property must be <= 50 characters", aMinimalAddressRequest().copy(property = "".padStart(51, 'X'))),
+      Arguments.of("property must be <= 130 characters", aMinimalAddressRequest().copy(property = "".padStart(131, 'X'))),
       Arguments.of("street must be <= 160 characters", aMinimalAddressRequest().copy(street = "".padStart(161, 'X'))),
       Arguments.of("area must be <= 70 characters", aMinimalAddressRequest().copy(area = "".padStart(71, 'X'))),
       Arguments.of("postcode must be <= 12 characters", aMinimalAddressRequest().copy(postcode = "".padStart(13, 'X'))),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -744,8 +744,8 @@ class CreateContactIntegrationTest : SecureAPIIntegrationTestBase() {
           aMinimalCreateContactRequest().copy(addresses = listOf(minimalAddress.copy(flat = "".padStart(31, 'X')))),
         ),
         Arguments.of(
-          "addresses[0].property must be <= 50 characters",
-          aMinimalCreateContactRequest().copy(addresses = listOf(minimalAddress.copy(property = "".padStart(51, 'X')))),
+          "addresses[0].property must be <= 130 characters",
+          aMinimalCreateContactRequest().copy(addresses = listOf(minimalAddress.copy(property = "".padStart(131, 'X')))),
         ),
         Arguments.of(
           "addresses[0].street must be <= 160 characters",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
@@ -460,8 +460,8 @@ class PatchContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
         aMinimalPatchAddressRequest().copy(flat = JsonNullable.of("".padStart(31, 'X'))),
       ),
       Arguments.of(
-        "property must be <= 50 characters",
-        aMinimalPatchAddressRequest().copy(property = JsonNullable.of("".padStart(51, 'X'))),
+        "property must be <= 130 characters",
+        aMinimalPatchAddressRequest().copy(property = JsonNullable.of("".padStart(131, 'X'))),
       ),
       Arguments.of(
         "street must be <= 160 characters",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressIntegrationTest.kt
@@ -439,8 +439,8 @@ class UpdateContactAddressIntegrationTest : SecureAPIIntegrationTestBase() {
     fun allFieldConstraintViolations(): List<Arguments> = listOf(
       Arguments.of("flat must be <= 30 characters", aMinimalUpdateAddressRequest().copy(flat = "".padStart(31, 'X'))),
       Arguments.of(
-        "property must be <= 50 characters",
-        aMinimalUpdateAddressRequest().copy(property = "".padStart(51, 'X')),
+        "property must be <= 130 characters",
+        aMinimalUpdateAddressRequest().copy(property = "".padStart(131, 'X')),
       ),
       Arguments.of(
         "street must be <= 160 characters",


### PR DESCRIPTION
NOMIS has recently updated the property field size to 130 characters and Syscon has detected its causing DLQs , This is to increase the size of the field to 130 chars