### PR TITLE
PRC-882 : Reconciliation - extend to non current term relationships

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -484,7 +484,7 @@ class SyncFacade(
    * Reconcile a single contact by ID - returns a very basic summary of data for
    * one contact and its sub-entities to reconcile against.
    */
-  fun reconcileSingleContact(contactId: Long) = syncContactReconciliationService.getContactDetailsById(contactId)
+  fun reconcileSingleContact(contactId: Long, currentTermOnly: Boolean) = syncContactReconciliationService.getContactDetailsById(contactId, currentTermOnly)
 
   /**
    * Reconcile a single prisoner by prisonerNumber - returns a summary of the prisoner's relationships

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.resource.sync
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.SyncFacade
@@ -219,7 +221,10 @@ class ContactSyncController(
   fun reconcileSingleContact(
     @Parameter(description = "The internal ID for the contact.", required = true)
     @PathVariable contactId: Long,
-  ) = syncFacade.reconcileSingleContact(contactId)
+    @RequestParam(name = "currentTermOnly", required = false, defaultValue = "true")
+    @Parameter(`in` = ParameterIn.QUERY, description = "filter results by current terms", example = "true", required = false)
+    currentTermOnly: Boolean = true,
+  ) = syncFacade.reconcileSingleContact(contactId, currentTermOnly)
 
   @GetMapping("/prisoner/{prisonerNumber}/reconcile")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncContactReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncContactReconciliationService.kt
@@ -42,7 +42,7 @@ class SyncContactReconciliationService(
   private val prisonerContactRepository: PrisonerContactRepository,
   private val prisonerContactRestrictionRepository: PrisonerContactRestrictionRepository,
 ) {
-  fun getContactDetailsById(contactId: Long): SyncContactReconcile {
+  fun getContactDetailsById(contactId: Long, currentTermOnly: Boolean): SyncContactReconcile {
     val contactEntity = contactRepository.findById(contactId)
       .orElseThrow { EntityNotFoundException("Contact with ID $contactId not found") }
 
@@ -111,7 +111,7 @@ class SyncContactReconciliationService(
         )
       },
       relationships = prisonerContactRepository.findAllByContactId(contactId)
-        .filter { it.currentTerm }
+        .filter { !currentTermOnly || it.currentTerm }
         .map { relationship ->
           ReconcileRelationship(
             prisonerContactId = relationship.prisonerContactId,

--- a/src/test/resources/reconcile.tests/data-for-reconcile-test.sql
+++ b/src/test/resources/reconcile.tests/data-for-reconcile-test.sql
@@ -14,7 +14,8 @@ values (40001, 30001, 'A3333AA', 'S', true, true, 'BRO', 'MDI', 'TIM', current_t
        (40003, 30001, 'A4444AA', 'S', true, true, 'MOT', 'MDI', 'TIM', current_timestamp),
        (40004, 30001, 'A4444AA', 'S', true, true, 'SIS', 'MDI', 'TIM', current_timestamp),
        (40005, 30002, 'A4444AA', 'O', true, true, 'POL', 'MDI', 'TIM', current_timestamp),
-       (40006, 30002, 'A4444AA', 'S', true, false, 'BRO', 'MDI', 'TIM', current_timestamp);
+       (40006, 30002, 'A4444AA', 'S', true, false, 'BRO', 'MDI', 'TIM', current_timestamp),
+       (40007, 30002, 'A4444AA', 'O', false, true, 'SIS', 'MDI', 'TIM', current_timestamp);
 
 insert into prisoner_contact_restriction (prisoner_contact_id, restriction_type, start_date, expiry_date, comments, created_by, created_time)
 values (40001, 'BAN', '2025-01-01', '2025-05-02', 'Restriction A', 'TIM', current_timestamp),


### PR DESCRIPTION
Reconciliation - extend to non-current term relationships
AC: introduce a new flag currentTermOnly, with a default of true, When passing currentTermOnly false, then all contacts with both current and non-current relationships should be returned