### PR TITLE
PRC-903 : Send CONTACT_UPDATED event to NOMIS when last internal relationships is deleted

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/internal/DeletedResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/internal/DeletedResponse.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.internal
+
+data class DeletedResponse(
+  val ids: DeletedRelationshipIds,
+  val wasUpdated: Boolean,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -1844,7 +1844,7 @@ class ContactServiceTest {
       whenever(prisonerContactRepository.findById(prisonerContactId)).thenReturn(Optional.of(prisonerContactEntity))
       whenever(prisonerContactRestrictionRepository.findAllByPrisonerContactId(prisonerContactId)).thenReturn(emptyList())
       whenever(deletedPrisonerContactRepository.saveAndFlush(any())).thenAnswer { i -> (i.arguments[0] as DeletedPrisonerContactEntity) }
-      whenever(prisonerContactRepository.findAllByContactIdAndRelationshipToPrisonerNotIn(any(), any())).thenReturn(emptyList())
+      whenever(prisonerContactRepository.findAllByContactId(prisonerContactEntity.contactId)).thenReturn(listOf(prisonerContactEntity.copy(prisonerContactId = 2L, relationshipToPrisoner = "POM")))
       val aContact = createContactEntity().copy(dateOfBirth = LocalDate.of(1990, 1, 1))
       whenever(contactRepository.findById(prisonerContactEntity.contactId)).thenReturn(Optional.of(aContact))
 


### PR DESCRIPTION
Update the existing logic to 

We delete a relationship

We should then check - are they in any other relationships? If no, leave the DOB alone.

If yes, are ALL of those relationships internal staff types? If no, leave the DOB alone.

If yes, remove the DOB and send the extra event.