### PR TITLE
schedule overnight and weekend shutdown in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,7 +6,10 @@ generic-service:
 
   ingress:
     host: personal-relationships-api-dev.hmpps.service.justice.gov.uk
-
+  
+  scheduledDowntime:
+    enabled: true
+  
   env:
     SENTRY_ENVIRONMENT: dev
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"


### PR DESCRIPTION
I noticed contacts was throwing lots of errors overnight on the health endpoint because it depends on prisoner-search which is scheduled to be down.

so might as well shut contacts off at same time.