### PR TITLE
Fix memory issues on helm / kubernetes

### DIFF
--- a/helm_deploy/hmpps-personal-relationships-api/values.yaml
+++ b/helm_deploy/hmpps-personal-relationships-api/values.yaml
@@ -100,6 +100,14 @@ generic-service:
       DPR_USER: "DPR_USER"
       DPR_PASSWORD: "DPR_PASSWORD"
 
+  resources:
+    requests:
+      cpu: 100m
+      memory: 1024Mi
+    limits:
+      cpu: 2000m
+      memory: 2048Mi
+
   allowlist:
     groups:
       - internal


### PR DESCRIPTION
## Issue
It looks like the 1Gb memory is constantly being hit (pod memory usage is at 99.3% on all pods) and occasionally something will push it past the 1Gb, and cause the pod to crash / restart.

Also the CPU quotas hitting are 300% of the original 10m.

## Evidence
<img width="1411" height="311" alt="Screenshot 2026-04-20 at 11 01 30" src="https://github.com/user-attachments/assets/0fbb9cce-500b-4c6c-9b61-883a8e1f9891" />
<img width="1411" height="302" alt="Screenshot 2026-04-20 at 10 54 50" src="https://github.com/user-attachments/assets/96cb70ba-bf1a-4db6-b944-a8914fedad87" />
<img width="1420" height="287" alt="Screenshot 2026-04-20 at 10 53 56" src="https://github.com/user-attachments/assets/aef48284-7788-4076-bf86-30e7200530eb" />
<img width="1064" height="292" alt="Screenshot 2026-04-20 at 10 52 58" src="https://github.com/user-attachments/assets/175e500b-c128-4ad1-a139-d0b270ecea4a" />
<img width="1056" height="319" alt="Screenshot 2026-04-20 at 10 52 24" src="https://github.com/user-attachments/assets/95e7a042-a3ca-489a-b922-babad4feb516" />
<img width="1048" height="308" alt="Screenshot 2026-04-20 at 10 52 10" src="https://github.com/user-attachments/assets/0cf01321-fe5e-474a-94e1-f9324ec3a008" />


## Fix
Raising memory to 2GB, and increase the requests to a higher base.
