### PR TITLE
PRC-901 : Add a metric to see how often approval is toggled by NOMIS vs DPS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -430,7 +430,11 @@ class ContactService(
     contactId = this.contactId,
     prisonerNumber = this.prisonerNumber,
     relationshipType = request.relationshipTypeCode.orElse(this.relationshipType),
-    approvedVisitor = request.isApprovedVisitor.orElse(this.approvedVisitor),
+    approvedVisitor = request.isApprovedVisitor.orElse(this.approvedVisitor).also {
+      if (request.isApprovedVisitor.isPresent && request.isApprovedVisitor.get() != this.approvedVisitor) {
+        logger.info("ApprovedVisitor changed in DPS: from=${this.approvedVisitor}, to=${request.isApprovedVisitor.get()}, updatebBy=${user.username}")
+      }
+    },
     currentTerm = this.currentTerm,
     nextOfKin = request.isNextOfKin.orElse(this.nextOfKin),
     emergencyContact = request.isEmergencyContact.orElse(this.emergencyContact),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -432,7 +432,7 @@ class ContactService(
     relationshipType = request.relationshipTypeCode.orElse(this.relationshipType),
     approvedVisitor = request.isApprovedVisitor.orElse(this.approvedVisitor).also {
       if (request.isApprovedVisitor.isPresent && request.isApprovedVisitor.get() != this.approvedVisitor) {
-        logger.info("ApprovedVisitor changed in DPS: from=${this.approvedVisitor}, to=${request.isApprovedVisitor.get()}, updatebBy=${user.username}")
+        logger.info("Approval status has been changed from DPS: for contactId=${this.contactId}, prisonerNumber=${this.prisonerNumber}: from ${this.approvedVisitor} to ${request.isApprovedVisitor.get()}, updated By ${user.username}")
       }
     },
     currentTerm = this.currentTerm,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.sync
 
 import jakarta.persistence.EntityNotFoundException
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.exception.DuplicateRelationshipException
@@ -16,6 +17,9 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactR
 class SyncPrisonerContactService(
   val prisonerContactRepository: PrisonerContactRepository,
 ) {
+  companion object {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+  }
 
   @Transactional(readOnly = true)
   fun getPrisonerContactById(prisonerContactId: Long): SyncPrisonerContact {
@@ -43,7 +47,11 @@ class SyncPrisonerContactService(
       nextOfKin = request.nextOfKin,
       emergencyContact = request.emergencyContact,
       active = request.active,
-      approvedVisitor = request.approvedVisitor,
+      approvedVisitor = request.approvedVisitor.also {
+        if (contact.approvedVisitor != request.approvedVisitor) {
+          logger.info("Approval status has been changed from NOMIS from ${contact.approvedVisitor} ,to ${request.approvedVisitor}, updated By ${request.updatedBy}")
+        }
+      },
       currentTerm = request.currentTerm,
       comments = request.comments,
     ).also {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactService.kt
@@ -49,7 +49,7 @@ class SyncPrisonerContactService(
       active = request.active,
       approvedVisitor = request.approvedVisitor.also {
         if (contact.approvedVisitor != request.approvedVisitor) {
-          logger.info("Approval status has been changed from NOMIS from ${contact.approvedVisitor} ,to ${request.approvedVisitor}, updated By ${request.updatedBy}")
+          logger.info("Approval status has been changed from NOMIS for contactId=${contact.contactId}, prisonerNumber=${contact.prisonerNumber}: from ${contact.approvedVisitor} to ${request.approvedVisitor}, updated By ${request.updatedBy}")
         }
       },
       currentTerm = request.currentTerm,


### PR DESCRIPTION
 Test evidence: update approvalStatus from both NOMIS and DPS logs if the value has been changed with the user name and current value and new value

Update from NOMIS:
<img width="1322" height="46" alt="image" src="https://github.com/user-attachments/assets/8c2d9a0c-2c20-4202-99d6-dca327a33323" />



Update from DPS: 
<img width="1284" height="40" alt="image" src="https://github.com/user-attachments/assets/fad427f4-6e13-445f-9cfd-b1c9ae8ff1e3" />
