### PR TITLE
Contacts bulk global restrictions look up controller

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/facade/ContactGlobalRestrictionsFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/facade/ContactGlobalRestrictionsFacade.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.personalrelationships.config.User
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.restrictions.CreateContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.restrictions.UpdateContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactRestrictionDetails
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactsRestrictionsResponse
 import uk.gov.justice.digital.hmpps.personalrelationships.service.RestrictionsService
 import uk.gov.justice.digital.hmpps.personalrelationships.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.personalrelationships.service.events.OutboundEventsService
@@ -19,6 +20,8 @@ class ContactGlobalRestrictionsFacade(
 ) {
 
   fun getGlobalRestrictionsForContact(contactId: Long): List<ContactRestrictionDetails> = restrictionsService.getGlobalRestrictionsForContact(contactId)
+
+  fun getGlobalRestrictionsForContacts(contactIds: Set<Long>): ContactsRestrictionsResponse = restrictionsService.getGlobalRestrictionsForContacts(contactIds)
 
   fun createContactGlobalRestriction(
     contactId: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/request/ContactIdsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/request/ContactIdsRequest.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.personalrelationships.model.request
+
+data class ContactIdsRequest(val contactIds: List<Long>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/response/ContactsRestrictionsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/model/response/ContactsRestrictionsResponse.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.personalrelationships.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Restrictions related to specific contacts")
+data class ContactsRestrictionsResponse(
+  @Schema(description = "The list of contact global restrictions for each contact where found")
+  val contactRestrictions: List<ContactRestrictions>,
+)
+
+data class ContactRestrictions(
+  @Schema(description = "The unique identifier for the contact", example = "123456")
+  val contactId: Long,
+
+  @Schema(description = "Global (estate-wide) restrictions for the contact")
+  val globalContactRestrictions: List<ContactRestrictionDetails>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactsGlobalRestrictionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactsGlobalRestrictionsController.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.personalrelationships.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.personalrelationships.facade.ContactGlobalRestrictionsFacade
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.ContactIdsRequest
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactsRestrictionsResponse
+
+@RestController
+@RequestMapping(value = ["contacts/restrictions"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class ContactsGlobalRestrictionsController(
+  val restrictionsFacade: ContactGlobalRestrictionsFacade,
+) {
+  @Operation(
+    summary = "Get global restrictions for one or more contacts where matches are found",
+    description = """
+      Get the global restrictions that apply to the specified contacts.
+
+      Global restrictions apply to all of a contact's relationships and are known as estate-wide restrictions in NOMIS.
+
+      Prisoner-contact restrictions for specific prisoner relationships will not be returned.
+    """,
+  )
+  @Tag(name = "Restrictions")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The global restrictions for the specified contact(s)",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ContactsRestrictionsResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @PostMapping
+  @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__R', 'ROLE_CONTACTS__RW')")
+  fun getContactGlobalRestrictionsByContactIds(
+    @RequestBody
+    @Parameter(description = "The ids of the contacts to search for", required = true)
+    contactIdsRequest: ContactIdsRequest,
+  ): ContactsRestrictionsResponse = restrictionsFacade.getGlobalRestrictionsForContacts(contactIdsRequest.contactIds.toSet())
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactsGlobalRestrictionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactsGlobalRestrictionsController.kt
@@ -16,9 +16,11 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.personalrelationships.facade.ContactGlobalRestrictionsFacade
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.ContactIdsRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactsRestrictionsResponse
+import uk.gov.justice.digital.hmpps.personalrelationships.swagger.AuthApiResponses
 
 @RestController
 @RequestMapping(value = ["contacts/restrictions"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@AuthApiResponses
 class ContactsGlobalRestrictionsController(
   val restrictionsFacade: ContactGlobalRestrictionsFacade,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/RestrictionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/RestrictionsService.kt
@@ -13,6 +13,8 @@ import uk.gov.justice.digital.hmpps.personalrelationships.model.request.restrict
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.restrictions.UpdateContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.restrictions.UpdatePrisonerContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactRestrictionDetails
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactRestrictions
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactsRestrictionsResponse
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.GlobalContactRestriction
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRestriction
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PrisonerContactRestrictionDetails
@@ -65,6 +67,53 @@ class RestrictionsService(
         updatedTime = entity.updatedTime,
       )
     }
+  }
+
+  fun getGlobalRestrictionsForContacts(contactIds: Set<Long>): ContactsRestrictionsResponse {
+    val contactRestrictions = buildList {
+      contactRepository.findAllById(contactIds)
+        .forEach { contact ->
+
+          val globalContactRestrictions = run {
+            val restrictionsWithEnteredBy = contactRestrictionDetailsRepository.findAllByContactId(contact.contactId!!)
+              .map { entity -> entity to (entity.updatedBy ?: entity.createdBy) }
+
+            val enteredByMap = restrictionsWithEnteredBy
+              .map { (_, enteredByUsername) -> enteredByUsername }
+              .toSet()
+              .associateWith { enteredByUsername ->
+                manageUsersService.getUserByUsername(enteredByUsername)?.name ?: enteredByUsername
+              }
+
+            restrictionsWithEnteredBy.map { (entity, enteredByUsername) ->
+              ContactRestrictionDetails(
+                contactRestrictionId = entity.contactRestrictionId,
+                contactId = entity.contactId,
+                restrictionType = entity.restrictionType,
+                restrictionTypeDescription = entity.restrictionTypeDescription,
+                startDate = entity.startDate,
+                expiryDate = entity.expiryDate,
+                comments = entity.comments,
+                enteredByUsername = enteredByUsername,
+                enteredByDisplayName = enteredByMap[enteredByUsername] ?: enteredByUsername,
+                createdBy = entity.createdBy,
+                createdTime = entity.createdTime,
+                updatedBy = entity.updatedBy,
+                updatedTime = entity.updatedTime,
+              )
+            }
+          }
+
+          add(
+            ContactRestrictions(
+              contactId = contact.contactId!!,
+              globalContactRestrictions = globalContactRestrictions,
+            ),
+          )
+        }
+    }
+
+    return ContactsRestrictionsResponse(contactRestrictions)
   }
 
   fun getPrisonerContactRestrictions(prisonerContactId: Long): PrisonerContactRestrictionsResponse {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/RestrictionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/service/RestrictionsService.kt
@@ -45,69 +45,19 @@ class RestrictionsService(
 
   fun getGlobalRestrictionsForContact(contactId: Long): List<ContactRestrictionDetails> {
     validateContactExists(contactId)
-    val restrictionsWithEnteredBy = contactRestrictionDetailsRepository.findAllByContactId(contactId)
-      .map { entity -> entity to (entity.updatedBy ?: entity.createdBy) }
-    val enteredByMap = restrictionsWithEnteredBy
-      .map { (_, enteredByUsername) -> enteredByUsername }
-      .toSet().associateWith { enteredByUsername -> manageUsersService.getUserByUsername(enteredByUsername)?.name ?: enteredByUsername }
-    return restrictionsWithEnteredBy.map { (entity, enteredByUsername) ->
-      ContactRestrictionDetails(
-        contactRestrictionId = entity.contactRestrictionId,
-        contactId = entity.contactId,
-        restrictionType = entity.restrictionType,
-        restrictionTypeDescription = entity.restrictionTypeDescription,
-        startDate = entity.startDate,
-        expiryDate = entity.expiryDate,
-        comments = entity.comments,
-        enteredByUsername = enteredByUsername,
-        enteredByDisplayName = enteredByMap[enteredByUsername] ?: enteredByUsername,
-        createdBy = entity.createdBy,
-        createdTime = entity.createdTime,
-        updatedBy = entity.updatedBy,
-        updatedTime = entity.updatedTime,
-      )
-    }
+    return getGlobalRestrictionDetails(contactId)
   }
 
   fun getGlobalRestrictionsForContacts(contactIds: Set<Long>): ContactsRestrictionsResponse {
     val contactRestrictions = buildList {
       contactRepository.findAllById(contactIds)
         .forEach { contact ->
-
-          val globalContactRestrictions = run {
-            val restrictionsWithEnteredBy = contactRestrictionDetailsRepository.findAllByContactId(contact.contactId!!)
-              .map { entity -> entity to (entity.updatedBy ?: entity.createdBy) }
-
-            val enteredByMap = restrictionsWithEnteredBy
-              .map { (_, enteredByUsername) -> enteredByUsername }
-              .toSet()
-              .associateWith { enteredByUsername ->
-                manageUsersService.getUserByUsername(enteredByUsername)?.name ?: enteredByUsername
-              }
-
-            restrictionsWithEnteredBy.map { (entity, enteredByUsername) ->
-              ContactRestrictionDetails(
-                contactRestrictionId = entity.contactRestrictionId,
-                contactId = entity.contactId,
-                restrictionType = entity.restrictionType,
-                restrictionTypeDescription = entity.restrictionTypeDescription,
-                startDate = entity.startDate,
-                expiryDate = entity.expiryDate,
-                comments = entity.comments,
-                enteredByUsername = enteredByUsername,
-                enteredByDisplayName = enteredByMap[enteredByUsername] ?: enteredByUsername,
-                createdBy = entity.createdBy,
-                createdTime = entity.createdTime,
-                updatedBy = entity.updatedBy,
-                updatedTime = entity.updatedTime,
-              )
-            }
-          }
+          val contactId = contact.contactId!!
 
           add(
             ContactRestrictions(
-              contactId = contact.contactId!!,
-              globalContactRestrictions = globalContactRestrictions,
+              contactId = contactId,
+              globalContactRestrictions = getGlobalRestrictionDetails(contactId),
             ),
           )
         }
@@ -366,5 +316,35 @@ class RestrictionsService(
   private fun validateContactExists(contactId: Long) {
     contactRepository.findById(contactId)
       .orElseThrow { EntityNotFoundException("Contact ($contactId) could not be found") }
+  }
+
+  private fun getGlobalRestrictionDetails(contactId: Long): List<ContactRestrictionDetails> {
+    val restrictionsWithEnteredBy = contactRestrictionDetailsRepository.findAllByContactId(contactId)
+      .map { entity -> entity to (entity.updatedBy ?: entity.createdBy) }
+
+    val enteredByMap = restrictionsWithEnteredBy
+      .map { (_, enteredByUsername) -> enteredByUsername }
+      .toSet()
+      .associateWith { enteredByUsername ->
+        manageUsersService.getUserByUsername(enteredByUsername)?.name ?: enteredByUsername
+      }
+
+    return restrictionsWithEnteredBy.map { (entity, enteredByUsername) ->
+      ContactRestrictionDetails(
+        contactRestrictionId = entity.contactRestrictionId,
+        contactId = entity.contactId,
+        restrictionType = entity.restrictionType,
+        restrictionTypeDescription = entity.restrictionTypeDescription,
+        startDate = entity.startDate,
+        expiryDate = entity.expiryDate,
+        comments = entity.comments,
+        enteredByUsername = enteredByUsername,
+        enteredByDisplayName = enteredByMap[enteredByUsername] ?: enteredByUsername,
+        createdBy = entity.createdBy,
+        createdTime = entity.createdTime,
+        updatedBy = entity.updatedBy,
+        updatedTime = entity.updatedTime,
+      )
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/helper/TestAPIClient.kt
@@ -472,7 +472,7 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
     .expectBodyList(ContactRestrictionDetails::class.java)
     .returnResult().responseBody!!
 
-  fun getBulkContactGlobalRestrictions(contactIds: List<Long>): ContactsRestrictionsResponse = webTestClient.post()
+  fun getContactsGlobalRestrictions(contactIds: List<Long>): ContactsRestrictionsResponse = webTestClient.post()
     .uri("/contacts/restrictions")
     .headers(setAuthorisationUsingCurrentUser())
     .bodyValue(ContactIdsRequest(contactIds))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/helper/TestAPIClient.kt
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.personalrelationships.model.ReferenceCodeGroup
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.AddContactRelationshipRequest
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.ContactIdsRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PatchRelationshipRequest
 import uk.gov.justice.digital.hmpps.personalrelationships.model.request.PrisonerContactIdsRequest
@@ -44,6 +45,7 @@ import uk.gov.justice.digital.hmpps.personalrelationships.model.response.Contact
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactPhoneDetails
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactRestrictionDetails
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactSearchResultItem
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactsRestrictionsResponse
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.EmploymentDetails
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.LinkedPrisonerDetails
 import uk.gov.justice.digital.hmpps.personalrelationships.model.response.PatchContactResponse
@@ -469,6 +471,16 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBodyList(ContactRestrictionDetails::class.java)
     .returnResult().responseBody!!
+
+  fun getBulkContactGlobalRestrictions(contactIds: List<Long>): ContactsRestrictionsResponse = webTestClient.post()
+    .uri("/contacts/restrictions")
+    .headers(setAuthorisationUsingCurrentUser())
+    .bodyValue(ContactIdsRequest(contactIds))
+    .exchange()
+    .expectStatus().isOk
+    .expectBody(ContactsRestrictionsResponse::class.java)
+    .returnResult()
+    .responseBody!!
 
   fun createContactGlobalRestriction(
     contactId: Long,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/resource/GetContactsGlobalRestrictionsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/resource/GetContactsGlobalRestrictionsIntegrationTest.kt
@@ -32,7 +32,7 @@ class GetContactsGlobalRestrictionsIntegrationTest : SecureAPIIntegrationTestBas
     stubGetUserByUsername(UserDetails("JBAKER_GEN", "James Baker"))
     setCurrentUser(StubUser.READ_ONLY_USER.copy(roles = listOf(role)))
 
-    val response = testAPIClient.getBulkContactGlobalRestrictions(listOf(3L))
+    val response = testAPIClient.getContactsGlobalRestrictions(listOf(3L))
 
     assertThat(response.contactRestrictions).hasSize(1)
 
@@ -72,7 +72,7 @@ class GetContactsGlobalRestrictionsIntegrationTest : SecureAPIIntegrationTestBas
       testAPIClient.createAContact(CreateContactRequest(lastName = "Last", firstName = "First"))
     }
 
-    val response = testAPIClient.getBulkContactGlobalRestrictions(listOf(createdContact.id))
+    val response = testAPIClient.getContactsGlobalRestrictions(listOf(createdContact.id))
 
     assertThat(response.contactRestrictions).hasSize(1)
 
@@ -86,7 +86,7 @@ class GetContactsGlobalRestrictionsIntegrationTest : SecureAPIIntegrationTestBas
   fun `should only return contacts where matches are found`() {
     stubGetUserByUsername(UserDetails("JBAKER_GEN", "James Baker"))
 
-    val response = testAPIClient.getBulkContactGlobalRestrictions(listOf(3L, -1L))
+    val response = testAPIClient.getContactsGlobalRestrictions(listOf(3L, -1L))
 
     assertThat(response.contactRestrictions).hasSize(1)
 
@@ -98,7 +98,7 @@ class GetContactsGlobalRestrictionsIntegrationTest : SecureAPIIntegrationTestBas
 
   @Test
   fun `should return empty list if no contacts are found`() {
-    val response = testAPIClient.getBulkContactGlobalRestrictions(listOf(-1L, -2L))
+    val response = testAPIClient.getContactsGlobalRestrictions(listOf(-1L, -2L))
 
     assertThat(response.contactRestrictions).isEmpty()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/resource/GetContactsGlobalRestrictionsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/integration/resource/GetContactsGlobalRestrictionsIntegrationTest.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.personalrelationships.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.personalrelationships.client.manage.users.UserDetails
+import uk.gov.justice.digital.hmpps.personalrelationships.integration.SecureAPIIntegrationTestBase
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.ContactIdsRequest
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.personalrelationships.util.StubUser
+import java.time.LocalDate
+
+class GetContactsGlobalRestrictionsIntegrationTest : SecureAPIIntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setCurrentUser(StubUser.READ_ONLY_USER)
+  }
+
+  override val allowedRoles: Set<String> = setOf("ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW", "ROLE_CONTACTS__R")
+
+  override fun baseRequestBuilder(): WebTestClient.RequestHeadersSpec<*> = webTestClient.post()
+    .uri("/contacts/restrictions")
+    .bodyValue(ContactIdsRequest(listOf(1L)))
+
+  @ParameterizedTest
+  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
+  fun `should return all global restrictions for contacts`(role: String) {
+    stubGetUserByUsername(UserDetails("JBAKER_GEN", "James Baker"))
+    setCurrentUser(StubUser.READ_ONLY_USER.copy(roles = listOf(role)))
+
+    val response = testAPIClient.getBulkContactGlobalRestrictions(listOf(3L))
+
+    assertThat(response.contactRestrictions).hasSize(1)
+
+    with(response.contactRestrictions[0]) {
+      assertThat(contactId).isEqualTo(3L)
+      assertThat(globalContactRestrictions).hasSize(2)
+
+      with(globalContactRestrictions[0]) {
+        assertThat(contactRestrictionId).isNotNull()
+        assertThat(contactId).isEqualTo(3L)
+        assertThat(restrictionType).isEqualTo("CCTV")
+        assertThat(restrictionTypeDescription).isEqualTo("CCTV")
+        assertThat(startDate).isEqualTo(LocalDate.of(2000, 11, 21))
+        assertThat(expiryDate).isEqualTo(LocalDate.of(2001, 11, 21))
+        assertThat(comments).isEqualTo("N/A")
+        assertThat(enteredByUsername).isEqualTo("JBAKER_GEN")
+        assertThat(enteredByDisplayName).isEqualTo("James Baker")
+      }
+
+      with(globalContactRestrictions[1]) {
+        assertThat(contactRestrictionId).isNotNull()
+        assertThat(contactId).isEqualTo(3L)
+        assertThat(restrictionType).isEqualTo("BAN")
+        assertThat(restrictionTypeDescription).isEqualTo("Banned")
+        assertThat(startDate).isNull()
+        assertThat(expiryDate).isNull()
+        assertThat(comments).isNull()
+        assertThat(enteredByUsername).isEqualTo("FOO_USER")
+        assertThat(enteredByDisplayName).isEqualTo("FOO_USER")
+      }
+    }
+  }
+
+  @Test
+  fun `should return empty restrictions list if contact has no restrictions`() {
+    val createdContact = doWithTemporaryWritePermission {
+      testAPIClient.createAContact(CreateContactRequest(lastName = "Last", firstName = "First"))
+    }
+
+    val response = testAPIClient.getBulkContactGlobalRestrictions(listOf(createdContact.id))
+
+    assertThat(response.contactRestrictions).hasSize(1)
+
+    with(response.contactRestrictions[0]) {
+      assertThat(contactId).isEqualTo(createdContact.id)
+      assertThat(globalContactRestrictions).isEmpty()
+    }
+  }
+
+  @Test
+  fun `should only return contacts where matches are found`() {
+    stubGetUserByUsername(UserDetails("JBAKER_GEN", "James Baker"))
+
+    val response = testAPIClient.getBulkContactGlobalRestrictions(listOf(3L, -1L))
+
+    assertThat(response.contactRestrictions).hasSize(1)
+
+    with(response.contactRestrictions[0]) {
+      assertThat(contactId).isEqualTo(3L)
+      assertThat(globalContactRestrictions).hasSize(2)
+    }
+  }
+
+  @Test
+  fun `should return empty list if no contacts are found`() {
+    val response = testAPIClient.getBulkContactGlobalRestrictions(listOf(-1L, -2L))
+
+    assertThat(response.contactRestrictions).isEmpty()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactsGlobalRestrictionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personalrelationships/resource/ContactsGlobalRestrictionsControllerTest.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.personalrelationships.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.personalrelationships.facade.ContactGlobalRestrictionsFacade
+import uk.gov.justice.digital.hmpps.personalrelationships.helpers.createContactRestrictionDetails
+import uk.gov.justice.digital.hmpps.personalrelationships.model.request.ContactIdsRequest
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactRestrictions
+import uk.gov.justice.digital.hmpps.personalrelationships.model.response.ContactsRestrictionsResponse
+
+class ContactsGlobalRestrictionsControllerTest {
+  private val restrictionsFacade: ContactGlobalRestrictionsFacade = mock()
+  private val controller = ContactsGlobalRestrictionsController(restrictionsFacade)
+
+  @Nested
+  inner class GetContactGlobalRestrictionsByContactIds {
+    @Test
+    fun `should get contact global restrictions successfully`() {
+      val request = ContactIdsRequest(
+        contactIds = listOf(1L, 2L, 3L),
+      )
+
+      val expected = ContactsRestrictionsResponse(
+        contactRestrictions = listOf(
+          ContactRestrictions(
+            contactId = 1L,
+            globalContactRestrictions = listOf(createContactRestrictionDetails(contactId = 1L)),
+          ),
+          ContactRestrictions(
+            contactId = 2L,
+            globalContactRestrictions = listOf(createContactRestrictionDetails(contactId = 2L)),
+          ),
+          ContactRestrictions(
+            contactId = 3L,
+            globalContactRestrictions = emptyList(),
+          ),
+        ),
+      )
+
+      whenever(
+        restrictionsFacade.getGlobalRestrictionsForContacts(setOf(1L, 2L, 3L)),
+      ).thenReturn(expected)
+
+      val result = controller.getContactGlobalRestrictionsByContactIds(request)
+
+      assertThat(result).isEqualTo(expected)
+      verify(restrictionsFacade).getGlobalRestrictionsForContacts(setOf(1L, 2L, 3L))
+    }
+
+    @Test
+    fun `should propagate exceptions getting contact global restrictions`() {
+      val request = ContactIdsRequest(
+        contactIds = listOf(1L, 2L, 3L),
+      )
+
+      val expected = RuntimeException("Bang!")
+
+      whenever(
+        restrictionsFacade.getGlobalRestrictionsForContacts(setOf(1L, 2L, 3L)),
+      ).thenThrow(expected)
+
+      val result = assertThrows<RuntimeException> {
+        controller.getContactGlobalRestrictionsByContactIds(request)
+      }
+
+      assertThat(result).isEqualTo(expected)
+      verify(restrictionsFacade).getGlobalRestrictionsForContacts(setOf(1L, 2L, 3L))
+    }
+  }
+}


### PR DESCRIPTION
Implement a new controller that allows you to pass in multiple contact IDs and retrieve their global restrictions.

Similar design / flow to the prisoner-contact bulk lookup controller.