### PR TITLE
VB-5817 - Update search contacts endpoint to allow searching for multiple contacts via ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ sonar-project.properties
 
 #Perf tests
 src/gatling/resources/data/
+
+#Other
+.DS_Store

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/request/ContactSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/request/ContactSearchRequest.kt
@@ -10,6 +10,7 @@ data class ContactSearchRequest(
   val searchType: UserSearchType,
   val previousNames: Boolean? = false,
   val contactId: Long? = null,
+  val contactIds: List<Long>? = null,
   val includePrisonerRelationships: String? = null,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/repository/ContactSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/repository/ContactSearchRepository.kt
@@ -14,10 +14,10 @@ interface ContactSearchRepository : JpaRepository<ContactEntity, Long> {
     """
     select c.contactId 
     from ContactEntity c 
-    where c.contactId = :contactId
+    where c.contactId in :contactIds
     """,
   )
-  fun findAllByContactIdEquals(contactId: Long, pageable: Pageable): Page<Long>
+  fun findAllByContactIdIn(contactIds: Collection<Long>, pageable: Pageable): Page<Long>
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactController.kt
@@ -196,7 +196,7 @@ class ContactController(
    * The search controller
    */
   @GetMapping("/search")
-  @Operation(summary = "Search contacts", description = "Search contacts by name, date of birth or contact ID")
+  @Operation(summary = "Search contacts", description = "Search contacts by name, date of birth, contact ID or list of contactIds")
   @ApiResponses(
     value = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactController.kt
@@ -231,7 +231,7 @@ class ContactController(
     middleNames: String?,
     @Parameter(`in` = ParameterIn.QUERY, description = "The contact ID", example = "123456", required = false)
     @RequestParam(required = false)
-    contactId: Long?,
+    contactId: String?,
     @Parameter(`in` = ParameterIn.QUERY, description = "Contact IDs. Comma-separated list of contact IDs, e.g. contactIds=123,456,789", example = "123,456,789", required = false)
     @RequestParam(required = false)
     contactIds: List<Long>?,
@@ -261,7 +261,7 @@ class ContactController(
       dateOfBirth = dateOfBirth,
       searchType = UserSearchType.valueOf(searchType!!),
       previousNames = previousNames,
-      contactId = contactId,
+      contactId = contactId?.toLong(),
       contactIds = contactIds,
       includePrisonerRelationships = includePrisonerRelationships,
     ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactController.kt
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.personalrelationships.config.User
 import uk.gov.justice.digital.hmpps.personalrelationships.facade.ContactFacade
@@ -217,27 +218,38 @@ class ContactController(
     @Parameter(hidden = true)
     pageable: Pageable,
     @Parameter(`in` = ParameterIn.QUERY, description = "Last name of the contact", example = "Jones", required = false)
+    @RequestParam(required = false)
     @Pattern(regexp = VALID_NAME_REGEX, message = VALID_NAME_MESSAGE)
     lastName: String?,
     @Parameter(`in` = ParameterIn.QUERY, description = "First name of the contact", example = "Elton", required = false)
+    @RequestParam(required = false)
     @Pattern(regexp = VALID_NAME_REGEX, message = VALID_NAME_MESSAGE)
     firstName: String?,
     @Parameter(`in` = ParameterIn.QUERY, description = "Middle names of the contact", example = "Simon", required = false)
+    @RequestParam(required = false)
     @Pattern(regexp = VALID_NAME_REGEX, message = VALID_NAME_MESSAGE)
     middleNames: String?,
     @Parameter(`in` = ParameterIn.QUERY, description = "The contact ID", example = "123456", required = false)
-    contactId: String?,
+    @RequestParam(required = false)
+    contactId: Long?,
+    @Parameter(`in` = ParameterIn.QUERY, description = "Contact IDs. Comma-separated list of contact IDs, e.g. contactIds=123,456,789", example = "123,456,789", required = false)
+    @RequestParam(required = false)
+    contactIds: List<Long>?,
     @Parameter(`in` = ParameterIn.QUERY, description = "Date of birth (dd/mm/yyyy)", example = "30/12/2010", required = false)
+    @RequestParam(required = false)
     @Past(message = "The date of birth must be in the past")
     @DateTimeFormat(pattern = "dd/MM/yyyy")
     dateOfBirth: LocalDate?,
     @NotNull(message = "The search type must be one of EXACT, PARTIAL or SOUNDS_LIKE")
     @Pattern(regexp = VALID_SEARCH_TYPE, message = "The search type must be one of EXACT, PARTIAL or SOUNDS_LIKE")
     @Parameter(`in` = ParameterIn.QUERY, description = "The search type one of EXACT, PARTIAL or SOUNDS_LIKE", example = "PARTIAL", required = true)
+    @RequestParam
     searchType: String?,
     @Parameter(`in` = ParameterIn.QUERY, description = "Search for previous names", example = "false", required = false)
+    @RequestParam(required = false)
     previousNames: Boolean = false,
     @Parameter(`in` = ParameterIn.QUERY, description = "Prisoner number to check relationships", example = "A1234BC", required = false)
+    @RequestParam(required = false)
     @Pattern(regexp = VALID_LETTER_OR_NUMBER_REGEX, message = VALID_LETTER_OR_NUMBER_MESSAGE)
     includePrisonerRelationships: String?,
   ): PagedModel<ContactSearchResultItem> = contactFacade.searchContacts(
@@ -249,7 +261,8 @@ class ContactController(
       dateOfBirth = dateOfBirth,
       searchType = UserSearchType.valueOf(searchType!!),
       previousNames = previousNames,
-      contactId = contactId?.toLong(),
+      contactId = contactId,
+      contactIds = contactIds,
       includePrisonerRelationships = includePrisonerRelationships,
     ),
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/ContactSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/ContactSearchService.kt
@@ -75,8 +75,11 @@ class ContactSearchService(
 
     val pageOfContactIds = when (searchType) {
       CONTACT_ID_ONLY -> {
-        logger.info("CONTACT_ID_ONLY search for ${request.contactId}")
-        contactSearchRepository.findAllByContactIdEquals(request.contactId!!, pageable)
+        val contactIds = resolveContactIds(request)!!
+
+        logger.info("CONTACT_ID_ONLY search for ${contactIds.size} contact IDs")
+
+        contactSearchRepository.findAllByContactIdIn(contactIds, pageable)
       }
 
       DATE_OF_BIRTH_ONLY -> {
@@ -280,9 +283,10 @@ class ContactSearchService(
 
   private fun validateRequest(request: ContactSearchRequest) {
     val nameProvided = request.lastName != null || request.firstName != null || request.middleNames != null
+    val contactIdsProvided = !resolveContactIds(request).isNullOrEmpty()
     val isNamedSearchType = request.searchType in setOf(UserSearchType.SOUNDS_LIKE, UserSearchType.PARTIAL, UserSearchType.EXACT)
 
-    if (isNamedSearchType && request.contactId == null && request.dateOfBirth == null) {
+    if (isNamedSearchType && !contactIdsProvided && request.dateOfBirth == null) {
       val typeLabel = request.searchType.name.lowercase().replace("_", "-")
       require(nameProvided) { "A name must be provided for $typeLabel searches" }
 
@@ -291,8 +295,8 @@ class ContactSearchService(
       }
     }
 
-    require(request.contactId != null || request.dateOfBirth != null || nameProvided) {
-      "Either contact ID, date of birth or a full or partial name must be provided for contact searches"
+    require(contactIdsProvided || request.dateOfBirth != null || nameProvided) {
+      "Either contact ID, contact IDs, date of birth or a full or partial name must be provided for contact searches"
     }
   }
 
@@ -308,7 +312,7 @@ class ContactSearchService(
   }
 
   fun determineSearchType(request: ContactSearchRequest): ContactSearchType {
-    val contactIdPresent = request.contactId != null
+    val contactIdPresent = !resolveContactIds(request).isNullOrEmpty()
     val dobPresent = request.dateOfBirth != null
     val namesEntered = listOf(request.firstName, request.lastName, request.middleNames).any { it != null }
     val previousNames = namesEntered && request.previousNames == true
@@ -335,6 +339,18 @@ class ContactSearchService(
     (UserSearchType.PARTIAL to false to false) -> NAMES_MATCH
     (UserSearchType.PARTIAL to false to true) -> NAMES_MATCH_AND_HISTORY
     else -> NAMES_MATCH
+  }
+
+  private fun resolveContactIds(request: ContactSearchRequest): List<Long>? {
+    if (request.contactId != null && !request.contactIds.isNullOrEmpty()) {
+      throw IllegalArgumentException("Provide either contactId or contactIds, not both")
+    }
+
+    return when {
+      !request.contactIds.isNullOrEmpty() -> request.contactIds.distinct()
+      request.contactId != null -> listOf(request.contactId)
+      else -> null
+    }
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/resource/SearchContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/resource/SearchContactsIntegrationTest.kt
@@ -224,6 +224,26 @@ class SearchContactsIntegrationTest : SecureAPIIntegrationTestBase() {
     }
   }
 
+  @Test
+  fun `should find contacts by list of contact IDs`() {
+    val uri = UriComponentsBuilder.fromPath("contact/search")
+      .queryParam("searchType", "EXACT")
+      .queryParam("contactIds", "1", "2")
+      .build()
+      .toUri()
+
+    val body = testAPIClient.getSearchContactResults(uri)
+
+    with(body!!) {
+      assertThat(content).isNotEmpty()
+      assertThat(content.size).isEqualTo(2)
+      assertThat(page.totalElements).isEqualTo(2)
+      assertThat(page.totalPages).isEqualTo(1)
+
+      assertThat(content).extracting("id").containsAll(listOf(1L, 2L))
+    }
+  }
+
   @ParameterizedTest
   @CsvSource(
     "Smith,John,Jon|Smith|1980-01-01;John|Smithe|1980-01-01",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactControllerTest.kt
@@ -161,12 +161,12 @@ class ContactControllerTest {
       val pageContacts = PageImpl(contactEntities, pageable, contactEntities.size.toLong())
 
       // When
-      val expectedRequest = ContactSearchRequest("last", "first", "middle", LocalDate.of(1980, 1, 1), UserSearchType.PARTIAL, false, 123456, "123456")
+      val expectedRequest = ContactSearchRequest("last", "first", "middle", LocalDate.of(1980, 1, 1), UserSearchType.PARTIAL, false, 123456, null, "123456")
       whenever(contactFacade.searchContacts(pageable, expectedRequest)).thenReturn(PagedModel(pageContacts))
 
       // Act
       val result: PagedModel<ContactSearchResultItem> =
-        controller.searchContacts(pageable, "last", "first", "middle", "123456", LocalDate.of(1980, 1, 1), "PARTIAL", false, "123456")
+        controller.searchContacts(pageable, "last", "first", "middle", 123456, null, LocalDate.of(1980, 1, 1), "PARTIAL", false, "123456")
 
       // Then
       assertNotNull(result)
@@ -177,6 +177,19 @@ class ContactControllerTest {
       assertThat(result.content[0].id).isEqualTo(1L)
       assertThat(result.content[0].noFixedAddress).isEqualTo(true)
       verify(contactFacade).searchContacts(pageable, expectedRequest)
+    }
+
+    @Test
+    fun `should propagate exceptions when searching for contacts`() {
+      val pageable = PageRequest.of(0, 10)
+
+      val expectedRequest = ContactSearchRequest("last", "first", "middle", LocalDate.of(1980, 1, 1), UserSearchType.PARTIAL, false, 123456, listOf(123456), "123456")
+
+      whenever(contactFacade.searchContacts(pageable, expectedRequest)).thenThrow(IllegalArgumentException("Provide either contactId or contactIds, not both"))
+
+      assertThrows<IllegalArgumentException>("Provide either contactId or contactIds, not both") {
+        controller.searchContacts(pageable, "last", "first", "middle", 123456, listOf(123456), LocalDate.of(1980, 1, 1), "PARTIAL", false, "123456")
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactControllerTest.kt
@@ -166,7 +166,7 @@ class ContactControllerTest {
 
       // Act
       val result: PagedModel<ContactSearchResultItem> =
-        controller.searchContacts(pageable, "last", "first", "middle", 123456, null, LocalDate.of(1980, 1, 1), "PARTIAL", false, "123456")
+        controller.searchContacts(pageable, "last", "first", "middle", "123456", null, LocalDate.of(1980, 1, 1), "PARTIAL", false, "123456")
 
       // Then
       assertNotNull(result)
@@ -188,7 +188,7 @@ class ContactControllerTest {
       whenever(contactFacade.searchContacts(pageable, expectedRequest)).thenThrow(IllegalArgumentException("Provide either contactId or contactIds, not both"))
 
       assertThrows<IllegalArgumentException>("Provide either contactId or contactIds, not both") {
-        controller.searchContacts(pageable, "last", "first", "middle", 123456, listOf(123456), LocalDate.of(1980, 1, 1), "PARTIAL", false, "123456")
+        controller.searchContacts(pageable, "last", "first", "middle", "123456", listOf(123456), LocalDate.of(1980, 1, 1), "PARTIAL", false, "123456")
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Add a new request parameter to the searchContacts method, which allows calling clients to pass in a list of contactIds, which can be used to find contacts.

Add validations to stop the clients passing both single contactId and list contactIds.

Add some logic into service to remove any possible duplicate IDs passed into the list using .distinct call.

Add test to the unit tests to assert exceptions are propegated to caller.

## Why are we making this change?
As part of a bug in the Visits service, we need new functionality on the personal-relationships-api to search for multiple contacts via their IDs. This change achieves that requirement.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5817