### PR TITLE
PRC-946 : Sort out approved status for Lowdham Grange

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntity
+import java.time.LocalDateTime
 
 @Repository
 interface PrisonerContactRepository : JpaRepository<PrisonerContactEntity, Long> {
@@ -56,4 +57,23 @@ interface PrisonerContactRepository : JpaRepository<PrisonerContactEntity, Long>
     """,
   )
   fun findAllContactsWithADobInRelationships(relationshipTypes: List<String>): List<RelationshipTypeCountProjection>
+
+  data class ContactProjection(
+    val prisonerNumber: String,
+    val prisonerContactId: Long,
+    val contactId: Long,
+  )
+
+  @Query(
+    """
+        select pc.prisonerNumber, pc.prisonerContactId, c.contactId
+        from PrisonerContactEntity pc, ContactEntity c
+        where pc.contactId = c.contactId
+          and pc.currentTerm = true
+          and pc.approvedVisitor = false
+          and pc.createdBy in :createdByList
+          and pc.createdTime > :createdAfter
+    """,
+  )
+  fun getContactList(createdAfter: LocalDateTime, createdByList: List<String>): List<ContactProjection>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
@@ -127,6 +127,13 @@ class PrisonerContactController(
     return ResponseEntity.noContent().build()
   }
 
+  @GetMapping("support/trigger")
+  @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__RW')")
+  fun applyApprovalsForLowdhamGrange(): ResponseEntity<Void> {
+    contactFacade.patchGiveRelationship()
+    return ResponseEntity.noContent().build()
+  }
+
   @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(
     summary = "Add a new prisoner contact relationship",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -626,6 +626,11 @@ class ContactService(
     return contactIdsToUpdate
   }
 
+  fun getContactList(createdAfter: LocalDateTime, createdByList: List<String>) = prisonerContactRepository.getContactList(
+    createdAfter,
+    createdByList,
+  )
+
   private fun ContactEntity.deleteDateOfBirth(
     user: User,
   ): ContactEntity {


### PR DESCRIPTION
This is a temporary PR to correct data created by a couple of users, potentially during the service downtime, with an invalid approval status. The fix involves 
1) updating all prisoner contact records created by those two users in the last 120 days to have approval status set to true. 
2) No other data will be modified. 

The endpoint created here will be executed by logging into the pod and running a curl GET call. 

Once the data is updated, this PR will be reverted.
