### PR TITLE
OV-529: Adding an endpoint to check the state of relationships for a list of prisoners and contacts

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/request/PrisonerContactRelationshipsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/request/PrisonerContactRelationshipsRequest.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.personalrelationships.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request to find relationships for prisoners and contacts")
+data class PrisonerContactRelationshipsRequest(
+  val identifiers: List<PrisonerAndContactId>,
+)
+
+data class PrisonerAndContactId(
+  @Schema(description = "The prisoner number", example = "A1234AA")
+  val prisonerNumber: String,
+
+  @Schema(description = "The contact ID", example = "1234")
+  val contactId: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/response/PrisonerContactRelationshipsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/response/PrisonerContactRelationshipsResponse.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.personalrelationships.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Describes limited details of a group of prisoner and contact relationships")
+data class PrisonerContactRelationshipsResponse(
+  val responses: List<PrisonerContactRelationship>,
+)
+
+data class PrisonerContactRelationship(
+  @Schema(description = "Prisoner number (NOMS ID)", example = "A1234BC")
+  val prisonerNumber: String,
+
+  @Schema(description = "The unique identifier for the contact", example = "654321")
+  val contactId: Long,
+
+  val relationships: List<SummaryRelationship>,
+)
+
+data class SummaryRelationship(
+  @Schema(description = "The prisoner contact ID", example = "1234")
+  val prisonerContactId: Long,
+
+  @Schema(description = "Coded value indicating either a social (S) or official contact (O)", example = "S")
+  val relationshipTypeCode: String,
+
+  @Schema(description = "The relationship with the prisoner coded value", example = "FRI")
+  val relationshipToPrisonerCode: String,
+
+  @Schema(description = "Is this a approved visitor for the prisoner?", example = "true")
+  val isApprovedVisitor: Boolean,
+
+  @Schema(description = "Is this prisoner's contact relationship active?", example = "true")
+  val isRelationshipActive: Boolean,
+
+  @Schema(description = "Is this prisoner's contact relationship active?", example = "true")
+  val currentTerm: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/repository/PrisonerContactRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/repository/PrisonerContactRepository.kt
@@ -70,4 +70,15 @@ interface PrisonerContactRepository : JpaRepository<PrisonerContactEntity, Long>
     """,
   )
   fun getRelationshipsToApprove(createdAfter: LocalDateTime, createdByList: List<String>): List<PrisonerContactEntity>
+
+  @Query(
+    """
+        select pc 
+        from PrisonerContactEntity pc
+        where pc.prisonerNumber in :prisonerNumbers
+          and pc.currentTerm = :currentTerm  
+        order by pc.prisonerNumber  
+    """,
+  )
+  fun getCurrentRelationshipsForPrisoners(prisonerNumbers: List<String>, currentTerm: Boolean = true): List<PrisonerContactEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/PrisonerContactController.kt
@@ -433,6 +433,11 @@ class PrisonerContactController(
           ),
         ],
       ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The request was invalid or empty",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
     ],
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/PrisonerContactController.kt
@@ -29,9 +29,11 @@ import uk.gov.justice.digital.hmpps.personalrelationships.facade.PrisonerContact
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.AddContactRelationshipRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PatchRelationshipRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PrisonerContactIdsRequest
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PrisonerContactRelationshipsRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.restrictions.CreatePrisonerContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.restrictions.UpdatePrisonerContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRelationshipDetails
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRelationshipsResponse
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRestrictionDetails
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRestrictionsResponse
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactsRestrictionsResponse
@@ -78,7 +80,7 @@ class PrisonerContactController(
   @GetMapping(value = ["/{prisonerContactId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
   fun getPrisonerContactById(
-    @PathVariable("prisonerContactId") @Parameter(
+    @PathVariable @Parameter(
       name = "prisonerContactId",
       description = "The id of the prisoner contact relationship to be returned",
       example = "1L",
@@ -117,7 +119,7 @@ class PrisonerContactController(
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__RW')")
   @ResponseStatus(HttpStatus.CREATED)
   fun patchContactRelationship(
-    @PathVariable("prisonerContactId") @Parameter(
+    @PathVariable @Parameter(
       name = "prisonerContactId",
       description = "The id of the prisoner contact",
       example = "123456",
@@ -209,7 +211,7 @@ class PrisonerContactController(
   @GetMapping(value = ["/{prisonerContactId}/restriction"], produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
   fun getPrisonerContactRestrictionsByPrisonerContactId(
-    @PathVariable("prisonerContactId") @Parameter(
+    @PathVariable @Parameter(
       name = "prisonerContactId",
       description = "The id of the prisoner contact",
       example = "1L",
@@ -281,7 +283,7 @@ class PrisonerContactController(
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__RW')")
   fun createPrisonerContactRestriction(
-    @PathVariable("prisonerContactId") @Parameter(
+    @PathVariable @Parameter(
       name = "prisonerContactId",
       description = "The id of the prisoner contact relationship",
       example = "123456",
@@ -327,12 +329,12 @@ class PrisonerContactController(
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__RW')")
   fun updatePrisonerContactRestriction(
-    @PathVariable("prisonerContactId") @Parameter(
+    @PathVariable @Parameter(
       name = "prisonerContactId",
       description = "The id of the prisoner contact relationship",
       example = "123456",
     ) prisonerContactId: Long,
-    @PathVariable("prisonerContactRestrictionId") @Parameter(
+    @PathVariable @Parameter(
       name = "prisonerContactRestrictionId",
       description = "The id of the  restriction",
       example = "123456",
@@ -368,7 +370,7 @@ class PrisonerContactController(
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__RW')")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   fun deleteContactRelationship(
-    @PathVariable("prisonerContactId") @Parameter(
+    @PathVariable @Parameter(
       name = "prisonerContactId",
       description = "The id of the prisoner contact",
       example = "123456",
@@ -406,10 +408,37 @@ class PrisonerContactController(
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__RW')")
   @ResponseStatus(HttpStatus.OK)
   fun assessIfRelationshipCanBeDeleted(
-    @PathVariable("prisonerContactId") @Parameter(
+    @PathVariable @Parameter(
       name = "prisonerContactId",
       description = "The id of the prisoner contact",
       example = "123456",
     ) prisonerContactId: Long,
   ): RelationshipDeletePlan = contactFacade.assessIfRelationshipCanBeDeleted(prisonerContactId)
+
+  @PostMapping(value = ["/relationships/summary"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @Operation(
+    summary = "Relationship summary details for prisoners and contacts",
+    description = "Relationship summary details for a list of prisoner number and contact ID pairs",
+  )
+  @Tag(name = "Prisoner relationships")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The prisoner and contact relationship summary details",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = PrisonerContactRelationshipsResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
+  fun postPrisonerContactRelationships(
+    @RequestBody
+    @Parameter(description = "The prisoner number and contact ID pairs to return relationships for", required = true)
+    request: PrisonerContactRelationshipsRequest,
+  ): PrisonerContactRelationshipsResponse = prisonerContactRelationshipService.getSummaryRelationships(request)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipService.kt
@@ -49,11 +49,15 @@ class PrisonerContactRelationshipService(
       throw ValidationException("No identifiers were provided in the request")
     }
 
-    val prisonerNumberList = request.identifiers.map { it.prisonerNumber }.toSet().toList()
-    val prisonerRelationships = prisonerContactRepository.getCurrentRelationshipsForPrisoners(prisonerNumberList)
+    // Make sure the requests are unique combinations of prisonerNumber and contactId
+    val uniqueRequests = request.identifiers.distinctBy { listOf(it.prisonerNumber, it.contactId) }
+
+    // Get the relationships for the pairs of prisonerNumber and contactId
+    val prisonerRelationships = prisonerContactRepository.getCurrentRelationshipsForPrisoners(uniqueRequests.map { it.prisonerNumber })
     val prisonerRelationshipMap = prisonerRelationships.groupBy { it.prisonerNumber }
 
-    val responses = request.identifiers.map { outerItem ->
+    // Build the response object
+    val responses = uniqueRequests.map { outerItem ->
       val relationshipsForPrisonerAndContact = prisonerRelationshipMap[outerItem.prisonerNumber]?.filter { innerItem ->
         innerItem.contactId == outerItem.contactId
       } ?: emptyList()
@@ -75,6 +79,7 @@ class PrisonerContactRelationshipService(
         relationships = relationships,
       )
     }
+
     return PrisonerContactRelationshipsResponse(responses)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipService.kt
@@ -1,17 +1,23 @@
 package uk.gov.justice.digital.hmpps.personalrelationships.service
 
 import jakarta.persistence.EntityNotFoundException
+import jakarta.validation.ValidationException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.personalrelationships.entity.PrisonerContactSummaryEntity
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PrisonerContactRelationshipsRequest
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRelationship
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRelationshipDetails
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRelationshipsResponse
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.SummaryRelationship
+import uk.gov.justice.digital.hmpps.personalrelationships.repository.PrisonerContactRepository
 import uk.gov.justice.digital.hmpps.personalrelationships.repository.PrisonerContactSummaryRepository
 
 @Service
 class PrisonerContactRelationshipService(
   private val prisonerContactSummaryRepository: PrisonerContactSummaryRepository,
+  private val prisonerContactRepository: PrisonerContactRepository,
   private val manageUsersService: ManageUsersService,
 ) {
-
   fun getById(prisonerContactId: Long): PrisonerContactRelationshipDetails = prisonerContactSummaryRepository.findById(prisonerContactId)
     .orElseThrow { EntityNotFoundException("prisoner contact relationship with id $prisonerContactId not found") }.toRelationshipModel()
 
@@ -30,6 +36,45 @@ class PrisonerContactRelationshipService(
     approvedBy = getApprovedByUserName(this.approvedBy),
     comments = this.comments,
   )
+
+  /**
+   *  Function to return summary relationships (type, approval, active) for a list
+   *  of prisoner number and contact ID pairs. This is primarily used by the official
+   *  visits service to check for issues with visitor approval since a visit was created.
+   */
+  fun getSummaryRelationships(request: PrisonerContactRelationshipsRequest): PrisonerContactRelationshipsResponse {
+    if (request.identifiers.isEmpty()) {
+      throw ValidationException("No identifiers were provided in the request")
+    }
+
+    val prisonerNumberList = request.identifiers.map { it.prisonerNumber }.toSet().toList()
+    val prisonerRelationships = prisonerContactRepository.getCurrentRelationshipsForPrisoners(prisonerNumberList)
+    val prisonerRelationshipMap = prisonerRelationships.groupBy { it.prisonerNumber }
+
+    val responses = request.identifiers.map { outerItem ->
+      val relationshipsForPrisonerAndContact = prisonerRelationshipMap[outerItem.prisonerNumber]?.filter { innerItem ->
+        innerItem.contactId == outerItem.contactId
+      } ?: emptyList()
+
+      val relationships = relationshipsForPrisonerAndContact.map { rel ->
+        SummaryRelationship(
+          prisonerContactId = rel.prisonerContactId,
+          relationshipTypeCode = rel.relationshipType,
+          relationshipToPrisonerCode = rel.relationshipToPrisoner,
+          isApprovedVisitor = rel.approvedVisitor,
+          isRelationshipActive = rel.active,
+          currentTerm = rel.currentTerm,
+        )
+      }
+
+      PrisonerContactRelationship(
+        prisonerNumber = outerItem.prisonerNumber,
+        contactId = outerItem.contactId,
+        relationships = relationships,
+      )
+    }
+    return PrisonerContactRelationshipsResponse(responses)
+  }
 
   fun getApprovedByUserName(approvedBy: String?): String? = approvedBy?.let { manageUsersService.getUserByUsername(it)?.name ?: it }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.personalrelationships.service
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.ValidationException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.personalrelationships.entity.PrisonerContactSummaryEntity
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PrisonerContactRelationshipsRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRelationship
@@ -13,6 +14,7 @@ import uk.gov.justice.digital.hmpps.personalrelationships.repository.PrisonerCon
 import uk.gov.justice.digital.hmpps.personalrelationships.repository.PrisonerContactSummaryRepository
 
 @Service
+@Transactional(readOnly = true)
 class PrisonerContactRelationshipService(
   private val prisonerContactSummaryRepository: PrisonerContactSummaryRepository,
   private val prisonerContactRepository: PrisonerContactRepository,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/resource/GetPrisonerContactsRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/resource/GetPrisonerContactsRelationshipIntegrationTest.kt
@@ -1,20 +1,26 @@
 package uk.gov.justice.digital.hmpps.personalrelationships.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.personalrelationships.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.personalrelationships.integration.SecureAPIIntegrationTestBase
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PrisonerAndContactId
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PrisonerContactRelationshipsRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRelationshipDetails
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRelationshipsResponse
 import uk.gov.justice.digital.hmpps.personalrelationships.util.StubUser
 
 class GetPrisonerContactsRelationshipIntegrationTest : SecureAPIIntegrationTestBase() {
   companion object {
     private const val GET_PRISONER_CONTACT_RELATIONSHIP = "/prisoner-contact/1"
+    private const val POST_SUMMARY_RELATIONSHIPS = "/prisoner-contact/relationships/summary"
   }
 
   override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
@@ -28,7 +34,7 @@ class GetPrisonerContactsRelationshipIntegrationTest : SecureAPIIntegrationTestB
   }
 
   @Test
-  fun `should return not found if no prisoner contact relationship found`() {
+  fun `getById - should return not found if no prisoner contact relationship found`() {
     stubPrisonSearchWithNotFoundResponse("A4385DZ")
 
     webTestClient.get()
@@ -41,7 +47,7 @@ class GetPrisonerContactsRelationshipIntegrationTest : SecureAPIIntegrationTestB
 
   @ParameterizedTest
   @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
-  fun `should return OK`(role: String) {
+  fun `getById - should return OK`(role: String) {
     stubGetUserByUsername(UserDetails("A_USER", "Created User", "BXI"))
     setCurrentUser(StubUser.READ_ONLY_USER.copy(roles = listOf(role)))
     val expectedPrisonerContactRelationship = PrisonerContactRelationshipDetails(
@@ -67,9 +73,60 @@ class GetPrisonerContactsRelationshipIntegrationTest : SecureAPIIntegrationTestB
       .expectStatus()
       .isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(PrisonerContactRelationshipDetails::class.java)
+      .expectBody<PrisonerContactRelationshipDetails>()
       .returnResult().responseBody!!
 
     assertThat(actualPrisonerContactSummary).isEqualTo(expectedPrisonerContactRelationship)
+  }
+
+  @Test
+  fun `getSummaryRelationships - should return summary relationships for prisoner and contact pairs`() {
+    val request = PrisonerContactRelationshipsRequest(
+      identifiers = listOf(
+        PrisonerAndContactId(prisonerNumber = "G4793VF", contactId = 1L),
+        PrisonerAndContactId(prisonerNumber = "G4793VF", contactId = 2L),
+        PrisonerAndContactId(prisonerNumber = "G4793VF", contactId = 3L),
+      ),
+    )
+
+    val response = webTestClient.post()
+      .uri(POST_SUMMARY_RELATIONSHIPS)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisationUsingCurrentUser())
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody<PrisonerContactRelationshipsResponse>()
+      .returnResult().responseBody!!
+
+    assertThat(response.responses).hasSize(3)
+
+    response.responses.forEach { resp ->
+      with(resp) {
+        assertThat(prisonerNumber).isEqualTo(request.identifiers[0].prisonerNumber)
+        assertThat(contactId).isBetween(1L, 3L)
+        assertThat(relationships).hasSize(1)
+      }
+    }
+
+    val allRelationships = response.responses.flatMap { it.relationships }
+    assertThat(allRelationships).hasSize(3)
+    assertThat(allRelationships).extracting(
+      "prisonerContactId",
+      "relationshipTypeCode",
+      "relationshipToPrisonerCode",
+      "isApprovedVisitor",
+      "isRelationshipActive",
+      "currentTerm",
+    ).containsAll(
+      listOf(
+        Tuple(8L, "S", "FA", false, true, true),
+        Tuple(9L, "S", "MOT", false, true, true),
+        Tuple(10L, "O", "POL", false, true, true),
+      ),
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipServiceTest.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.personalrelationships.service
 
 import jakarta.persistence.EntityNotFoundException
+import jakarta.validation.ValidationException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -10,12 +12,17 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.personalrelationships.client.manage.users.UserDetails
 import uk.gov.justice.digital.hmpps.personalrelationships.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.personalrelationships.entity.PrisonerContactSummaryEntity
+import uk.gov.justice.digital.hmpps.personalrelationships.helpers.createPrisonerContactEntity
 import uk.gov.justice.digital.hmpps.personalrelationships.helpers.prisoner
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PrisonerAndContactId
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PrisonerContactRelationshipsRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRelationshipDetails
+import uk.gov.justice.digital.hmpps.personalrelationships.repository.PrisonerContactRepository
 import uk.gov.justice.digital.hmpps.personalrelationships.repository.PrisonerContactSummaryRepository
 import java.time.LocalDate
 import java.util.Optional
@@ -25,6 +32,9 @@ class PrisonerContactRelationshipServiceTest {
 
   @Mock
   private lateinit var prisonerContactSummaryRepository: PrisonerContactSummaryRepository
+
+  @Mock
+  private lateinit var prisonerContactRepository: PrisonerContactRepository
 
   @Mock
   private lateinit var manageUsersService: ManageUsersService
@@ -89,6 +99,156 @@ class PrisonerContactRelationshipServiceTest {
 
     assertThat(exception.message).isEqualTo("prisoner contact relationship with id $prisonerContactId not found")
     verify(prisonerContactSummaryRepository).findById(prisonerContactId)
+  }
+
+  @Test
+  fun `getSummaryRelationships - should throw ValidationFoundException when an empty list of identifiers is provided`() {
+    val request = PrisonerContactRelationshipsRequest(
+      identifiers = emptyList(),
+    )
+
+    val exception = assertThrows<ValidationException> {
+      prisonerContactRelationshipService.getSummaryRelationships(request)
+    }
+
+    assertThat(exception.message).isEqualTo("No identifiers were provided in the request")
+
+    verifyNoInteractions(prisonerContactRepository)
+  }
+
+  @Test
+  fun `getSummaryRelationships - should return a single prisoner relationship`() {
+    val prisonerContact = createPrisonerContactEntity(
+      prisonerContactId = 1L,
+      contactId = 2L,
+      prisonerNumber = "A1234BC",
+      relationshipType = "S",
+      relationshipToPrisoner = "SIS",
+      active = true,
+      approvedVisitor = false,
+      currentTerm = true,
+    )
+
+    val request = PrisonerContactRelationshipsRequest(
+      identifiers = listOf(
+        PrisonerAndContactId(prisonerNumber = "A1234BC", contactId = 2L),
+      ),
+    )
+
+    val prisonerList = request.identifiers.map { it.prisonerNumber }
+
+    whenever(
+      prisonerContactRepository.getCurrentRelationshipsForPrisoners(prisonerList),
+    ).thenReturn(listOf(prisonerContact))
+
+    val response = prisonerContactRelationshipService.getSummaryRelationships(request)
+
+    assertThat(response.responses).hasSize(1)
+    with(response.responses.first()) {
+      assertThat(prisonerNumber).isEqualTo(prisonerContact.prisonerNumber)
+      assertThat(contactId).isEqualTo(prisonerContact.contactId)
+      assertThat(relationships).hasSize(1)
+      assertThat(relationships.first().relationshipTypeCode).isEqualTo(prisonerContact.relationshipType)
+      assertThat(relationships.first().relationshipToPrisonerCode).isEqualTo(prisonerContact.relationshipToPrisoner)
+      assertThat(relationships.first().isApprovedVisitor).isEqualTo(prisonerContact.approvedVisitor)
+      assertThat(relationships.first().currentTerm).isEqualTo(prisonerContact.currentTerm)
+    }
+
+    verify(prisonerContactRepository).getCurrentRelationshipsForPrisoners(prisonerList)
+  }
+
+  @Test
+  fun `getSummaryRelationships - should return multiple prisoner relationships`() {
+    val prisonerContacts = listOf(
+      createPrisonerContactEntity(
+        prisonerContactId = 1L,
+        contactId = 8L,
+        prisonerNumber = "A1234AA",
+        relationshipType = "S",
+        relationshipToPrisoner = "SIS",
+        approvedVisitor = false,
+        currentTerm = true,
+      ),
+      createPrisonerContactEntity(
+        prisonerContactId = 2L,
+        contactId = 9L,
+        prisonerNumber = "A1234BB",
+        relationshipType = "O",
+        relationshipToPrisoner = "POL",
+        approvedVisitor = true,
+        currentTerm = true,
+      ),
+      createPrisonerContactEntity(
+        prisonerContactId = 3L,
+        contactId = 10L,
+        prisonerNumber = "A1234CC",
+        relationshipType = "O",
+        relationshipToPrisoner = "SOL",
+        approvedVisitor = true,
+        currentTerm = true,
+      ),
+    )
+
+    val request = PrisonerContactRelationshipsRequest(
+      identifiers = listOf(
+        PrisonerAndContactId(prisonerNumber = "A1234AA", contactId = 8L),
+        PrisonerAndContactId(prisonerNumber = "A1234BB", contactId = 9L),
+        PrisonerAndContactId(prisonerNumber = "A1234CC", contactId = 10L),
+      ),
+    )
+
+    val prisonerList = request.identifiers.map { it.prisonerNumber }
+
+    whenever(
+      prisonerContactRepository.getCurrentRelationshipsForPrisoners(prisonerList),
+    ).thenReturn(prisonerContacts)
+
+    val response = prisonerContactRelationshipService.getSummaryRelationships(request)
+
+    assertThat(response.responses).hasSize(3)
+
+    // Check that the responses reflect the request structure
+    assertThat(response.responses)
+      .extracting("prisonerNumber", "contactId")
+      .containsAll(
+        listOf(
+          Tuple("A1234AA", 8L),
+          Tuple("A1234BB", 9L),
+          Tuple("A1234CC", 10L),
+        ),
+      )
+
+    // Check the size of the responses
+    assertThat(response.responses[0].relationships).hasSize(1)
+    assertThat(response.responses[1].relationships).hasSize(1)
+    assertThat(response.responses[2].relationships).hasSize(1)
+
+    verify(prisonerContactRepository).getCurrentRelationshipsForPrisoners(prisonerList)
+  }
+
+  @Test
+  fun `getSummaryRelationships - should return no matching relationships for a valid request`() {
+    val request = PrisonerContactRelationshipsRequest(
+      identifiers = listOf(
+        PrisonerAndContactId(prisonerNumber = "A1234BC", contactId = 2L),
+      ),
+    )
+
+    val prisonerList = request.identifiers.map { it.prisonerNumber }
+
+    // Mock no matches in the prisoner's relationships
+    whenever(
+      prisonerContactRepository.getCurrentRelationshipsForPrisoners(prisonerList),
+    ).thenReturn(emptyList())
+
+    val response = prisonerContactRelationshipService.getSummaryRelationships(request)
+
+    assertThat(response.responses).hasSize(1)
+    with(response.responses.first()) {
+      assertThat(relationships).isEmpty()
+    }
+
+    verify(prisonerContactRepository).getCurrentRelationshipsForPrisoners(prisonerList)
   }
 
   private fun makePrisonerContact(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/PrisonerContactRelationshipServiceTest.kt
@@ -29,7 +29,6 @@ import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class PrisonerContactRelationshipServiceTest {
-
   @Mock
   private lateinit var prisonerContactSummaryRepository: PrisonerContactSummaryRepository
 
@@ -247,6 +246,41 @@ class PrisonerContactRelationshipServiceTest {
     with(response.responses.first()) {
       assertThat(relationships).isEmpty()
     }
+
+    verify(prisonerContactRepository).getCurrentRelationshipsForPrisoners(prisonerList)
+  }
+
+  @Test
+  fun `getSummaryRelationships - should flatten and remove duplicates in the request`() {
+    val prisonerContacts = listOf(
+      createPrisonerContactEntity(
+        prisonerContactId = 1L,
+        contactId = 8L,
+        prisonerNumber = "A1234AA",
+        relationshipType = "S",
+        relationshipToPrisoner = "SIS",
+        approvedVisitor = false,
+        currentTerm = true,
+      ),
+    )
+
+    val request = PrisonerContactRelationshipsRequest(
+      identifiers = listOf(
+        PrisonerAndContactId(prisonerNumber = "A1234AA", contactId = 8L),
+        PrisonerAndContactId(prisonerNumber = "A1234AA", contactId = 8L),
+      ),
+    )
+
+    val prisonerList = request.identifiers.map { it.prisonerNumber }.toSet().toList()
+
+    whenever(
+      prisonerContactRepository.getCurrentRelationshipsForPrisoners(prisonerList),
+    ).thenReturn(prisonerContacts)
+
+    val response = prisonerContactRelationshipService.getSummaryRelationships(request)
+
+    assertThat(response.responses).hasSize(1)
+    assertThat(response.responses[0].relationships).hasSize(1)
 
     verify(prisonerContactRepository).getCurrentRelationshipsForPrisoners(prisonerList)
   }


### PR DESCRIPTION
This is primarily an endpoint required by Official Visits, which needs to check if the state of visitors on visits has altered since its original creation. e.g. Are they still approved, active, and still in a relationship? 