### PR TITLE
OV-529: Exclude the reading of prisoner/contact relationships from re…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/config/UserRequestContextConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/config/UserRequestContextConfiguration.kt
@@ -17,7 +17,7 @@ class UserRequestContextConfiguration(private val userRequestContextInterceptor:
   override fun addInterceptors(registry: InterceptorRegistry) {
     registry.addInterceptor(userRequestContextInterceptor)
       .addPathPatterns("/contact/**", "/prisoner/**", "/prisoner-contact/**")
-      .excludePathPatterns("/prisoner-contact/restrictions")
+      .excludePathPatterns("/prisoner-contact/restrictions", "/prisoner-contact/relationships/summary")
   }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -134,5 +134,3 @@ sentry:
 contact-search:
   slow-query:
     row-limit: 2000
-
-springdoc.swagger-ui.version: 5.32.1


### PR DESCRIPTION
This is an oddity which will probably require a bit of tidying for API to API communication most of which will not have a username in the token. I think its assuming that calls only originate from the UI - and that's not a good assumption. Maybe will require a more flexible way to check / set username or service as a user on all calls?

This resolves my immediate requirement.

Also resolved the missing swagger docs after latest dependency updates.